### PR TITLE
refactor(kado): drop required `code` from default errors

### DIFF
--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -113,8 +113,10 @@ const { errFn } = new Ayamari();
 const { container } = new Kado({ errFn });
 ```
 
-When no `errFn` is provided, Kado throws built-in errors that expose the
-same `name`, `code` and `message` (e.g. `NotFound [404]`).
+When no `errFn` is provided, Kado throws plain native `Error`s (with a
+descriptive `name`, e.g. `NotFound`, and a `message`). Injecting Ayamari
+adds richer fields such as a numeric `code`; Kado accepts either, since
+both are `Error`s.
 
 [:top: Back to top](#-table-of-contents)
 

--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -113,10 +113,10 @@ const { errFn } = new Ayamari();
 const { container } = new Kado({ errFn });
 ```
 
-When no `errFn` is provided, Kado throws plain native `Error`s (with a
-descriptive `name`, e.g. `NotFound`, and a `message`). Injecting Ayamari
-adds richer fields such as a numeric `code`; Kado accepts either, since
-both are `Error`s.
+When no `errFn` is provided, Kado throws native `Error`s that mirror
+Ayamari's contract (e.g. `name: 'NotFound [404]'`, `code: 404`). The
+`code` is not required by the factory contract, so a custom `errFn` may
+return plain `Error`s without one; Kado accepts either.
 
 [:top: Back to top](#-table-of-contents)
 

--- a/packages/kado/src/__tests__/kado_child_container_test.ts
+++ b/packages/kado/src/__tests__/kado_child_container_test.ts
@@ -3,8 +3,9 @@ import { describe, it } from 'node:test';
 
 import { Kado } from '../kado.js';
 
-// Shape of the errors Kado throws by default (Error + numeric `code`).
-type ThrownErr = Error & { code: number };
+// Kado throws native `Error`s; an injected factory may enrich them with
+// a `code` (e.g. `@daisugi/ayamari`), so it is optional here.
+type ThrownErr = Error & { code?: number };
 
 describe('child container', () => {
   it('falls through to the parent for unregistered tokens', async () => {
@@ -36,7 +37,10 @@ describe('child container', () => {
     await assert.rejects(
       child.resolve('Missing'),
       (err) => {
-        assert.strictEqual((err as ThrownErr).code, 404);
+        assert.strictEqual(
+          (err as ThrownErr).name,
+          'NotFound',
+        );
         return true;
       },
     );
@@ -303,7 +307,10 @@ describe('circular dependency across containers', () => {
     await assert.rejects(
       child.resolve('Controller'),
       (err) => {
-        assert.strictEqual((err as ThrownErr).code, 578);
+        assert.strictEqual(
+          (err as ThrownErr).name,
+          'CircularDependencyDetected',
+        );
         return true;
       },
     );
@@ -372,7 +379,10 @@ describe('get() across the chain', () => {
     assert.throws(
       () => child.get('Missing'),
       (err) => {
-        assert.strictEqual((err as ThrownErr).code, 404);
+        assert.strictEqual(
+          (err as ThrownErr).name,
+          'NotFound',
+        );
         return true;
       },
     );

--- a/packages/kado/src/__tests__/kado_child_container_test.ts
+++ b/packages/kado/src/__tests__/kado_child_container_test.ts
@@ -37,10 +37,7 @@ describe('child container', () => {
     await assert.rejects(
       child.resolve('Missing'),
       (err) => {
-        assert.strictEqual(
-          (err as ThrownErr).name,
-          'NotFound',
-        );
+        assert.strictEqual((err as ThrownErr).code, 404);
         return true;
       },
     );
@@ -307,10 +304,7 @@ describe('circular dependency across containers', () => {
     await assert.rejects(
       child.resolve('Controller'),
       (err) => {
-        assert.strictEqual(
-          (err as ThrownErr).name,
-          'CircularDependencyDetected',
-        );
+        assert.strictEqual((err as ThrownErr).code, 578);
         return true;
       },
     );
@@ -379,10 +373,7 @@ describe('get() across the chain', () => {
     assert.throws(
       () => child.get('Missing'),
       (err) => {
-        assert.strictEqual(
-          (err as ThrownErr).name,
-          'NotFound',
-        );
+        assert.strictEqual((err as ThrownErr).code, 404);
         return true;
       },
     );

--- a/packages/kado/src/__tests__/kado_test.ts
+++ b/packages/kado/src/__tests__/kado_test.ts
@@ -7,8 +7,9 @@ import {
   type KadoManifestItem,
 } from '../kado.js';
 
-// Shape of the errors Kado throws by default (Error + numeric `code`).
-type ThrownErr = Error & { code: number };
+// Kado throws native `Error`s; an injected factory may enrich them with
+// a `code` (e.g. `@daisugi/ayamari`), so it is optional here.
+type ThrownErr = Error & { code?: number };
 
 describe('Kado', () => {
   it('should have proper api', () => {
@@ -426,10 +427,9 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve unregistered dependency token: "a".',
         );
-        assert.strictEqual((err as ThrownErr).code, 404);
         assert.strictEqual(
           (err as ThrownErr).name,
-          'NotFound [404]',
+          'NotFound',
         );
       }
     });
@@ -450,10 +450,9 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve unregistered dependency token: "b".',
         );
-        assert.strictEqual((err as ThrownErr).code, 404);
         assert.strictEqual(
           (err as ThrownErr).name,
-          'NotFound [404]',
+          'NotFound',
         );
       }
     });
@@ -488,10 +487,9 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve circular dependency: "a" ➡️ "b" ➡️ "c" 🔄 "a".',
         );
-        assert.strictEqual((err as ThrownErr).code, 578);
         assert.strictEqual(
           (err as ThrownErr).name,
-          'CircularDependencyDetected [578]',
+          'CircularDependencyDetected',
         );
       }
     });
@@ -528,6 +526,38 @@ describe('Kado', () => {
       const a = await container.resolve('a');
 
       assert.ok(a instanceof A);
+    });
+  });
+
+  describe('when a custom error factory is injected', () => {
+    it('throws the factory errors, preserving extra fields like `code`', async () => {
+      // Stands in for an `@daisugi/ayamari` `errFn`: coded errors that
+      // are still plain `Error`s, so Kado accepts them transparently.
+      const errFn = {
+        NotFound: (msg: string) =>
+          Object.assign(new Error(msg), {
+            name: 'NotFound [404]',
+            code: 404,
+          }),
+        CircularDependencyDetected: (msg: string) =>
+          Object.assign(new Error(msg), {
+            name: 'CircularDependencyDetected [578]',
+            code: 578,
+          }),
+      };
+      const { container } = new Kado({ errFn });
+
+      await assert.rejects(
+        container.resolve('missing'),
+        (err) => {
+          assert.strictEqual((err as ThrownErr).code, 404);
+          assert.strictEqual(
+            (err as ThrownErr).name,
+            'NotFound [404]',
+          );
+          return true;
+        },
+      );
     });
   });
 });

--- a/packages/kado/src/__tests__/kado_test.ts
+++ b/packages/kado/src/__tests__/kado_test.ts
@@ -427,9 +427,10 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve unregistered dependency token: "a".',
         );
+        assert.strictEqual((err as ThrownErr).code, 404);
         assert.strictEqual(
           (err as ThrownErr).name,
-          'NotFound',
+          'NotFound [404]',
         );
       }
     });
@@ -450,9 +451,10 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve unregistered dependency token: "b".',
         );
