### PR TITLE
fix(kado): harden resolve/register against edge cases

### DIFF
--- a/packages/kado/src/__tests__/kado_test.ts
+++ b/packages/kado/src/__tests__/kado_test.ts
@@ -33,7 +33,20 @@ describe('Kado', () => {
     const { container } = new Kado();
     const manifestItem = { token: 'a' };
     container.register([manifestItem]);
-    assert.equal(container.get('a'), manifestItem);
+    assert.deepEqual(container.get('a'), manifestItem);
+  });
+
+  it('#register() does not mutate the given manifest item', () => {
+    const { container } = new Kado();
+    const manifestItem: KadoManifestItem = {
+      useValue: 'a',
+    };
+    container.register([manifestItem]);
+    assert.strictEqual('token' in manifestItem, false);
+    const stored = container.list()[0];
+    assert.ok(stored);
+    assert.notStrictEqual(stored, manifestItem);
+    assert.ok(stored.token);
   });
 
   it('useClass', async () => {
@@ -95,6 +108,55 @@ describe('Kado', () => {
     const a = await container.resolve<A>('A');
 
     assert.strictEqual(a.a, false);
+  });
+
+  it('useValue undefined', async () => {
+    const { container } = new Kado();
+
+    container.register([
+      { token: 'a', useValue: undefined },
+    ]);
+
+    const a = await container.resolve('a');
+
+    assert.strictEqual(a, undefined);
+  });
+
+  it('resolve by falsy tokens', async () => {
+    const { container } = new Kado();
+
+    container.register([
+      { token: 0, useValue: 'zero' },
+      { token: '', useValue: 'empty' },
+    ]);
+
+    assert.strictEqual(await container.resolve(0), 'zero');
+    assert.strictEqual(
+      await container.resolve(''),
+      'empty',
+    );
+  });
+
+  it('failed Singleton resolution can be retried', async () => {
+    const { container } = new Kado();
+    let count = 0;
+
+    container.register([
+      {
+        token: 'a',
+        useFn() {
+          count++;
+          if (count === 1) {
+            throw new Error('boom');
+          }
+          return 'ok';
+        },
+      },
+    ]);
+
+    await assert.rejects(container.resolve('a'), /boom/u);
+    // Must not hang on a poisoned pending promise.
+    assert.strictEqual(await container.resolve('a'), 'ok');
   });
 
   it('should resolve Singleton only once', async () => {

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -46,7 +46,7 @@ export class Container {
       );
     }
     const manifestItem = containerItem.manifestItem;
-    if (manifestItem.useValue !== undefined) {
+    if ('useValue' in manifestItem) {
       return manifestItem.useValue;
     }
     if (containerItem.instance) {
@@ -58,32 +58,39 @@ export class Container {
         resolve = _resolve;
       });
     }
-    let paramsInstances = null;
-    if (manifestItem.params) {
-      this.#checkForCircularDep(containerItem);
-      paramsInstances = await Promise.all(
-        manifestItem.params.map(
-          this.#resolveParam.bind(this),
-        ),
-      );
+    try {
+      let paramsInstances = null;
+      if (manifestItem.params) {
+        this.#checkForCircularDep(containerItem);
+        paramsInstances = await Promise.all(
+          manifestItem.params.map(
+            this.#resolveParam.bind(this),
+          ),
+        );
+      }
+      let instance: any;
+      if (manifestItem.useFn) {
+        instance = paramsInstances
+          ? manifestItem.useFn(...paramsInstances)
+          : manifestItem.useFn();
+      } else if (manifestItem.useFnByContainer) {
+        instance = manifestItem.useFnByContainer(this);
+      } else if (manifestItem.useClass) {
+        instance = paramsInstances
+          ? new manifestItem.useClass(...paramsInstances)
+          : new manifestItem.useClass();
+      }
+      if (manifestItem.scope === Kado.scope.Transient) {
+        return instance;
+      }
+      resolve!(instance);
+      return containerItem.instance;
+    } catch (error) {
+      // Reset the cached pending promise so a failed resolution
+      // does not poison future resolves of this token.
+      containerItem.instance = null;
+      throw error;
     }
-    let instance: any;
-    if (manifestItem.useFn) {
-      instance = paramsInstances
-        ? manifestItem.useFn(...paramsInstances)
-        : manifestItem.useFn();
-    } else if (manifestItem.useFnByContainer) {
-      instance = manifestItem.useFnByContainer(this);
-    } else if (manifestItem.useClass) {
-      instance = paramsInstances
-        ? new manifestItem.useClass(...paramsInstances)
-        : new manifestItem.useClass();
-    }
-    if (manifestItem.scope === Kado.scope.Transient) {
-      return instance;
-    }
-    resolve!(instance);
-    return containerItem.instance;
   }
 
   #resolveParam(param: KadoParam) {
@@ -98,12 +105,17 @@ export class Container {
     for (const manifestItem of manifestItems) {
       this.#registerItem(manifestItem);
     }
+    // Newly registered items may introduce cycles through tokens
+    // that were already validated, so re-arm circular-dep checking.
+    for (const containerItem of this.#tokenToContainerItem.values()) {
+      containerItem.checkedForCircularDep = false;
+    }
   }
 
   #registerItem(manifestItem: KadoManifestItem): KadoToken {
-    const token = manifestItem.token || urandom();
+    const token = manifestItem.token ?? urandom();
     this.#tokenToContainerItem.set(token, {
-      manifestItem: Object.assign(manifestItem, { token }),
+      manifestItem: { ...manifestItem, token },
       checkedForCircularDep: false,
       instance: null,
     });


### PR DESCRIPTION
- Reset cached pending promise on failed Singleton resolution so a failure no longer poisons future resolves (forever-pending hang)
- Use `??` for token default so falsy tokens (0, '') are preserved
- Detect `useValue` via `'useValue' in manifestItem` so injecting `undefined` as a value works
- Copy manifest item on register instead of mutating the caller's object
- Re-arm circular-dep checking after register so newly added cycles are detected

Add regression tests for each case.