### PR TITLE
feat(kado): introduce a config argument to move ayamari and kintsugi to `devDependencies`

### DIFF
--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -14,7 +14,7 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 
 - 💡 Minimal size overhead ([see details](https://bundlephobia.com/result?p=@daisugi/kado))
 - ⚡️ Written in TypeScript
-- 📦 Uses only trusted dependencies
+- 📦 Zero dependencies (while [`@daisugi/ayamari`][ayamari] and [`@daisugi/kintsugi`][kintsugi] integrate seamlessly)
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
 - 🤝 Used in production
@@ -136,6 +136,29 @@ Kado was created to address limitations found in other IoC libraries. If these r
 ---
 
 ## 📜 API
+
+### `new Kado(kadoConfig?)`
+
+Initializes the container.
+
+```js
+import { Kado } from '@daisugi/kado';
+
+const { container } = new Kado();
+```
+
+If either of the [`@daisugi/ayamari`][ayamari] or [`@daisugi/kintsugi`][kintsugi] libraries is not installed, then you have to provide the required dependencies manually. For example:
+
+```js
+import { Kado } from '@daisugi/kado';
+
+const errFn = {
+  NotFound: Error,
+  CircularDependencyDetected: Error,
+};
+const urandom = Symbol;
+const { container } = new Kado({ errFn, urandom });
+```
 
 ### `#register(manifestItems)`
 
@@ -358,9 +381,15 @@ import {
   type KadoContainer,
   type KadoToken,
   type KadoScope,
+  type KadoConfig,
 } from '@daisugi/kado';
+import { Ayamari } from '@daisugi/ayamari';
+import { urandom } from '@daisugi/kintsugi';
 
-const { container } = new Kado();
+const { errFn } = new Ayamari();
+const kadoConfig: KadoConfig = { errFn, urandom };
+
+const { container } = new Kado(kadoConfig);
 
 class Foo {}
 
@@ -413,3 +442,6 @@ Explore the [@daisugi](../../README.md) ecosystem.
 [MIT](../../LICENSE)
 
 [:top: Back to top](#-table-of-contents)
+
+[ayamari]: https://www.npmjs.com/package/@daisugi/ayamari
+[kintsugi]: https://www.npmjs.com/package/@daisugi/kintsugi

--- a/packages/kado/package.json
+++ b/packages/kado/package.json
@@ -52,14 +52,22 @@
     "url": "https://github.com/daisugiland/daisugi.git"
   },
   "types": "dist/types/kado.d.ts",
-  "dependencies": {
-    "@daisugi/ayamari": "workspace:*",
-    "@daisugi/kintsugi": "workspace:*"
-  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/node": "^22.13.13",
     "tsc-watch": "^6.2.1",
     "typescript": "^5.8.2"
+  },
+  "peerDependencies": {
+    "@daisugi/ayamari": "workspace:*",
+    "@daisugi/kintsugi": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@daisugi/ayamari": {
+      "optional": true
+    },
+    "@daisugi/kintsugi": {
+      "optional": true
+    }
   }
 }

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -26,30 +26,30 @@ type KadoTokenToContainerItem = Map<
 export type KadoContainer = Container;
 
 /**
+ * Error conditions that may be met when resolving a request
+ */
+export type KadoErrorReason =
+  | 'NotFound'
+  | 'CircularDependencyDetected';
+/**
+ * Creates `Error`s to throw that may occur when resolving (conforms to `@daisugi/ayamari`)
+ */
+export type KadoErrorFactory = Record<
+  KadoErrorReason,
+  (msg: string) => Error
+>;
+/**
  * Required dependencies for Kado to work
  */
 export interface KadoConfig {
   /**
-   * Creates Error to throw on error conditions (conforms to `@daisugi/ayamari`)
+   * Creates `Error`s to throw on error conditions (conforms to `@daisugi/ayamari`)
    */
   errFn: KadoErrorFactory;
   /**
    * Generates tokens for anonymous registrations (conforms to `@daisugi/kintsugi`)
    */
   urandom: () => KadoToken;
-}
-/**
- * Creates Error to throw that may occur when resolving (conforms to `@daisugi/ayamari`)
- */
-export interface KadoErrorFactory {
-  /**
-   * Creates error to throw when given token does not correspond to registered manifests
-   */
-  NotFound(msg: string): Error;
-  /**
-   * Creates error to throw when dependencies are in cycle
-   */
-  CircularDependencyDetected(msg: string): Error;
 }
 
 /** Default dependency libraries for Kado */

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -1,8 +1,3 @@
-import { Ayamari } from '@daisugi/ayamari';
-import { urandom } from '@daisugi/kintsugi';
-
-const { errFn } = new Ayamari();
-
 interface Class {
   new (...args: any[]): unknown;
 }