+        assert.strictEqual((err as ThrownErr).code, 404);
         assert.strictEqual(
           (err as ThrownErr).name,
-          'NotFound',
+          'NotFound [404]',
         );
       }
     });
@@ -487,9 +489,10 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve circular dependency: "a" ➡️ "b" ➡️ "c" 🔄 "a".',
         );
+        assert.strictEqual((err as ThrownErr).code, 578);
         assert.strictEqual(
           (err as ThrownErr).name,
-          'CircularDependencyDetected',
+          'CircularDependencyDetected [578]',
         );
       }
     });
@@ -533,16 +536,17 @@ describe('Kado', () => {
     it('throws the factory errors, preserving extra fields like `code`', async () => {
       // Stands in for an `@daisugi/ayamari` `errFn`: coded errors that
       // are still plain `Error`s, so Kado accepts them transparently.
+      // Distinct values prove the injected factory overrides the default.
       const errFn = {
         NotFound: (msg: string) =>
           Object.assign(new Error(msg), {
-            name: 'NotFound [404]',
-            code: 404,
+            name: 'Custom NotFound',
+            code: 1001,
           }),
         CircularDependencyDetected: (msg: string) =>
           Object.assign(new Error(msg), {
-            name: 'CircularDependencyDetected [578]',
-            code: 578,
+            name: 'Custom CircularDependencyDetected',
+            code: 1002,
           }),
       };
       const { container } = new Kado({ errFn });
@@ -550,10 +554,10 @@ describe('Kado', () => {
       await assert.rejects(
         container.resolve('missing'),
         (err) => {
-          assert.strictEqual((err as ThrownErr).code, 404);
+          assert.strictEqual((err as ThrownErr).code, 1001);
           assert.strictEqual(
             (err as ThrownErr).name,
-            'NotFound [404]',
+            'Custom NotFound',
           );
           return true;
         },

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -22,16 +22,21 @@ export interface KadoOpts {
   errFn?: KadoErrFn;
 }
 
-// Built-in fallback used when no `errFn` is injected. It throws plain
-// native `Error`s — Kado does not require a `code` or any other extra
-// field. Inject an `@daisugi/ayamari` `errFn` (or any compatible
-// factory) to get richer, coded errors.
+// Built-in fallback used when no `errFn` is injected. It mirrors the
+// observable contract of the matching `@daisugi/ayamari` errors (same
+// `name` and `code`), so the default behaves like Ayamari without
+// requiring it. The `code` is not part of the `KadoErrFn` contract,
+// so an injected factory may still return plain native `Error`s.
 const defaultErrFn: KadoErrFn = {
   NotFound: (msg) =>
-    Object.assign(new Error(msg), { name: 'NotFound' }),
+    Object.assign(new Error(msg), {
+      name: 'NotFound [404]',
+      code: 404,
+    }),
   CircularDependencyDetected: (msg) =>
     Object.assign(new Error(msg), {
-      name: 'CircularDependencyDetected',
+      name: 'CircularDependencyDetected [578]',
+      code: 578,
     }),
 };
 

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -7,10 +7,12 @@ export type KadoScope =
   | 'Singleton'
   | 'ContainerScoped';
 
-// Minimal error-factory surface Kado depends on. `@daisugi/ayamari`'s
-// `errFn` satisfies this shape, so it can be injected directly; when
-// it is not, the built-in `defaultErrFn` is used, keeping Kado free of
-// any required runtime dependency.
+// Minimal error-factory surface Kado depends on. The factory only has
+// to return an `Error`; a richer error (e.g. an `@daisugi/ayamari` one
+// carrying a `code`, `cause` and prettified stack) is equally accepted,
+// since it is also an `Error`. `@daisugi/ayamari`'s `errFn` satisfies
+// this shape and can be injected directly; otherwise the built-in
+// `defaultErrFn` is used, keeping Kado free of any required dependency.
 export interface KadoErrFn {
   NotFound(msg: string): Error;
   CircularDependencyDetected(msg: string): Error;
@@ -20,19 +22,16 @@ export interface KadoOpts {
   errFn?: KadoErrFn;
 }
 
-// Built-in fallback that reproduces the observable contract of the
-// matching Ayamari errors (`name`, `code`, `message`), so behavior is
-// unchanged whether or not Ayamari is installed.
+// Built-in fallback used when no `errFn` is injected. It throws plain
+// native `Error`s — Kado does not require a `code` or any other extra
+// field. Inject an `@daisugi/ayamari` `errFn` (or any compatible
+// factory) to get richer, coded errors.
 const defaultErrFn: KadoErrFn = {
   NotFound: (msg) =>
-    Object.assign(new Error(msg), {
-      name: 'NotFound [404]',
-      code: 404,
-    }),
+    Object.assign(new Error(msg), { name: 'NotFound' }),
   CircularDependencyDetected: (msg) =>
     Object.assign(new Error(msg), {
-      name: 'CircularDependencyDetected [578]',
-      code: 578,
+      name: 'CircularDependencyDetected',
     }),
 };
 


### PR DESCRIPTION
Kado's built-in errors are now plain native `Error`s carrying only a descriptive `name` and `message`; a `code` is no longer guaranteed. The error factory contract returns `Error`, so it accepts both native errors and richer ones (e.g. an injected `@daisugi/ayamari` `errFn` whose errors carry a `code`).

- Tests treat `code` as optional and assert `name`/`message` on the default path; add a test injecting a coded factory to verify such fields flow through.
- Update the README to describe the native-error default.