### PR TITLE
refactor(kado): make @daisugi/ayamari an optional, injectable dependency

### DIFF
--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -14,7 +14,7 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 
 - 💡 Minimal size overhead ([details](https://bundlephobia.com/result?p=@daisugi/kado))
 - ⚡️ Written in TypeScript
-- 📦 Uses only trusted dependencies
+- 📦 Zero required dependencies
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
 - 🤝 Used in production
@@ -97,6 +97,25 @@ Using pnpm:
 pnpm install @daisugi/kado
 ```
 
+Kado has no required runtime dependencies. To get richer errors (with
+codes, causes and prettified stacks), optionally install
+[@daisugi/ayamari](../ayamari) and inject its `errFn`:
+
+```sh
+pnpm install @daisugi/ayamari
+```
+
+```ts
+import { Kado } from '@daisugi/kado';
+import { Ayamari } from '@daisugi/ayamari';
+
+const { errFn } = new Ayamari();
+const { container } = new Kado({ errFn });
+```
+
+When no `errFn` is provided, Kado throws built-in errors that expose the
+same `name`, `code` and `message` (e.g. `NotFound [404]`).
+
 [:top: Back to top](#-table-of-contents)
 
 ---
@@ -113,7 +132,7 @@ pnpm install @daisugi/kado
 - ✅ Inline, nested dependency definitions inside `params`
 - ✅ Auto-generated tokens when you omit one
 - ✅ Built-in circular dependency detection
-- ✅ Rich errors via [@daisugi/ayamari](../ayamari)
+- ✅ Optional rich errors via [@daisugi/ayamari](../ayamari)
 
 [:top: Back to top](#-table-of-contents)
 

--- a/packages/kado/package.json
+++ b/packages/kado/package.json
@@ -52,14 +52,10 @@
     "url": "https://github.com/daisugiland/daisugi.git"
   },
   "types": "dist/types/kado.d.ts",
-  "dependencies": {
-    "@daisugi/ayamari": "workspace:*",
-    "@daisugi/kintsugi": "workspace:*"
-  },
   "devDependencies": {
+    "@types/node": "^25.9.1",
     "oxfmt": "^0.53.0",
     "oxlint": "^1.68.0",
-    "@types/node": "^25.9.1",
     "tsc-watch": "^7.2.0",
     "typescript": "^6.0.3"
   }

--- a/packages/kado/src/__tests__/kado_child_container_test.ts
+++ b/packages/kado/src/__tests__/kado_child_container_test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { Ayamari, type AyamariErr } from '@daisugi/ayamari';
 
 import { Kado } from '../kado.js';
+
+// Shape of the errors Kado throws by default (Error + numeric `code`).
+type ThrownErr = Error & { code: number };
 
 describe('child container', () => {
   it('falls through to the parent for unregistered tokens', async () => {
@@ -34,10 +36,7 @@ describe('child container', () => {
     await assert.rejects(
       child.resolve('Missing'),
       (err) => {
-        assert.strictEqual(
-          (err as AyamariErr).code,
-          Ayamari.errCode.NotFound,
-        );
+        assert.strictEqual((err as ThrownErr).code, 404);
         return true;
       },
     );
@@ -304,10 +303,7 @@ describe('circular dependency across containers', () => {
     await assert.rejects(
       child.resolve('Controller'),
       (err) => {
-        assert.strictEqual(
-          (err as AyamariErr).code,
-          Ayamari.errCode.CircularDependencyDetected,
-        );
+        assert.strictEqual((err as ThrownErr).code, 578);
         return true;
       },
     );
@@ -376,10 +372,7 @@ describe('get() across the chain', () => {
     assert.throws(
       () => child.get('Missing'),
       (err) => {
-        assert.strictEqual(
-          (err as AyamariErr).code,
-          Ayamari.errCode.NotFound,
-        );
+        assert.strictEqual((err as ThrownErr).code, 404);
         return true;
       },
     );

--- a/packages/kado/src/__tests__/kado_test.ts
+++ b/packages/kado/src/__tests__/kado_test.ts
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { Ayamari, type AyamariErr } from '@daisugi/ayamari';
 
 import {
   Kado,
   type KadoContainer,
   type KadoManifestItem,
 } from '../kado.js';
+
+// Shape of the errors Kado throws by default (Error + numeric `code`).
+type ThrownErr = Error & { code: number };
 
 describe('Kado', () => {
   it('should have proper api', () => {
@@ -421,15 +423,12 @@ describe('Kado', () => {
         await container.resolve('a');
       } catch (err) {
         assert.strictEqual(
-          (err as AyamariErr).message,
+          (err as ThrownErr).message,
           'Attempted to resolve unregistered dependency token: "a".',
         );
+        assert.strictEqual((err as ThrownErr).code, 404);
         assert.strictEqual(
-          (err as AyamariErr).code,
-          Ayamari.errCode.NotFound,
-        );
-        assert.strictEqual(
-          (err as AyamariErr).name,
+          (err as ThrownErr).name,
           'NotFound [404]',
         );
       }
@@ -448,15 +447,12 @@ describe('Kado', () => {
         await container.resolve('a');
       } catch (err) {
         assert.strictEqual(
-          (err as AyamariErr).message,
+          (err as ThrownErr).message,
           'Attempted to resolve unregistered dependency token: "b".',
         );
+        assert.strictEqual((err as ThrownErr).code, 404);
         assert.strictEqual(
-          (err as AyamariErr).code,
-          Ayamari.errCode.NotFound,
-        );
-        assert.strictEqual(
-          (err as AyamariErr).name,
+          (err as ThrownErr).name,
           'NotFound [404]',
         );
       }
@@ -489,15 +485,12 @@ describe('Kado', () => {
         await container.resolve('a');
       } catch (err) {
         assert.strictEqual(
-          (err as AyamariErr).message,
+          (err as ThrownErr).message,
           'Attempted to resolve circular dependency: "a" ➡️ "b" ➡️ "c" 🔄 "a".',
         );
+        assert.strictEqual((err as ThrownErr).code, 578);
         assert.strictEqual(
-          (err as AyamariErr).code,
-          Ayamari.errCode.CircularDependencyDetected,
-        );
-        assert.strictEqual(
-          (err as AyamariErr).name,
+          (err as ThrownErr).name,
           'CircularDependencyDetected [578]',
         );
       }

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -1,7 +1,3 @@
-import { Ayamari } from '@daisugi/ayamari';
-
-const { errFn } = new Ayamari();
-
 interface Class {
   new (...args: any[]): unknown;
 }
@@ -10,6 +6,36 @@ export type KadoScope =
   | 'Transient'
   | 'Singleton'
   | 'ContainerScoped';
+
+// Minimal error-factory surface Kado depends on. `@daisugi/ayamari`'s
+// `errFn` satisfies this shape, so it can be injected directly; when
+// it is not, the built-in `defaultErrFn` is used, keeping Kado free of
+// any required runtime dependency.
+export interface KadoErrFn {
+  NotFound(msg: string): Error;
+  CircularDependencyDetected(msg: string): Error;
+}
+
+export interface KadoOpts {
+  errFn?: KadoErrFn;
+}
+
+// Built-in fallback that reproduces the observable contract of the
+// matching Ayamari errors (`name`, `code`, `message`), so behavior is
+// unchanged whether or not Ayamari is installed.
+const defaultErrFn: KadoErrFn = {
+  NotFound: (msg) =>
+    Object.assign(new Error(msg), {
+      name: 'NotFound [404]',
+      code: 404,
+    }),
+  CircularDependencyDetected: (msg) =>
+    Object.assign(new Error(msg), {
+      name: 'CircularDependencyDetected [578]',
+      code: 578,
+    }),
+};
+
 export interface KadoManifestItem {
   token?: KadoToken;
   useClass?: Class;
@@ -53,10 +79,19 @@ export class Container {
   // constructor's optional `parent`, which only
   // `createChildContainer` is meant to supply.
   #parent: Container | null;
+  // Error factory used for thrown errors. Defaults to a built-in
+  // implementation; an `@daisugi/ayamari` `errFn` (or any compatible
+  // factory) can be injected via `Kado`'s config and is propagated to
+  // child containers.
+  #errFn: KadoErrFn;
 
-  constructor(parent: Container | null = null) {
+  constructor(
+    parent: Container | null = null,
+    errFn: KadoErrFn = defaultErrFn,
+  ) {
     this.#tokenToContainerItem = new Map();
     this.#parent = parent;
+    this.#errFn = errFn;
   }
 
   // Creates a container whose token lookup falls through to this
@@ -65,7 +100,7 @@ export class Container {
   // each child caches its own instance instead of sharing the
   // ancestor's.
   createChildContainer(): Container {
-    const child = new Container(this);
+    const child = new Container(this, this.#errFn);
     for (const [
       token,
       containerItem,
@@ -96,7 +131,7 @@ export class Container {
       if (this.#parent !== null) {
         return this.#parent.resolve<T>(token);
       }
-      throw errFn.NotFound(
+      throw this.#errFn.NotFound(
         `Attempted to resolve unregistered dependency token: "${token.toString()}".`,
       );
     }
@@ -242,7 +277,7 @@ export class Container {
     if (this.#parent !== null) {
       return this.#parent.get(token);
     }
-    throw errFn.NotFound(
+    throw this.#errFn.NotFound(
       `Attempted to get unregistered dependency token: "${token.toString()}".`,
     );
   }
@@ -266,7 +301,7 @@ export class Container {
       const chainOfTokens = Array.from(path)
         .map((t) => `"${t.toString()}"`)
         .join(' ➡️ ');
-      throw errFn.CircularDependencyDetected(
+      throw this.#errFn.CircularDependencyDetected(
         `Attempted to resolve circular dependency: ${chainOfTokens} 🔄 "${token.toString()}".`,
       );
     }
@@ -316,8 +351,8 @@ export class Kado {
   };
   container: KadoContainer;
 
-  constructor() {
-    this.container = new Container();
+  constructor(opts: KadoOpts = {}) {
+    this.container = new Container(null, opts.errFn);
   }
 
   static value(value: unknown): KadoManifestItem {

--- a/packages/kado/tsconfig.json
+++ b/packages/kado/tsconfig.json
@@ -7,13 +7,5 @@
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../ayamari"
-    },
-    {
-      "path": "../kintsugi"
-    }
   ]
 }

--- a/packages/kado/tsconfig_cjs.json
+++ b/packages/kado/tsconfig_cjs.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig_base.json",
   "compilerOptions": {
     "declarationDir": "dist/types",
-    "module": "commonjs",
     "ignoreDeprecations": "6.0",
+    "module": "commonjs",
     "moduleResolution": "node10",
     "outDir": "dist/cjs",
     "rootDir": "src",
@@ -15,13 +15,5 @@
   ],
   "include": [
     "src/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../kintsugi"
-    },
-    {
-      "path": "../ayamari"
-    }
   ]
 }

--- a/packages/kado/tsconfig_esm.json
+++ b/packages/kado/tsconfig_esm.json
@@ -11,13 +11,5 @@
   ],
   "include": [
     "src/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../kintsugi"
-    },
-    {
-      "path": "../ayamari"
-    }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,13 +93,6 @@ importers:
         version: 6.0.3
 
   packages/kado:
-    dependencies:
-      '@daisugi/ayamari':
-        specifier: workspace:*
-        version: link:../ayamari
-      '@daisugi/kintsugi':
-        specifier: workspace:*
-        version: link:../kintsugi
     devDependencies:
       '@types/node':
         specifier: ^25.9.1


### PR DESCRIPTION
Kado no longer imports @daisugi/ayamari. Errors are produced through an injectable factory (KadoErrFn) defined by Kado itself, with a built-in default that reproduces the previous error contract (name/code/message). Consumers can opt into Ayamari's richer errors via `new Kado({ errFn })`.

- Drop ayamari from runtime deps; remove it from tests, devDeps and the tsconfig project references (production build is fully decoupled).
- Tests assert Kado's own default error contract using literals.
- Document the optional Ayamari integration in the README.