### PR TITLE
feat(kado): add child containers and ContainerScoped lifetime

### DIFF
--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -60,6 +60,7 @@ const foo = await container.resolve('Foo');
   - [📚 API](#-api)
     - [`container.register(manifestItems)`](#containerregistermanifestitems)
     - [`container.resolve(token)`](#containerresolvetoken)
+    - [`container.createChildContainer()`](#containercreatechildcontainer)
     - [`container.get(token)`](#containergettoken)
     - [`container.list()`](#containerlist)
     - [Manifest items](#manifest-items)
@@ -105,8 +106,9 @@ pnpm install @daisugi/kado
 **Kado** wires your application together by resolving dependencies from a declarative manifest, so construction logic stays out of your business code. It provides:
 
 - ✅ Multiple isolated containers — no global state
+- ✅ Child containers with fall-through resolution to ancestors
 - ✅ Async resolution (`resolve` returns a `Promise`)
-- ✅ `Singleton` (cached) and `Transient` (per-resolve) scopes
+- ✅ `Singleton` (cached), `Transient` (per-resolve), and `ContainerScoped` (per-container) scopes
 - ✅ Class, factory, factory-by-container, and value providers
 - ✅ Inline, nested dependency definitions inside `params`
 - ✅ Auto-generated tokens when you omit one
@@ -181,12 +183,59 @@ Returns a `Promise` of the resolved instance (`T`).
 
 - `Singleton` (default) dependencies are built once and cached; subsequent resolves return the same instance.
 - `Transient` dependencies are rebuilt on every resolve.
-- Throws a `NotFound` error if the `token` is not registered.
+- `ContainerScoped` dependencies are built once per container (see [`createChildContainer`](#containercreatechildcontainer)).
+- When a `token` is not registered locally, lookup falls through to the parent container and up the ancestor chain.
+- Throws a `NotFound` error if the `token` is not registered anywhere in the chain.
 - Throws a `CircularDependencyDetected` error if the dependency graph contains a cycle.
 
 ```js
 const foo = await container.resolve('Foo');
 ```
+
+---
+
+### `container.createChildContainer()`
+
+Creates a child container. Token lookup falls through to the parent (and its ancestors) when a token is not registered locally, so children share their parents' registrations while adding or overriding their own.
+
+```ts
+container.createChildContainer(): KadoContainer
+```
+
+Returns a new `KadoContainer` whose `#parent` is the current container.
+
+- Inherited `Singleton` and `useValue` registrations are shared across the whole chain — resolved once, cached on the owning ancestor.
+- Inherited `ContainerScoped` registrations are isolated per child — each container that resolves the token builds and caches its own instance.
+- A token registered on the child shadows the same token on an ancestor for that child only.
+- Circular-dependency detection walks the ancestor chain, so cross-level `params` are validated too.
+
+```js
+// App-wide singletons live on the root.
+const { container: root } = new Kado();
+root.register([
+  { token: 'DbPool', useValue: createDbPool() },
+  { token: 'Logger', useClass: Logger },
+]);
+
+// One child per unit of work (e.g. an HTTP request).
+function handleRequest(req) {
+  const scoped = root.createChildContainer();
+  scoped.register([
+    { token: 'RequestContext', useValue: { userId: req.userId } },
+    {
+      token: 'UserRepo',
+      useClass: UserRepo,
+      // `DbPool` falls through to the root automatically.
+      params: ['DbPool', 'RequestContext'],
+      scope: Kado.scope.ContainerScoped,
+    },
+  ]);
+  return scoped.resolve('UserRepo');
+}
+```
+
+> [!NOTE]
+> `get()` and `list()` walk the ancestor chain like `resolve()`. `get()` falls through to the parent on a local miss; `list()` merges the whole chain, where a nearer container shadows its ancestors and each token appears once.
 
 ---
 
@@ -202,7 +251,7 @@ container.get(token: KadoToken): KadoManifestItem
 |---|---|---|
 | `token` | `KadoToken` | Identifier of the registered dependency. |
 
-Returns the registered `KadoManifestItem`. Throws a `NotFound` error if the `token` is not registered.
+Returns the registered `KadoManifestItem`. Falls through to the parent container on a local miss. Throws a `NotFound` error if the `token` is not registered anywhere in the chain.
 
 ```js
 const manifestItem = container.get('Foo');
@@ -212,13 +261,13 @@ const manifestItem = container.get('Foo');
 
 ### `container.list()`
 
-Returns the manifest items for every registered dependency, in registration order.
+Returns the manifest items for every dependency visible to the container, including those inherited from ancestors.
 
 ```ts
 container.list(): KadoManifestItem[]
 ```
 
-Takes no parameters. Returns every registered `KadoManifestItem`, in registration order.
+Takes no parameters. Items registered on this container come first (in registration order), followed by inherited ones. A nearer container shadows its ancestors, so each token appears once.
 
 ```js
 const manifestItems = container.list();
@@ -320,8 +369,9 @@ container.register([
 
 Defines the lifecycle of a dependency.
 
-- **`Singleton`** (default) — reuses the same instance across resolves.
+- **`Singleton`** (default) — reuses the same instance across resolves, shared by the whole container chain.
 - **`Transient`** — creates a new instance on each resolve.
+- **`ContainerScoped`** — caches one instance per container. Behaves like `Singleton` within a container and like `Transient` across sibling containers. See [`container.createChildContainer()`](#containercreatechildcontainer).
 
 ```js
 container.register([

--- a/packages/kado/src/__tests__/kado_child_container_test.ts
+++ b/packages/kado/src/__tests__/kado_child_container_test.ts
@@ -1,0 +1,449 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Ayamari, type AyamariErr } from '@daisugi/ayamari';
+
+import { Kado } from '../kado.js';
+
+describe('child container', () => {
+  it('falls through to the parent for unregistered tokens', async () => {
+    const { container: root } = new Kado();
+    root.register([{ token: 'DbPool', useValue: 'pool' }]);
+
+    const child = root.createChildContainer();
+
+    assert.strictEqual(
+      await child.resolve('DbPool'),
+      'pool',
+    );
+  });
+
+  it('walks the full ancestor chain', async () => {
+    const { container: root } = new Kado();
+    root.register([{ token: 'Config', useValue: 'cfg' }]);
+
+    const middle = root.createChildContainer();
+    const leaf = middle.createChildContainer();
+
+    assert.strictEqual(await leaf.resolve('Config'), 'cfg');
+  });
+
+  it('throws NotFound when no ancestor has the token', async () => {
+    const { container: root } = new Kado();
+    const child = root.createChildContainer();
+
+    await assert.rejects(
+      child.resolve('Missing'),
+      (err) => {
+        assert.strictEqual(
+          (err as AyamariErr).code,
+          Ayamari.errCode.NotFound,
+        );
+        return true;
+      },
+    );
+  });
+
+  it('child overrides shadow the parent registration', async () => {
+    const { container: root } = new Kado();
+    root.register([{ token: 'Env', useValue: 'prod' }]);
+
+    const child = root.createChildContainer();
+    child.register([{ token: 'Env', useValue: 'test' }]);
+
+    assert.strictEqual(await root.resolve('Env'), 'prod');
+    assert.strictEqual(await child.resolve('Env'), 'test');
+  });
+
+  it('resolves a child class with a param inherited from the parent', async () => {
+    const { container: root } = new Kado();
+    root.register([{ token: 'DbPool', useValue: 'pool' }]);
+
+    class UserRepo {
+      constructor(public dbPool: string) {}
+    }
+
+    const child = root.createChildContainer();
+    child.register([
+      {
+        token: 'UserRepo',
+        useClass: UserRepo,
+        params: ['DbPool'],
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    const repo = await child.resolve<UserRepo>('UserRepo');
+    assert.strictEqual(repo.dbPool, 'pool');
+  });
+});
+
+describe('ContainerScoped scope', () => {
+  it('caches one instance per container', async () => {
+    const { container: root } = new Kado();
+    class Svc {}
+    root.register([
+      {
+        token: 'Svc',
+        useClass: Svc,
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    const child = root.createChildContainer();
+
+    const a = await child.resolve<Svc>('Svc');
+    const b = await child.resolve<Svc>('Svc');
+
+    assert.strictEqual(a, b);
+  });
+
+  it('is isolated across sibling containers', async () => {
+    const { container: root } = new Kado();
+    class Svc {}
+    root.register([
+      {
+        token: 'Svc',
+        useClass: Svc,
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    const childA = root.createChildContainer();
+    const childB = root.createChildContainer();
+
+    const a = await childA.resolve<Svc>('Svc');
+    const b = await childB.resolve<Svc>('Svc');
+
+    assert.notStrictEqual(a, b);
+  });
+
+  it('differs from the parent instance (inherited registration)', async () => {
+    const { container: root } = new Kado();
+    class Svc {}
+    root.register([
+      {
+        token: 'Svc',
+        useClass: Svc,
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    const child = root.createChildContainer();
+
+    const rootInstance = await root.resolve<Svc>('Svc');
+    const childInstance = await child.resolve<Svc>('Svc');
+
+    assert.notStrictEqual(rootInstance, childInstance);
+  });
+
+  it('contrasts with Singleton, which is shared across the chain', async () => {
+    const { container: root } = new Kado();
+    class Logger {}
+    root.register([
+      {
+        token: 'Logger',
+        useClass: Logger,
+        scope: Kado.scope.Singleton,
+      },
+    ]);
+
+    const child = root.createChildContainer();
+
+    const rootLogger = await root.resolve<Logger>('Logger');
+    const childLogger =
+      await child.resolve<Logger>('Logger');
+
+    assert.strictEqual(rootLogger, childLogger);
+  });
+});
+
+describe('nested scopes (app → request → transaction)', () => {
+  it('each level resolves its own concerns and shares ancestors', async () => {
+    const { container: root } = new Kado();
+
+    class DbPool {}
+    class UserRepo {
+      constructor(
+        public dbPool: DbPool,
+        public ctx: { userId: number },
+      ) {}
+    }
+    class OrderRepo {
+      constructor(
+        public tx: { id: number },
+        public dbPool: DbPool,
+      ) {}
+    }
+    class OrderService {
+      constructor(
+        public orderRepo: OrderRepo,
+        public userRepo: UserRepo,
+      ) {}
+    }
+
+    // Level 0: app
+    const app = root.createChildContainer();
+    app.register([{ token: 'DbPool', useClass: DbPool }]);
+
+    // Level 1: per-request
+    const request = app.createChildContainer();
+    request.register([
+      {
+        token: 'RequestContext',
+        useValue: { userId: 7 },
+      },
+      {
+        token: 'UserRepo',
+        useClass: UserRepo,
+        params: ['DbPool', 'RequestContext'],
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    // Level 2: per-transaction
+    const tx = request.createChildContainer();
+    tx.register([
+      { token: 'Transaction', useValue: { id: 1 } },
+      {
+        token: 'OrderRepo',
+        useClass: OrderRepo,
+        params: ['Transaction', 'DbPool'],
+        scope: Kado.scope.ContainerScoped,
+      },
+      {
+        token: 'OrderService',
+        useClass: OrderService,
+        params: ['OrderRepo', 'UserRepo'],
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    const service =
+      await tx.resolve<OrderService>('OrderService');
+
+    // DbPool (app) is the same shared singleton everywhere.
+    assert.strictEqual(
+      service.orderRepo.dbPool,
+      service.userRepo.dbPool,
+    );
+    // Transaction (tx) and RequestContext (request) reached via
+    // the chain.
+    assert.strictEqual(service.orderRepo.tx.id, 1);
+    assert.strictEqual(service.userRepo.ctx.userId, 7);
+  });
+
+  it('sibling requests get isolated ContainerScoped instances', async () => {
+    const { container: root } = new Kado();
+    class DbPool {}
+    class UserRepo {
+      constructor(public dbPool: DbPool) {}
+    }
+    const app = root.createChildContainer();
+    app.register([{ token: 'DbPool', useClass: DbPool }]);
+
+    function makeRequest() {
+      const request = app.createChildContainer();
+      request.register([
+        {
+          token: 'UserRepo',
+          useClass: UserRepo,
+          params: ['DbPool'],
+          scope: Kado.scope.ContainerScoped,
+        },
+      ]);
+      return request;
+    }
+
+    const r1 = makeRequest();
+    const r2 = makeRequest();
+
+    const repo1 = await r1.resolve<UserRepo>('UserRepo');
+    const repo2 = await r2.resolve<UserRepo>('UserRepo');
+
+    // Different UserRepo per request...
+    assert.notStrictEqual(repo1, repo2);
+    // ...but the shared DbPool singleton is identical.
+    assert.strictEqual(repo1.dbPool, repo2.dbPool);
+  });
+});
+
+describe('circular dependency across containers', () => {
+  it('detects a parent-side cycle reached through child fallthrough', async () => {
+    const { container: root } = new Kado();
+
+    class P {
+      constructor(public q: unknown) {}
+    }
+    class Q {
+      constructor(public p: unknown) {}
+    }
+    class Controller {
+      constructor(public p: unknown) {}
+    }
+
+    // The cycle p ➡️ q 🔄 p lives entirely in the parent (a
+    // parent token cannot reference a child token — that would be
+    // a NotFound, never a cycle).
+    root.register([
+      { token: 'p', useClass: P, params: ['q'] },
+      { token: 'q', useClass: Q, params: ['p'] },
+    ]);
+
+    // Resolution starts from the child and walks up the chain to
+    // the cyclic parent tokens; the check must still catch it.
+    const child = root.createChildContainer();
+    child.register([
+      {
+        token: 'Controller',
+        useClass: Controller,
+        params: ['p'],
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    await assert.rejects(
+      child.resolve('Controller'),
+      (err) => {
+        assert.strictEqual(
+          (err as AyamariErr).code,
+          Ayamari.errCode.CircularDependencyDetected,
+        );
+        return true;
+      },
+    );
+  });
+
+  it('does not flag a valid cross-container graph', async () => {
+    const { container: root } = new Kado();
+    class Repo {
+      constructor(public pool: string) {}
+    }
+    class Service {
+      constructor(public repo: Repo) {}
+    }
+    root.register([{ token: 'Pool', useValue: 'pool' }]);
+
+    const child = root.createChildContainer();
+    child.register([
+      {
+        token: 'Repo',
+        useClass: Repo,
+        params: ['Pool'],
+        scope: Kado.scope.ContainerScoped,
+      },
+      {
+        token: 'Service',
+        useClass: Service,
+        params: ['Repo'],
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    const service = await child.resolve<Service>('Service');
+    assert.ok(service instanceof Service);
+    assert.strictEqual(service.repo.pool, 'pool');
+  });
+});
+
+describe('get() across the chain', () => {
+  it('returns an inherited manifest item', () => {
+    const { container: root } = new Kado();
+    root.register([{ token: 'DbPool', useValue: 'pool' }]);
+
+    const child = root.createChildContainer();
+
+    assert.deepStrictEqual(child.get('DbPool'), {
+      token: 'DbPool',
+      useValue: 'pool',
+    });
+  });
+
+  it('prefers the child registration when shadowed', () => {
+    const { container: root } = new Kado();
+    root.register([{ token: 'Env', useValue: 'prod' }]);
+
+    const child = root.createChildContainer();
+    child.register([{ token: 'Env', useValue: 'test' }]);
+
+    assert.strictEqual(root.get('Env').useValue, 'prod');
+    assert.strictEqual(child.get('Env').useValue, 'test');
+  });
+
+  it('throws NotFound when no ancestor has the token', () => {
+    const { container: root } = new Kado();
+    const child = root.createChildContainer();
+
+    assert.throws(
+      () => child.get('Missing'),
+      (err) => {
+        assert.strictEqual(
+          (err as AyamariErr).code,
+          Ayamari.errCode.NotFound,
+        );
+        return true;
+      },
+    );
+  });
+});
+
+describe('list() across the chain', () => {
+  it('includes inherited registrations', () => {
+    const { container: root } = new Kado();
+    root.register([{ token: 'DbPool', useValue: 'pool' }]);
+
+    const child = root.createChildContainer();
+    child.register([
+      { token: 'RequestContext', useValue: { userId: 1 } },
+    ]);
+
+    const tokens = child
+      .list()
+      .map((manifestItem) => manifestItem.token);
+
+    assert.strictEqual(tokens.length, 2);
+    assert.ok(tokens.includes('DbPool'));
+    assert.ok(tokens.includes('RequestContext'));
+  });
+
+  it('lists a shadowed token once, preferring the child', () => {
+    const { container: root } = new Kado();
+    root.register([{ token: 'Env', useValue: 'prod' }]);
+
+    const child = root.createChildContainer();
+    child.register([{ token: 'Env', useValue: 'test' }]);
+
+    const envItems = child
+      .list()
+      .filter(
+        (manifestItem) => manifestItem.token === 'Env',
+      );
+
+    assert.deepStrictEqual(envItems, [
+      { token: 'Env', useValue: 'test' },
+    ]);
+  });
+
+  it('lists an inherited ContainerScoped token only once', () => {
+    const { container: root } = new Kado();
+    class Svc {}
+    root.register([
+      {
+        token: 'Svc',
+        useClass: Svc,
+        scope: Kado.scope.ContainerScoped,
+      },
+    ]);
+
+    // `createChildContainer` copies the ContainerScoped item into
+    // the child, so it lives in both maps — `list()` must dedupe.
+    const child = root.createChildContainer();
+
+    const svcItems = child
+      .list()
+      .filter(
+        (manifestItem) => manifestItem.token === 'Svc',
+      );
+
+    assert.strictEqual(svcItems.length, 1);
+  });
+});

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -6,7 +6,10 @@ interface Class {
   new (...args: any[]): unknown;
 }
 export type KadoToken = string | symbol | number;
-export type KadoScope = 'Transient' | 'Singleton';
+export type KadoScope =
+  | 'Transient'
+  | 'Singleton'
+  | 'ContainerScoped';
 export interface KadoManifestItem {
   token?: KadoToken;
   useClass?: Class;
@@ -45,15 +48,54 @@ export class Container {
   // Bumped on every `register` to invalidate prior circular-dep
   // validations in O(1) instead of resetting a flag per item.
   #generation = 0;
+  // Token lookup falls through to the parent when not found
+  // locally; `null` for a root container. Passed through the
+  // constructor's optional `parent`, which only
+  // `createChildContainer` is meant to supply.
+  #parent: Container | null;
 
-  constructor() {
+  constructor(parent: Container | null = null) {
     this.#tokenToContainerItem = new Map();
+    this.#parent = parent;
+  }
+
+  // Creates a container whose token lookup falls through to this
+  // one (and its ancestors) when a token is not registered
+  // locally. `ContainerScoped` registrations are copied down so
+  // each child caches its own instance instead of sharing the
+  // ancestor's.
+  createChildContainer(): Container {
+    const child = new Container(this);
+    for (const [
+      token,
+      containerItem,
+    ] of this.#tokenToContainerItem) {
+      if (
+        containerItem.manifestItem.scope ===
+        Kado.scope.ContainerScoped
+      ) {
+        child.#tokenToContainerItem.set(token, {
+          ...containerItem,
+          validatedGeneration: -1,
+          instance: null,
+        });
+      }
+    }
+    return child;
   }
 
   async resolve<T>(token: KadoToken): Promise<T> {
     const containerItem =
       this.#tokenToContainerItem.get(token);
     if (containerItem === undefined) {
+      // Not registered locally: fall through to the ancestor
+      // chain. The matching ancestor becomes the resolving
+      // container, so its singletons cache there and are shared,
+      // while `ContainerScoped` items were already copied down to
+      // this container by `createChildContainer`.
+      if (this.#parent !== null) {
+        return this.#parent.resolve<T>(token);
+      }
       throw errFn.NotFound(
         `Attempted to resolve unregistered dependency token: "${token.toString()}".`,
       );
@@ -158,21 +200,51 @@ export class Container {
   }
 
   list(): KadoManifestItem[] {
-    return Array.from(
-      this.#tokenToContainerItem.values(),
-      (containerItem) => containerItem.manifestItem,
-    );
+    // Merge the whole chain. A nearer container shadows its
+    // ancestors, so the first registration seen for a token wins
+    // (this also dedupes the `ContainerScoped` copies that
+    // `createChildContainer` placed in descendants).
+    const manifestItemByToken = new Map<
+      KadoToken,
+      KadoManifestItem
+    >();
+    this.#collectManifestItems(manifestItemByToken);
+    return Array.from(manifestItemByToken.values());
+  }
+
+  #collectManifestItems(
+    manifestItemByToken: Map<KadoToken, KadoManifestItem>,
+  ): void {
+    for (const containerItem of this.#tokenToContainerItem.values()) {
+      const token = containerItem.manifestItem.token!;
+      if (!manifestItemByToken.has(token)) {
+        manifestItemByToken.set(
+          token,
+          containerItem.manifestItem,
+        );
+      }
+    }
+    if (this.#parent !== null) {
+      this.#parent.#collectManifestItems(
+        manifestItemByToken,
+      );
+    }
   }
 
   get(token: KadoToken): KadoManifestItem {
     const containerItem =
       this.#tokenToContainerItem.get(token);
-    if (containerItem === undefined) {
-      throw errFn.NotFound(
-        `Attempted to get unregistered dependency token: "${token.toString()}".`,
-      );
+    if (containerItem !== undefined) {
+      return containerItem.manifestItem;
     }
-    return containerItem.manifestItem;
+    // Not registered locally: fall through to the ancestor chain,
+    // mirroring `resolve`.
+    if (this.#parent !== null) {
+      return this.#parent.get(token);
+    }
+    throw errFn.NotFound(
+      `Attempted to get unregistered dependency token: "${token.toString()}".`,
+    );
   }
 
   #checkForCircularDep(
@@ -205,18 +277,34 @@ export class Container {
         if (typeof param === 'object') {
           continue;
         }
-        const paramContainerItem =
-          this.#tokenToContainerItem.get(param);
-        if (paramContainerItem) {
-          this.#checkForCircularDep(
-            paramContainerItem,
-            path,
-          );
-        }
+        // A param may live in an ancestor; validate it against
+        // its owner so each container memoizes with its own
+        // generation. Cycles can't span back down the chain
+        // (ancestors can't see descendant tokens), so walking up
+        // is sufficient.
+        this.#checkTokenForCircularDep(param, path);
       }
       path.delete(token);
     }
     containerItem.validatedGeneration = this.#generation;
+  }
+
+  // Locates `token` along the ancestor chain and runs the cycle
+  // check on the container that owns it, so the validation
+  // memoizes against that container's own generation.
+  #checkTokenForCircularDep(
+    token: KadoToken,
+    path: Set<KadoToken>,
+  ): void {
+    const containerItem =
+      this.#tokenToContainerItem.get(token);
+    if (containerItem !== undefined) {
+      this.#checkForCircularDep(containerItem, path);
+      return;
+    }
+    if (this.#parent !== null) {
+      this.#parent.#checkTokenForCircularDep(token, path);
+    }
   }
 }
 
@@ -224,6 +312,7 @@ export class Kado {
   static scope: Record<KadoScope, KadoScope> = {
     Transient: 'Transient',
     Singleton: 'Singleton',
+    ContainerScoped: 'ContainerScoped',
   };
   container: KadoContainer;
 


### PR DESCRIPTION
Add createChildContainer() with fall-through resolution up the ancestor chain, and a ContainerScoped scope that caches one instance per container (copied down so each child is isolated). get() and list() now walk the chain too, and the circular-dep check validates params against their owning container.