@@ -30,18 +25,78 @@ type KadoTokenToContainerItem = Map<
 >;
 export type KadoContainer = Container;
 
+/**
+ * Required dependencies for Kado to work
+ */
+export interface KadoConfig {
+  /**
+   * Creates Error to throw on error conditions (conforms to `@daisugi/ayamari`)
+   */
+  errFn: KadoErrorFactory;
+  /**
+   * Generates tokens for anonymous registrations (conforms to `@daisugi/kintsugi`)
+   */
+  urandom: () => KadoToken;
+}
+/**
+ * Creates Error to throw that may occur when resolving (conforms to `@daisugi/ayamari`)
+ */
+export interface KadoErrorFactory {
+  /**
+   * Creates error to throw when given token does not correspond to registered manifests
+   */
+  NotFound(msg: string): Error;
+  /**
+   * Creates error to throw when dependencies are in cycle
+   */
+  CircularDependencyDetected(msg: string): Error;
+}
+
+/** Default dependency libraries for Kado */
+const defaultConfig: Partial<KadoConfig> =
+  await (async () => {
+    // Try to import other @daisugi modules
+    let libErrFn: undefined | KadoErrorFactory;
+    try {
+      const { Ayamari } = await import('@daisugi/ayamari');
+      libErrFn = new Ayamari().errFn;
+    } catch {}
+
+    let libUrandom: undefined | (() => KadoToken);
+    try {
+      const { urandom } = await import('@daisugi/kintsugi');
+      libUrandom = urandom;
+    } catch {}
+
+    return { errFn: libErrFn, urandom: libUrandom };
+  })();
+
 export class Container {
   #tokenToContainerItem: KadoTokenToContainerItem;
+  #errFn: KadoErrorFactory;
+  #urandom: () => KadoToken;
 
-  constructor() {
+  constructor(kadoConfig?: KadoConfig) {
     this.#tokenToContainerItem = new Map();
+
+    const errFn = kadoConfig?.errFn ?? defaultConfig.errFn;
+    const urandom =
+      kadoConfig?.urandom ?? defaultConfig.urandom;
+    if (!errFn || !urandom) {
+      throw new TypeError(
+        'the kadoConfig argument is required if one of @daisugi/ayamari or @daisugi/kintsugi is not installed.',
+      );
+    }
+
+    this.#errFn = errFn;
+    this.#urandom = urandom;
   }
 
   async resolve<T>(token: KadoToken): Promise<T> {
     const containerItem =
       this.#tokenToContainerItem.get(token);
     if (containerItem === undefined) {
-      throw errFn.NotFound(
+      throw this.#errFn.NotFound(
         `Attempted to resolve unregistered dependency token: "${token.toString()}".`,
       );
     }
@@ -102,7 +157,7 @@ export class Container {
   }
 
   #registerItem(manifestItem: KadoManifestItem): KadoToken {
-    const token = manifestItem.token || urandom();
+    const token = manifestItem.token || this.#urandom();
     this.#tokenToContainerItem.set(token, {
       manifestItem: Object.assign(manifestItem, { token }),
       checkedForCircularDep: false,
@@ -121,7 +176,7 @@ export class Container {
     const containerItem =
       this.#tokenToContainerItem.get(token);
     if (containerItem === undefined) {
-      throw errFn.NotFound(
+      throw this.#errFn.NotFound(
         `Attempted to get unregistered dependency token: "${token.toString()}".`,
       );
     }
@@ -143,7 +198,7 @@ export class Container {
       const chainOfTokens = tokens
         .map((token) => `"${token.toString()}"`)
         .join(' ➡️ ');
-      throw errFn.CircularDependencyDetected(
+      throw this.#errFn.CircularDependencyDetected(
         `Attempted to resolve circular dependency: ${chainOfTokens} 🔄 "${token.toString()}".`,
       );
     }
@@ -175,8 +230,8 @@ export class Kado {
   };
   container: KadoContainer;
 
-  constructor() {
-    this.container = new Container();
+  constructor(kadoConfig?: KadoConfig) {
+    this.container = new Container(kadoConfig);
   }
 
   static value(value: unknown): KadoManifestItem {


### PR DESCRIPTION
Hi, thank you for your neat librar(y|ies).
Having used Kado for a while, I've noticed interactions with other packages are quite minimal in the library and thought we could achieve zero dependencies by requiring users to pass a config argument (which accepts the currently used ones). It's also in the spirit of DIP I guess.
This would further reduce the bundled package size, but it would certainly be a change to the API. What do you think?