### PR TITLE
fix(kintsugi,ayamari): tighten and correct types across modules

### DIFF
--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -60,11 +60,11 @@ export class Ayamari<CustomErrCode> {
     ValidationFailed: 577,
   };
   errCode = Ayamari.errCode;
-  errFn = new Map() as Record<
+  errFn = {} as Record<
     AyamariErrCodeKey<CustomErrCode>,
     AyamariCreateErr
   >;
-  errFnRes = new Map() as Record<
+  errFnRes = {} as Record<
     AyamariErrCodeKey<CustomErrCode>,
     AyamariCreateErrRes
   >;

--- a/packages/kintsugi/src/deferred_promise.ts
+++ b/packages/kintsugi/src/deferred_promise.ts
@@ -1,10 +1,10 @@
-export function deferredPromise() {
+export function deferredPromise<T = unknown>() {
   let isPending = true;
   let isRejected = false;
   let isFulfilled = false;
-  let resolve!: (value?: any) => void;
-  let reject!: (reason?: any) => void;
-  const promise = new Promise(
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>(
     (privateResolve, privateReject) => {
       resolve = privateResolve;
       reject = privateReject;

--- a/packages/kintsugi/src/reuse_promise.ts
+++ b/packages/kintsugi/src/reuse_promise.ts
@@ -2,22 +2,27 @@ import { SimpleMemoryStore } from './simple_memory_store.js';
 import { stringifyArgs } from './stringify_args.js';
 import type { AsyncFn } from './types.js';
 
-export function reusePromise(fn: AsyncFn) {
+export function reusePromise<Fn extends AsyncFn>(fn: Fn) {
   const simpleMemoryStore = new SimpleMemoryStore();
 
   // eslint-disable-next-line require-await
-  return async function (this: unknown, ...args: any[]) {
-    const cacheKey = stringifyArgs(args) as string;
+  return async function (
+    this: unknown,
+    ...args: Parameters<Fn>
+  ): Promise<Awaited<ReturnType<Fn>>> {
+    const cacheKey = stringifyArgs(args);
     const cacheResponse = simpleMemoryStore.get(cacheKey);
     if (cacheResponse.isSuccess) {
-      return cacheResponse.getValue();
+      return cacheResponse.getValue() as Promise<
+        Awaited<ReturnType<Fn>>
+      >;
     }
     const response = fn.apply(this, args).then(
-      (value: any) => {
+      (value) => {
         simpleMemoryStore.delete(cacheKey);
         return value;
       },
-      (reason: any) => {
+      (reason) => {
         simpleMemoryStore.delete(cacheKey);
         throw reason;
       },

--- a/packages/kintsugi/src/simple_memory_store.ts
+++ b/packages/kintsugi/src/simple_memory_store.ts
@@ -6,7 +6,7 @@ import type { CacheStore } from './with_cache.js';
 const { errFn } = new Ayamari();
 
 export class SimpleMemoryStore implements CacheStore {
-  #store;
+  #store: Record<string, unknown>;
 
   constructor() {
     this.#store = Object.create(null);
@@ -22,7 +22,7 @@ export class SimpleMemoryStore implements CacheStore {
     return Result.success(value);
   }
 
-  set(cacheKey: string, value: any) {
+  set(cacheKey: string, value: unknown) {
     this.#store[cacheKey] = value;
     return Result.success(value);
   }

--- a/packages/kintsugi/src/stringify_args.ts
+++ b/packages/kintsugi/src/stringify_args.ts
@@ -1,4 +1,4 @@
-function isPrimitive(value: any) {
+function isPrimitive(value: unknown) {
   return (
     value == null ||
     typeof value === 'number' ||
@@ -6,10 +6,10 @@ function isPrimitive(value: any) {
   );
 }
 
-export function stringifyArgs(args: any[]) {
+export function stringifyArgs(args: unknown[]): string {
   if (args.length === 1) {
     return isPrimitive(args[0])
-      ? args[0]
+      ? String(args[0])
       : JSON.stringify(args[0]);
   }
   return JSON.stringify(args);

--- a/packages/kintsugi/src/with_cache.ts
+++ b/packages/kintsugi/src/with_cache.ts
@@ -74,8 +74,8 @@ export function shouldCache(
   return false;
 }
 
-export function withCache(
-  fn: AnzenResultFn<any, any>,
+export function withCache<E, T>(
+  fn: AnzenResultFn<E, T>,
   opts: WithCacheOpts = {},
 ) {
   const cacheStore =
@@ -90,7 +90,10 @@ export function withCache(
   const shouldInvalidateCacheFn =
     opts.shouldInvalidateCache || shouldInvalidateCache;
   const fnHash = encToFNV1A(fn.toString());
-  return async function (this: unknown, ...args: any[]) {
+  return async function (
+    this: unknown,
+    ...args: any[]
+  ): Promise<AnzenAnyResult<E, T>> {
     const cacheKey = buildCacheKeyFn(fnHash, version, args);
     if (!shouldInvalidateCacheFn(args)) {
       const cacheResponse = await cacheStore.get(cacheKey);

--- a/packages/kintsugi/src/with_circuit_breaker.ts
+++ b/packages/kintsugi/src/with_circuit_breaker.ts
@@ -31,10 +31,13 @@ const State = {
   HalfOpen: 3,
 };
 
+/** A bucket holds the number of failures and total calls within a window slice. */
+type Bucket = [failures: number, calls: number];
+
 const Measure = {
-  Failure: 1,
-  Calls: 2,
-};
+  Failure: 0,
+  Calls: 1,
+} as const;
 
 const circuitSuspendedErr = Result.failure(
   errFn.CircuitSuspended(
@@ -57,8 +60,8 @@ export function isFailureResponse(
   return true;
 }
 
-export function withCircuitBreaker(
-  fn: AnzenResultFn<any, any>,
+export function withCircuitBreaker<E, T>(
+  fn: AnzenResultFn<E, T>,
   opts: WithCircuitBreakerOpts = {},
 ) {
   const windowDurationMs =
@@ -75,7 +78,7 @@ export function withCircuitBreaker(
   const returnToServiceAfterMs =
     opts.returnToServiceAfterMs ||
     defaultReturnToServiceAfterMs;
-  const buckets = [[0, 0]];
+  const buckets: Bucket[] = [[0, 0]];
   let currentState = State.Close;
   let nextAttemptMs = Date.now();
   setInterval(() => {
@@ -84,7 +87,12 @@ export function withCircuitBreaker(
       buckets.shift();
     }
   }, windowDurationMs / totalBuckets);
-  return async function (this: unknown, ...args: any[]) {
+  return async function (
+    this: unknown,
+    ...args: any[]
+  ): Promise<
+    AnzenAnyResult<E, T> | typeof circuitSuspendedErr
+  > {
     if (currentState === State.Open) {
       if (nextAttemptMs > Date.now()) {
         return circuitSuspendedErr;
@@ -95,16 +103,16 @@ export function withCircuitBreaker(
     const lastBucket = buckets.at(-1)!;
     const isFailure = isFailureResponseFn(response);
     lastBucket[Measure.Calls] =
-      lastBucket[Measure.Calls]! + 1;
+      lastBucket[Measure.Calls] + 1;
     if (isFailure) {
       lastBucket[Measure.Failure] =
-        lastBucket[Measure.Failure]! + 1;
+        lastBucket[Measure.Failure] + 1;
     }
     let bucketsFailures = 0;
     let bucketsCalls = 0;
     for (const bucket of buckets) {
-      bucketsFailures += bucket[Measure.Failure]!;
-      bucketsCalls += bucket[Measure.Calls]!;
+      bucketsFailures += bucket[Measure.Failure];
+      bucketsCalls += bucket[Measure.Calls];
     }
     if (currentState === State.HalfOpen) {
       const lastCallFailed =

--- a/packages/kintsugi/src/with_pool.ts
+++ b/packages/kintsugi/src/with_pool.ts
@@ -84,18 +84,24 @@ export function createWithPool(opts: WithPoolOpts = {}) {
     opts.concurrencyCount || defaultConcurrencyCount;
   const tasks: Task[] = [];
   return {
-    withPool(fn: AsyncFn) {
-      return withPoolCreator(fn, tasks, concurrencyCount);
+    withPool<Fn extends AsyncFn>(fn: Fn) {
+      return withPoolCreator(
+        fn,
+        tasks,
+        concurrencyCount,
+      ) as (...args: Parameters<Fn>) => ReturnType<Fn>;
     },
   };
 }
 
-export function withPool(
-  fn: AsyncFn,
+export function withPool<Fn extends AsyncFn>(
+  fn: Fn,
   opts: WithPoolOpts = {},
-) {
+): (...args: Parameters<Fn>) => ReturnType<Fn> {
   const concurrencyCount =
     opts.concurrencyCount || defaultConcurrencyCount;
   const tasks: Task[] = [];
-  return withPoolCreator(fn, tasks, concurrencyCount);
+  return withPoolCreator(fn, tasks, concurrencyCount) as (
+    ...args: Parameters<Fn>
+  ) => ReturnType<Fn>;
 }

--- a/packages/kintsugi/src/with_retry.ts
+++ b/packages/kintsugi/src/with_retry.ts
@@ -19,7 +19,7 @@ interface WithRetryOpts {
     retryNumber: number,
   ): number;
   shouldRetry?(
-    response: any,
+    response: AnzenAnyResult<unknown, unknown>,
     retryNumber: number,
     maxRetries: number,
   ): boolean;
@@ -65,8 +65,8 @@ export function shouldRetry(
   return false;
 }
 
-export function withRetry(
-  fn: AnzenResultFn<any, any>,
+export function withRetry<E, T>(
+  fn: AnzenResultFn<E, T>,
   opts: WithRetryOpts = {},
 ) {
   const firstDelayMs =
@@ -80,10 +80,10 @@ export function withRetry(
 
   async function fnWithRetry(
     this: unknown,
-    retryFn: AnzenResultFn<any, any>,
+    retryFn: AnzenResultFn<E, T>,
     args: any[],
     retryNumber: number,
-  ): Promise<AnzenAnyResult<any, any>> {
+  ): Promise<AnzenAnyResult<E, T>> {
     const response = await retryFn.call(this, args);
     if (shouldRetryFn(response, retryNumber, maxRetries)) {
       await waitFor(
@@ -99,5 +99,6 @@ export function withRetry(
     return response;
   }
 
-  return (...args: any[]) => fnWithRetry(fn, args, 0);
+  return (...args: any[]): Promise<AnzenAnyResult<E, T>> =>
+    fnWithRetry(fn, args, 0);
 }

--- a/packages/kintsugi/src/with_timeout.ts
+++ b/packages/kintsugi/src/with_timeout.ts
@@ -14,22 +14,26 @@ interface WithTimeoutOpts {
   maxTimeMs?: number;
 }
 
-export function withTimeout(
-  fn: AsyncFn,
+export function withTimeout<Fn extends AsyncFn>(
+  fn: Fn,
   opts: WithTimeoutOpts = {},
-) {
+): (
+  ...args: Parameters<Fn>
+) => Promise<Awaited<ReturnType<Fn>> | typeof timeoutErr> {
   const maxTimeMs = opts.maxTimeMs || defaultMaxTimeMs;
-  return function (this: unknown, ...args: any[]) {
+  return function (this: unknown, ...args: Parameters<Fn>) {
     const promise = fn.apply(this, args);
-    const timeout = new Promise((resolve) => {
-      const timeoutId = setTimeout(() => {
-        resolve(timeoutErr);
-      }, maxTimeMs);
-      //This will handle the promise (and makes possible unhandled-rejection warnings away) to avoid breaking on errors, but you should still handle this promise!
-      promise
-        .catch(() => {})
-        .then(() => clearTimeout(timeoutId));
-    });
+    const timeout = new Promise<typeof timeoutErr>(
+      (resolve) => {
+        const timeoutId = setTimeout(() => {
+          resolve(timeoutErr);
+        }, maxTimeMs);
+        //This will handle the promise (and makes possible unhandled-rejection warnings away) to avoid breaking on errors, but you should still handle this promise!
+        promise
+          .catch(() => {})
+          .then(() => clearTimeout(timeoutId));
+      },
+    );
     return Promise.race([timeout, promise]);
   };
 }


### PR DESCRIPTION
Make the resilience wrappers generic so they preserve caller types instead of erasing them to any:
- withCache/withRetry/withCircuitBreaker are generic over <E, T> and return Promise<AnzenAnyResult<E, T>>; circuit breaker and timeout unions reflect their injected failures (circuitSuspendedErr / timeoutErr) honestly.
- withPool/createWithPool/withTimeout/reusePromise are generic over the wrapped function and preserve Parameters/ReturnType.

Tighten leaf helpers: stringifyArgs returns string, SimpleMemoryStore #store is Record<string, unknown>, deferredPromise is generic <T>.

Fix a latent circuit-breaker bug the loose number[][] type hid: Measure indices (1,2) read out of bounds on 2-element buckets, yielding NaN so the breaker never tripped. Buckets are now a [failures, calls] tuple with corrected indices.

In ayamari, errFn/errFnRes were new Map() cast to Record but only ever used as plain-object dictionaries; use {} so the type matches runtime.