### PR TITLE
fix(anzen): correct and tighten Result method types

### DIFF
--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -412,7 +412,7 @@ Result.failure('err').toJSON();
 Deserializes a JSON string (as produced by `toJSON`) into a Result instance.
 
 ```ts
-Result.fromJSON<T = unknown, E = unknown>(json: string): AnzenAnyResult<E, T>
+Result.fromJSON<E = unknown, T = unknown>(json: string): AnzenAnyResult<E, T>
 ```
 
 | Parameter | Type | Description |
@@ -470,14 +470,14 @@ result.getError(); // 'err'
 Runs an array of Results or Promises of Results in parallel and unwraps them. The first element of the returned tuple is a Result representing the overall outcome; the remaining elements are the individual unwrapped values (or defaults on failure).
 
 ```ts
-Result.unwrapPromiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[], D extends unknown[]>(
-  args: [D, ...T],
+Result.unwrapPromiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
+  args: [Partial<ExtractSuccess<T>>, ...T],
 ): Promise<[AnzenResultSuccess<ExtractSuccess<T>> | AnzenResultFailure<ExtractFailure<T>>, ...ExtractSuccess<T>]>
 ```
 
 | Parameter | Type | Description |
 |---|---|---|
-| `args[0]` | `unknown[]` | Default values returned as the remaining tuple elements on failure. |
+| `args[0]` | `Partial<ExtractSuccess<T>>` | Default values returned as the remaining tuple elements on failure. Each default is type-checked against the corresponding success value type; pass `[]` to omit them. |
 | `args[1..n]` | `Result \| Promise<Result>` | Results or Promises of Results to run in parallel. |
 
 ```js
@@ -523,7 +523,7 @@ const [res, output] = await fn().then(Result.unwrap('foo'));
 Executes an async function that may throw. Returns a success Result with the resolved value, or a failure Result with the error passed through `parseErr`.
 
 ```ts
-Result.fromThrowable<T, E = unknown>(
+Result.fromThrowable<E = unknown, T = unknown>(
   fn: () => Promise<T>,
   parseErr?: (err: unknown) => E,
 ): Promise<AnzenAnyResult<E, T>>
@@ -552,7 +552,7 @@ result.getError(); // 'err'
 Same as `fromThrowable`, but for synchronous functions.
 
 ```ts
-Result.fromSyncThrowable<T, E = unknown>(
+Result.fromSyncThrowable<E = unknown, T = unknown>(
   fn: () => T,
   parseErr?: (err: unknown) => E,
 ): AnzenAnyResult<E, T>

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -56,14 +56,16 @@ describe('Result', () => {
     it('should return expected value', () => {
       const successRes = Result.success(
         1,
-      ) as AnzenAnyResult<void, number>;
+      ) as AnzenAnyResult<string, number>;
       assert.throws(
         () => {
           const a = successRes.getError();
           const b = successRes.getValue();
+          // The throwing branch is typed `never`, so union access
+          // stays clean: getError() -> E, getValue() -> T.
           checkType<
-            Equal<typeof a, void>,
-            Equal<typeof b, void | number>
+            Equal<typeof a, string>,
+            Equal<typeof b, number>
           >();
         },
         { message: 'Cannot get the error of a success.' },
@@ -332,6 +334,23 @@ describe('Result', () => {
       assert.equal(failureRes.isFailure, true);
       assert.equal(failureRes.getError(), 1);
     });
+
+    it('types the result from its generic arguments', () => {
+      // No generics: both sides default to unknown.
+      const res = Result.fromJSON(
+        JSON.stringify({ value: 1, isSuccess: true }),
+      );
+      checkType<
+        Equal<typeof res, AnzenAnyResult<unknown, unknown>>
+      >();
+      // Error-first generics, consistent with AnzenAnyResult<E, T>.
+      const typed = Result.fromJSON<string, number>(
+        JSON.stringify({ value: 1, isSuccess: true }),
+      );
+      checkType<
+        Equal<typeof typed, AnzenAnyResult<string, number>>
+      >();
+    });
   });
 
   describe('Result.promiseAll', () => {
@@ -380,6 +399,20 @@ describe('Result', () => {
         Equal<typeof res, AnzenResultFailure<number>>
       >();
     });
+
+    it('all-success inputs yield a never failure branch (no narrowing)', async () => {
+      const res = await Result.promiseAll([
+        Result.success(1),
+        Promise.resolve(Result.success('a')),
+      ]);
+      checkType<
+        Equal<
+          typeof res,
+          | AnzenResultSuccess<[number, string]>
+          | AnzenResultFailure<never>
+        >
+      >();
+    });
   });
 
   describe('Result.unwrapPromiseAll', () => {
@@ -420,6 +453,75 @@ describe('Result', () => {
         Equal<typeof res, AnzenResultFailure<number>>
       >();
     });
+
+    it('when inputs may fail, res should be typed as a success-or-failure union', async () => {
+      const promise1 = Promise.resolve(Result.success(1));
+      const promise2 = async () => Result.success(2);
+      const promise3 = () => Result.success('A');
+      const [res, ...results] =
+        await Result.unwrapPromiseAll([
+          [0, 0, '', 0],
+          promise1,
+          promise2(),
+          promise3(),
+          getRandomRes(),
+        ]);
+      checkType<
+        Equal<
+          typeof res,
+          | AnzenResultFailure<string>
+          | AnzenResultSuccess<
+              [number, number, string, number]
+            >
+        >,
+        Equal<
+          typeof results,
+          [number, number, string, number]
+        >
+      >();
+    });
+
+    it('when any input fails, returns the provided defaults as values', async () => {
+      const ok = async (): Promise<
+        AnzenAnyResult<string, number>
+      > => Result.success(1);
+      const bad = async (): Promise<
+        AnzenAnyResult<string, number>
+      > => Result.failure('boom');
+      const [res, ...results] =
+        await Result.unwrapPromiseAll([
+          [10, 20],
+          ok(),
+          bad(),
+        ]);
+      // Assert the type before any narrowing access to `res`.
+      checkType<
+        Equal<
+          typeof res,
+          | AnzenResultFailure<string>
+          | AnzenResultSuccess<[number, number]>
+        >,
+        Equal<typeof results, [number, number]>
+      >();
+      assert.equal(res.isFailure, true);
+      if (res.isFailure) {
+        assert.equal(res.getError(), 'boom');
+      }
+      assert.deepEqual(results, [10, 20]);
+    });
+
+    it('defaults are type-checked against the success value types', async () => {
+      const promise1 = Promise.resolve(Result.success(1));
+      // No defaults is allowed.
+      await Result.unwrapPromiseAll([[], promise1]);
+      // A matching default is allowed.
+      await Result.unwrapPromiseAll([[0], promise1]);
+      await Result.unwrapPromiseAll([
+        // @ts-expect-error default must match the success value type.
+        ['not a number'],
+        promise1,
+      ]);
+    });
   });
 
   describe('Result.unwrap', () => {
@@ -453,22 +555,79 @@ describe('Result', () => {
         >
       >();
     });
+
+    it('infers the success-or-failure tuple union without narrowing', async () => {
+      const fn = async (): Promise<
+        AnzenAnyResult<'err', number>
+      > => Result.success(1);
+      // Assert the type before any narrowing access.
+      const res = await fn().then(Result.unwrap());
+      checkType<
+        Equal<
+          typeof res,
+          | [AnzenResultFailure<'err'>, undefined]
+          | [AnzenResultSuccess<number>, number]
+        >
+      >();
+      // With a default, the failure value takes the default type.
+      const res2 = await fn().then(
+        Result.unwrap('fallback'),
+      );
+      checkType<
+        Equal<
+          typeof res2,
+          | [AnzenResultFailure<'err'>, string]
+          | [AnzenResultSuccess<number>, number]
+        >
+      >();
+    });
+
+    it('uses never for the impossible branch of a single-variant input', async () => {
+      // A statically-success input cannot fail: error type is never.
+      const ok = await (async () =>
+        Result.success(1))().then(Result.unwrap());
+      checkType<
+        Equal<
+          typeof ok,
+          | [AnzenResultFailure<never>, undefined]
+          | [AnzenResultSuccess<number>, number]
+        >
+      >();
+      // A statically-failure input cannot succeed: value type is never.
+      const bad = await (async () =>
+        Result.failure('e'))().then(Result.unwrap());
+      checkType<
+        Equal<
+          typeof bad,
+          | [AnzenResultFailure<string>, undefined]
+          | [AnzenResultSuccess<never>, never]
+        >
+      >();
+    });
   });
 
   describe('Result.fromThrowable', () => {
     it('when throwable is thrown, should return expected value', () => {
-      const res = Result.fromSyncThrowable<Error, Error>(
-        () => {
-          throw new Error('err');
-        },
-      );
+      // Error-first generics let you name only the error type.
+      const res = Result.fromSyncThrowable<Error>(() => {
+        throw new Error('err');
+      });
+      checkType<
+        Equal<typeof res, AnzenAnyResult<Error, unknown>>
+      >();
       assert.equal(res.isSuccess, false);
       assert.equal(res.isFailure, true);
-      assert.equal(res.getError().message, 'err');
+      if (res.isFailure) {
+        assert.equal(res.getError().message, 'err');
+      }
     });
 
     it('when throwable is not thrown, should return expected value', () => {
       const res = Result.fromSyncThrowable(() => 1);
+      // No parseErr: value is inferred, error defaults to unknown.
+      checkType<
+        Equal<typeof res, AnzenAnyResult<unknown, number>>
+      >();
       assert.equal(res.isSuccess, true);
       assert.equal(res.isFailure, false);
       assert.equal(res.getValue(), 1);
@@ -481,30 +640,45 @@ describe('Result', () => {
             throw new Error('err');
           },
           (err) =>
-            err instanceof Error ? err.message : err,
+            err instanceof Error
+              ? err.message
+              : String(err),
         );
+        // Error type is inferred from parseErr's return type.
+        checkType<
+          Equal<typeof res, AnzenAnyResult<string, never>>
+        >();
         assert.equal(res.isSuccess, false);
         assert.equal(res.isFailure, true);
-        assert.equal(res.getError(), 'err');
+        if (res.isFailure) {
+          assert.equal(res.getError(), 'err');
+        }
       });
     });
 
     describe('async', () => {
       it('when throwable is thrown, should return expected value', async () => {
-        const res = await Result.fromThrowable<
-          Error,
-          Error
-        >(async () => {
-          throw new Error('err');
-        });
+        const res = await Result.fromThrowable<Error>(
+          async () => {
+            throw new Error('err');
+          },
+        );
+        checkType<
+          Equal<typeof res, AnzenAnyResult<Error, unknown>>
+        >();
         assert.equal(res.isSuccess, false);
         assert.equal(res.isFailure, true);
-        assert.equal(res.getError().message, 'err');
+        if (res.isFailure) {
+          assert.equal(res.getError().message, 'err');
+        }
       });
     });
 
     it('when throwable is not thrown, should return expected value', async () => {
       const res = await Result.fromThrowable(async () => 1);
+      checkType<
+        Equal<typeof res, AnzenAnyResult<unknown, number>>
+      >();
       assert.equal(res.isSuccess, true);
       assert.equal(res.isFailure, false);
       assert.equal(res.getValue(), 1);

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -37,7 +37,7 @@ export class ResultSuccess<T> {
     return this.#value;
   }
 
-  getError(): void {
+  getError(): never {
     throw new Error('Cannot get the error of a success.');
   }
 
@@ -84,7 +84,7 @@ export class ResultFailure<E> {
     this.#error = err;
   }
 
-  getValue(): void {
+  getValue(): never {
     throw new Error('Cannot get the value of a failure.');
   }
 
@@ -153,7 +153,12 @@ export class Result {
       | AnzenAnyResult<unknown, unknown>
       | Promise<AnzenAnyResult<unknown, unknown>>
     )[],
-  >(whenRes: T) {
+  >(
+    whenRes: T,
+  ): Promise<
+    | AnzenResultSuccess<ExtractSuccess<T>>
+    | AnzenResultFailure<ExtractFailure<T>>
+  > {
     try {
       const vals = await Promise.all(
         whenRes.map((r) => handleResult(r)),
@@ -173,8 +178,17 @@ export class Result {
       | AnzenAnyResult<unknown, unknown>
       | Promise<AnzenAnyResult<unknown, unknown>>
     )[],
-    const D extends unknown[] = unknown[],
-  >(args: [D, ...T]) {
+  >(
+    args: [Partial<ExtractSuccess<T>>, ...T],
+  ): Promise<
+    [
+      (
+        | AnzenResultSuccess<ExtractSuccess<T>>
+        | AnzenResultFailure<ExtractFailure<T>>
+      ),
+      ...ExtractSuccess<T>,
+    ]
+  > {
     const [defaultsVals, ...whenRes] = args;
     try {
       const vals = await Promise.all(
@@ -192,7 +206,9 @@ export class Result {
     }
   }
 
-  static unwrap<T, E, D = undefined>(defaultVal?: D) {
+  static unwrap<T = never, E = never, D = undefined>(
+    defaultVal?: D,
+  ) {
     return (
       res: AnzenAnyResult<E, T>,
     ):
@@ -203,7 +219,7 @@ export class Result {
         : [res, defaultVal as D];
   }
 
-  static fromJSON<T = unknown, E = unknown>(
+  static fromJSON<E = unknown, T = unknown>(
     json: string,
   ): AnzenAnyResult<E, T> {
     const obj = JSON.parse(json);
@@ -212,7 +228,7 @@ export class Result {
       : new ResultFailure<E>(obj.error);
   }
 
-  static fromSyncThrowable<T, E = unknown>(
+  static fromSyncThrowable<E = unknown, T = unknown>(
     fn: () => T,
     parseErr?: (err: unknown) => E,
   ): AnzenAnyResult<E, T> {
@@ -223,7 +239,7 @@ export class Result {
     }
   }
 
-  static async fromThrowable<T, E = unknown>(
+  static async fromThrowable<E = unknown, T = unknown>(
     fn: () => Promise<T>,
     parseErr?: (err: unknown) => E,
   ): Promise<AnzenAnyResult<E, T>> {


### PR DESCRIPTION
- unwrapPromiseAll: constrain defaults to Partial<ExtractSuccess<T>> and return the documented single-tuple union; reject mismatched defaults.
- promiseAll: add explicit return-type annotation matching the README.
- unwrap: default generics to never so uninferable branches stop leaking unknown; .then inference unaffected.
- fromThrowable/fromSyncThrowable/fromJSON: reorder generics to error-first <E, T>, aligning with AnzenAnyResult<E, T> so the error type can be named alone.
- ResultSuccess.getError()/ResultFailure.getValue(): return never (they always throw), giving clean T/E on union access instead of T | void.
- Add honest, un-masked type tests across all methods; update README.