### PR TITLE
feat(ayamari)!: string error codes, levelValue severity, isAyamariErr & findCauseByCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Explore the <code>@daisugi</code> ecosystem, a collection of modular tools desig
 | **[Anzen](./packages/anzen)**                                                       | [![version](https://img.shields.io/npm/v/@daisugi/anzen.svg)](https://www.npmjs.com/package/@daisugi/anzen)       | A `Result` type for safe error handling without exceptions, inspired by Rust and Haskell. |
 | **[Ayamari](./packages/ayamari)**                                                   | [![version](https://img.shields.io/npm/v/@daisugi/ayamari.svg)](https://www.npmjs.com/package/@daisugi/ayamari)   | A factory for rich, structured errors with error codes, chained causes, and prettified stack traces. |
 | **[Land](./packages/land)**                                                         | [![version](https://img.shields.io/npm/v/@daisugi/land.svg)](https://www.npmjs.com/package/@daisugi/land)         | A single package that bundles the entire @daisugi toolkit (Daisugi, Kado, Anzen, Ayamari, Kintsugi). |
-| **[JavaScript Style Guide](https://github.com/daisugiland/javascript-style-guide)** |                                                                                                                   | A set of best practices for writing clean and maintainable JavaScript.                    |
 
 ## 📦 Package Features
 

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -134,9 +134,9 @@ Every created error is a lightweight object (`AyamariErr`) — its prototype is 
 
 | Field     | Type                          | Description                                                               |
 | --------- | ----------------------------- | ------------------------------------------------------------------------- |
-| `name`    | `string`                      | `"<Name> [<code>]"`, e.g. `"Fail [575]"`                                  |
+| `name`    | `string`                      | The error name, e.g. `"Fail"`.                                            |
 | `message` | `string`                      | The message you passed.                                                   |
-| `code`    | `number`                      | Numeric error code.                                                       |
+| `code`    | `string`                      | String error code (equal to the error name), e.g. `"Fail"`.              |
 | `stack`   | `string`                      | `"<name>: <message>"` — or a real stack trace when `injectStack` is true. |
 | `cause`   | `AyamariErr \| Error \| null` | Chained cause.                                                            |
 | `meta`    | `unknown`                     | Extra context data.                                                       |
@@ -148,8 +148,8 @@ const err = errFn.NotFound('User not found.', {
   meta: { userId: 42 },
 });
 
-console.log(err.code);      // 404
-console.log(err.name);      // "NotFound [404]"
+console.log(err.code);      // "NotFound"
+console.log(err.name);      // "NotFound"
 console.log(err.message);   // "User not found."
 console.log(err.meta);      // { userId: 42 }
 ```
@@ -177,7 +177,7 @@ function findUser(id: number) {
 const result = findUser(-1);
 
 if (result.isFailure) {
-  console.log(result.getError().code); // 576
+  console.log(result.getError().code); // "InvalidArgument"
 }
 ```
 
@@ -185,21 +185,21 @@ if (result.isFailure) {
 
 ### `errCode`
 
-The full map of error names to numeric codes available on the instance (built-ins merged with any `customErrCode`).
+The full map of error names to their string codes available on the instance (built-ins merged with any `customErrCode`). Each built-in code is a string equal to its name.
 
 Built-in codes:
 
-| Name                         | Code | Description                                 |
-| ---------------------------- | ---- | ------------------------------------------- |
-| `UnexpectedError`            | 571  | Catch-all for unhandled exceptions.         |
-| `CircuitSuspended`           | 572  | Circuit breaker is open.                    |
-| `StopPropagation`            | 574  | Signals that error propagation should halt. |
-| `Fail`                       | 575  | Generic failure.                            |
-| `InvalidArgument`            | 576  | Bad input.                                  |
-| `ValidationFailed`           | 577  | Validation rule failed.                     |
-| `CircularDependencyDetected` | 578  | Circular dependency found.                  |
-| `NotFound`                   | 404  | Resource not found.                         |
-| `Timeout`                    | 504  | Operation timed out.                        |
+| Name                         | Code                           | Description                                 |
+| ---------------------------- | ------------------------------ | ------------------------------------------- |
+| `UnexpectedError`            | `"UnexpectedError"`            | Catch-all for unhandled exceptions.         |
+| `CircuitSuspended`           | `"CircuitSuspended"`            | Circuit breaker is open.                    |
+| `StopPropagation`            | `"StopPropagation"`            | Signals that error propagation should halt. |
+| `Fail`                       | `"Fail"`                       | Generic failure.                            |
+| `InvalidArgument`            | `"InvalidArgument"`            | Bad input.                                  |
+| `ValidationFailed`           | `"ValidationFailed"`           | Validation rule failed.                     |
+| `CircularDependencyDetected` | `"CircularDependencyDetected"` | Circular dependency found.                  |
+| `NotFound`                   | `"NotFound"`                   | Resource not found.                         |
+| `Timeout`                    | `"Timeout"`                    | Operation timed out.                        |
 
 ---
 
@@ -225,7 +225,7 @@ function readConfig(path: string) {
 }
 ```
 
-The propagated error has the same numeric code as `cause` so callers can pattern-match on code without knowing the internal boundary. When `cause` is a native `Error` (or carries a code Ayamari doesn't recognize), it falls back to `UnexpectedError`.
+The propagated error has the same code as `cause` so callers can pattern-match on code without knowing the internal boundary. When `cause` is a native `Error` (or carries a code Ayamari doesn't recognize), it falls back to `UnexpectedError`.
 
 ---
 
@@ -276,7 +276,7 @@ console.error(Ayamari.prettifyStack(err, { color: true }));
 Example output:
 
 <pre>
-<span style="color:red">UnexpectedError [571]</span>: Request failed
+<span style="color:red">UnexpectedError</span>: Request failed
 <span style="color:green">  url</span><span style="color:#888">: /api/users</span>
     <span style="color:#888">at</span> <span style="color:cyan">processRequest</span> <span style="color:#888">(</span><span style="color:yellow">~/src/server.ts</span><span style="color:cyan">:42:12</span><span style="color:#888">)</span>
     <span style="color:#888">at</span> <span style="color:cyan">handleRoute</span> <span style="color:#888">(</span><span style="color:yellow">~/src/router.ts</span><span style="color:cyan">:18:5</span><span style="color:#888">)</span>
@@ -303,14 +303,14 @@ Pass a `customErrCode` map to extend the built-in set. The instance's `errFn`, `
 
 ```ts
 const customErrCode = {
-  PaymentDeclined: 402,
-  RateLimitExceeded: 429,
+  PaymentDeclined: 'PaymentDeclined',
+  RateLimitExceeded: 'RateLimitExceeded',
 } as const;
 
 const { errFn, errCode } = new Ayamari({ customErrCode });
 
 const err = errFn.PaymentDeclined('Card was declined.');
-console.log(err.code); // 402
+console.log(err.code); // "PaymentDeclined"
 
 // TypeScript: errFn and errCode are fully typed with your custom codes.
 ```

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -55,8 +55,11 @@ try {
     - [errFn](#errfn)
     - [errFnRes](#errfnres)
     - [errCode](#errcode)
+    - [Ayamari.level](#ayamarilevel)
     - [propagateErr / propagateErrRes](#propagateerr--propagateerrres)
     - [Ayamari.prettifyStack](#ayamariprettifystack)
+    - [Ayamari.isAyamariErr](#ayamariisayamarierr)
+    - [Ayamari.findCauseByCode](#ayamarifindcausebycode)
     - [Custom error codes](#custom-error-codes)
   - [🌍 Other Projects](#-other-projects)
   - [📜 License](#-license)
@@ -129,6 +132,7 @@ errFn.<Name>(message: string, opts?: AyamariOpts): AyamariErr
 | `cause`       | `AyamariErr \| Error` | —                | The underlying error that caused this one.                             |
 | `meta`        | `unknown`             | `null`           | Arbitrary extra data attached to the error (surfaced in pretty-print). |
 | `injectStack` | `boolean`             | instance default | Override stack injection per call.                                     |
+| `levelValue`  | `number`              | `error`          | Override the error's severity (see [`Ayamari.level`](#ayamarilevel)).  |
 
 Every created error is a lightweight object (`AyamariErr`) — its prototype is `Error.prototype`, so `err instanceof Error` is `true`, but no native `Error` is constructed (no stack-capture cost unless `injectStack` is enabled). It has these fields:
 
@@ -137,6 +141,7 @@ Every created error is a lightweight object (`AyamariErr`) — its prototype is 
 | `name`    | `string`                      | The error name, e.g. `"Fail"`.                                            |
 | `message` | `string`                      | The message you passed.                                                   |
 | `code`    | `string`                      | String error code (equal to the error name), e.g. `"Fail"`.              |
+| `levelValue` | `number`                   | Numeric severity (see [`Ayamari.level`](#ayamarilevel)); defaults to `error`. |
 | `stack`   | `string`                      | `"<name>: <message>"` — or a real stack trace when `injectStack` is true. |
 | `cause`   | `AyamariErr \| Error \| null` | Chained cause.                                                            |
 | `meta`    | `unknown`                     | Extra context data.                                                       |
@@ -200,6 +205,34 @@ Built-in codes:
 | `CircularDependencyDetected` | `"CircularDependencyDetected"` | Circular dependency found.                  |
 | `NotFound`                   | `"NotFound"`                   | Resource not found.                         |
 | `Timeout`                    | `"Timeout"`                    | Operation timed out.                        |
+
+---
+
+### `Ayamari.level`
+
+Pino-style numeric severity levels. Higher means more severe, so monitoring can threshold on them (e.g. alert when `err.levelValue >= Ayamari.level.error`, ship `>= warn` to a dashboard).
+
+| Name    | Value |
+| ------- | ----- |
+| `off`   | 100   |
+| `fatal` | 60    |
+| `error` | 50    |
+| `warn`  | 40    |
+| `info`  | 30    |
+| `debug` | 20    |
+| `trace` | 10    |
+
+Every error carries a `levelValue`, defaulting to `error` (50). Override per error with `opts.levelValue`:
+
+```ts
+const { errFn } = new Ayamari();
+
+errFn.NotFound('missing').levelValue;                          // 50 (error, the default)
+errFn.NotFound('missing', { levelValue: Ayamari.level.debug }) // 20 (overridden)
+  .levelValue;
+```
+
+`propagateErr` carries the cause's `levelValue` through to the wrapper.
 
 ---
 
@@ -294,6 +327,44 @@ Ayamari.prettifyStack(err, {
   frameFilter: (frame) => frame.file.startsWith('/home/me/project/src'),
 });
 ```
+
+---
+
+### `Ayamari.isAyamariErr`
+
+Type guard that tells whether a value is an error created by Ayamari. Use it in a `catch` to safely read `code` / `levelValue` / `meta`:
+
+```ts
+try {
+  await doWork();
+} catch (e) {
+  if (Ayamari.isAyamariErr(e)) {
+    // e is typed as AyamariErr here
+    console.log(e.code, e.levelValue);
+  }
+}
+```
+
+It checks an internal brand (a registry-global `Symbol`), not the shape of the object — so it never mistakes a native error that happens to carry a `code` (e.g. Node's `ENOENT`) for an Ayamari one, and it works across bundles/realms where `instanceof` would not.
+
+---
+
+### `Ayamari.findCauseByCode`
+
+Walks an error's cause chain (the error itself first) and returns the first error whose `code` matches, or `null`. Lets a boundary branch on a failure mode no matter how many times it was wrapped on the way up:
+
+```ts
+try {
+  await query();
+} catch (e) {
+  if (Ayamari.findCauseByCode(e, errCode.Timeout)) return retry();
+  const notFound = Ayamari.findCauseByCode(e, errCode.NotFound);
+  if (notFound) return respond(404);
+  throw e;
+}
+```
+
+It returns the matched error (use `!== null` for the boolean case, or read the match's `meta` / `levelValue` after narrowing with `isAyamariErr`). `code` is read generically, so a native error in the chain carrying one (e.g. `ENOENT`, `ECONNREFUSED`) matches too. Cyclic cause chains are handled safely.
 
 ---
 

--- a/packages/ayamari/src/__tests__/ayamari_test.ts
+++ b/packages/ayamari/src/__tests__/ayamari_test.ts
@@ -7,10 +7,10 @@ describe('Ayamari', () => {
   it('should work', () => {
     const { errFn } = new Ayamari();
     const err = errFn.Fail('err');
-    assert.equal(err.code, 575);
-    assert.equal(err.name, 'Fail [575]');
+    assert.equal(err.code, 'Fail');
+    assert.equal(err.name, 'Fail');
     assert.equal(err.message, 'err');
-    assert.equal(err.stack, 'Fail [575]: err');
+    assert.equal(err.stack, 'Fail: err');
     assert.equal(err.cause, null);
   });
 
@@ -28,13 +28,10 @@ describe('Ayamari', () => {
     const err = errFn.Fail('err', {
       cause: nativeErr,
     });
-    assert.equal(err.code, 575);
-    assert.equal(err.name, 'Fail [575]');
+    assert.equal(err.code, 'Fail');
+    assert.equal(err.name, 'Fail');
     assert.equal(err.message, 'err');
-    assert.equal(
-      err.stack.split('\n')[0],
-      'Fail [575]: err',
-    );
+    assert.equal(err.stack.split('\n')[0], 'Fail: err');
     assert.equal(err.cause, nativeErr);
   });
 
@@ -43,24 +40,21 @@ describe('Ayamari', () => {
     const err = errFn.Fail('err', {
       injectStack: true,
     });
-    assert.equal(err.code, 575);
-    assert.equal(err.name, 'Fail [575]');
+    assert.equal(err.code, 'Fail');
+    assert.equal(err.name, 'Fail');
     assert.equal(err.message, 'err');
-    assert.equal(
-      err.stack.split('\n')[0],
-      'Fail [575]: err',
-    );
+    assert.equal(err.stack.split('\n')[0], 'Fail: err');
     assert.equal(err.cause, null);
   });
 
   it('should could customize errFn', () => {
     const customErrCode = {
-      FooErr: 1,
+      FooErr: 'FooErr',
     };
     const { errFn } = new Ayamari({
       customErrCode,
     });
-    assert.equal(errFn.FooErr('err').code, 1);
+    assert.equal(errFn.FooErr('err').code, 'FooErr');
   });
 
   describe('propagateErr', () => {
@@ -68,8 +62,8 @@ describe('Ayamari', () => {
       const { errFn, propagateErr } = new Ayamari();
       const cause = errFn.NotFound('missing');
       const err = propagateErr('wrapped', { cause });
-      assert.equal(err.code, 404);
-      assert.equal(err.name, 'NotFound [404]');
+      assert.equal(err.code, 'NotFound');
+      assert.equal(err.name, 'NotFound');
       assert.equal(err.message, 'wrapped');
       assert.equal(err.cause, cause);
     });
@@ -78,8 +72,8 @@ describe('Ayamari', () => {
       const { propagateErr } = new Ayamari();
       const cause = new Error('native');
       const err = propagateErr('wrapped', { cause });
-      assert.equal(err.code, 571);
-      assert.equal(err.name, 'UnexpectedError [571]');
+      assert.equal(err.code, 'UnexpectedError');
+      assert.equal(err.name, 'UnexpectedError');
       assert.equal(err.cause, cause);
     });
 
@@ -88,7 +82,7 @@ describe('Ayamari', () => {
       const cause = errFn.NotFound('missing');
       const res = propagateErrRes('wrapped', { cause });
       assert.equal(res.isSuccess, false);
-      assert.equal(res.getError().code, 404);
+      assert.equal(res.getError().code, 'NotFound');
     });
   });
 
@@ -102,7 +96,7 @@ describe('Ayamari', () => {
     });
     assert.match(
       Ayamari.prettifyStack(err, { color: false }),
-      /Fail \[575\]: err/u,
+      /Fail: err/u,
     );
   });
 
@@ -115,7 +109,7 @@ describe('Ayamari', () => {
       });
       assert.match(
         Ayamari.prettifyStack(err, { color: false }),
-        /Fail \[575\]: err/u,
+        /Fail: err/u,
       );
     });
 
@@ -125,7 +119,7 @@ describe('Ayamari', () => {
         const err = errFn.Fail('err');
         assert.match(
           Ayamari.prettifyStack(err, { color: false }),
-          /Fail \[575\]: err/u,
+          /Fail: err/u,
         );
       });
     });

--- a/packages/ayamari/src/__tests__/ayamari_test.ts
+++ b/packages/ayamari/src/__tests__/ayamari_test.ts
@@ -57,6 +57,56 @@ describe('Ayamari', () => {
     assert.equal(errFn.FooErr('err').code, 'FooErr');
   });
 
+  describe('levelValue', () => {
+    it('should default to error for every code', () => {
+      const { errFn } = new Ayamari();
+      assert.equal(
+        errFn.UnexpectedError('boom').levelValue,
+        Ayamari.level.error,
+      );
+      assert.equal(
+        errFn.NotFound('missing').levelValue,
+        Ayamari.level.error,
+      );
+      assert.equal(
+        errFn.StopPropagation('halt').levelValue,
+        Ayamari.level.error,
+      );
+    });
+
+    it('should let opts.levelValue override the default', () => {
+      const { errFn } = new Ayamari();
+      const err = errFn.NotFound('missing', {
+        levelValue: Ayamari.level.debug,
+      });
+      assert.equal(err.levelValue, Ayamari.level.debug);
+    });
+  });
+
+  describe('isAyamariErr', () => {
+    it('should be true for an Ayamari error', () => {
+      const { errFn } = new Ayamari();
+      assert.equal(
+        Ayamari.isAyamariErr(errFn.Fail('boom')),
+        true,
+      );
+    });
+
+    it('should be false for native errors and non-errors', () => {
+      assert.equal(
+        Ayamari.isAyamariErr(new Error('boom')),
+        false,
+      );
+      // A native error carrying its own `code`/`meta` must not be
+      // mistaken for an Ayamari error (the brand, not duck-typing).
+      assert.equal(
+        Ayamari.isAyamariErr({ code: 'ENOENT', meta: {} }),
+        false,
+      );
+      assert.equal(Ayamari.isAyamariErr(null), false);
+    });
+  });
+
   describe('propagateErr', () => {
     it('should reuse the code of an AyamariErr cause', () => {
       const { errFn, propagateErr } = new Ayamari();
@@ -83,6 +133,73 @@ describe('Ayamari', () => {
       const res = propagateErrRes('wrapped', { cause });
       assert.equal(res.isSuccess, false);
       assert.equal(res.getError().code, 'NotFound');
+    });
+
+    it("should carry the cause's levelValue", () => {
+      const { errFn, propagateErr } = new Ayamari();
+      const cause = errFn.NotFound('missing', {
+        levelValue: Ayamari.level.fatal,
+      });
+      const err = propagateErr('wrapped', { cause });
+      assert.equal(err.levelValue, Ayamari.level.fatal);
+    });
+  });
+
+  describe('findCauseByCode', () => {
+    it('should find a matching error deep in the cause chain', () => {
+      const { errFn } = new Ayamari();
+      const root = errFn.NotFound('missing');
+      const middle = errFn.Fail('mid', { cause: root });
+      const top = errFn.Timeout('top', { cause: middle });
+      assert.equal(
+        Ayamari.findCauseByCode(top, 'NotFound'),
+        root,
+      );
+    });
+
+    it('should match the error itself', () => {
+      const { errFn } = new Ayamari();
+      const err = errFn.NotFound('missing');
+      assert.equal(
+        Ayamari.findCauseByCode(err, 'NotFound'),
+        err,
+      );
+    });
+
+    it('should match a native error in the chain by its code', () => {
+      const { errFn } = new Ayamari();
+      const native = Object.assign(new Error('fs'), {
+        code: 'ENOENT',
+      });
+      const err = errFn.Fail('wrapped', { cause: native });
+      assert.equal(
+        Ayamari.findCauseByCode(err, 'ENOENT'),
+        native,
+      );
+    });
+
+    it('should return null when no cause matches', () => {
+      const { errFn } = new Ayamari();
+      const err = errFn.Fail('boom');
+      assert.equal(
+        Ayamari.findCauseByCode(err, 'NotFound'),
+        null,
+      );
+      assert.equal(
+        Ayamari.findCauseByCode(null, 'NotFound'),
+        null,
+      );
+    });
+
+    it('should not hang on a cyclic cause chain', () => {
+      const { errFn } = new Ayamari();
+      const a = errFn.Fail('a');
+      const b = errFn.Fail('b', { cause: a });
+      a.cause = b;
+      assert.equal(
+        Ayamari.findCauseByCode(b, 'NotFound'),
+        null,
+      );
     });
   });
 

--- a/packages/ayamari/src/__tests__/pretty_stack_test.ts
+++ b/packages/ayamari/src/__tests__/pretty_stack_test.ts
@@ -17,7 +17,7 @@ describe('PrettyStack.print', () => {
 
       assert.equal(
         result,
-        'UnexpectedError [571]: something went wrong',
+        'UnexpectedError: something went wrong',
       );
     });
   });
@@ -26,7 +26,7 @@ describe('PrettyStack.print', () => {
     it('includes user frames', () => {
       const error = errFn.UnexpectedError('top level');
       error.stack = [
-        'UnexpectedError [571]: top level',
+        'UnexpectedError: top level',
         '    at userFn (/project/src/foo.ts:10:5)',
       ].join('\n');
 
@@ -38,7 +38,7 @@ describe('PrettyStack.print', () => {
     it('omits native node: frames', () => {
       const error = errFn.UnexpectedError('top level');
       error.stack = [
-        'UnexpectedError [571]: top level',
+        'UnexpectedError: top level',
         '    at userFn (/project/src/foo.ts:10:5)',
         '    at node:internal/process/task_queues:140:7',
       ].join('\n');
@@ -53,7 +53,7 @@ describe('PrettyStack.print', () => {
     it('labels anonymous frames as <unknown>', () => {
       const error = errFn.UnexpectedError('top level');
       error.stack = [
-        'UnexpectedError [571]: top level',
+        'UnexpectedError: top level',
         '    at /project/src/anon.ts:3:1',
       ].join('\n');
 
@@ -68,7 +68,7 @@ describe('PrettyStack.print', () => {
     it('renders frames that have no column', () => {
       const error = errFn.UnexpectedError('top level');
       error.stack = [
-        'UnexpectedError [571]: top level',
+        'UnexpectedError: top level',
         '    at noCol (/project/src/x.ts:7)',
       ].join('\n');
 
@@ -84,7 +84,7 @@ describe('PrettyStack.print', () => {
     it('displays builtin frames with an <anonymous> location', () => {
       const error = errFn.UnexpectedError('boom');
       error.stack = [
-        'UnexpectedError [571]: boom',
+        'UnexpectedError: boom',
         '    at callback (/project/src/foo.ts:10:5)',
         '    at Array.map (<anonymous>)',
       ].join('\n');
@@ -121,7 +121,7 @@ describe('PrettyStack.print', () => {
     it('drops frames the filter rejects', () => {
       const error = errFn.UnexpectedError('boom');
       error.stack = [
-        'UnexpectedError [571]: boom',
+        'UnexpectedError: boom',
         '    at keep (/project/src/keep.ts:1:1)',
         '    at drop (/project/src/drop.ts:2:2)',
       ].join('\n');
@@ -139,7 +139,7 @@ describe('PrettyStack.print', () => {
     it('can retain node: frames the default would drop', () => {
       const error = errFn.UnexpectedError('boom');
       error.stack = [
-        'UnexpectedError [571]: boom',
+        'UnexpectedError: boom',
         '    at internal (node:internal/foo:1:1)',
       ].join('\n');
 
@@ -154,7 +154,7 @@ describe('PrettyStack.print', () => {
     it('drops node: frames by default', () => {
       const error = errFn.UnexpectedError('boom');
       error.stack = [
-        'UnexpectedError [571]: boom',
+        'UnexpectedError: boom',
         '    at internal (node:internal/foo:1:1)',
       ].join('\n');
 
@@ -202,17 +202,17 @@ describe('PrettyStack.print', () => {
     it('includes unique frames from all levels', () => {
       const root = errFn.NotFound('not found');
       root.stack =
-        'NotFound [404]: not found\n    at rootFn (/project/src/root.ts:5:3)';
+        'NotFound: not found\n    at rootFn (/project/src/root.ts:5:3)';
       const middle = errFn.UnexpectedError('query failed', {
         cause: root,
       });
       middle.stack =
-        'UnexpectedError [571]: query failed\n    at middleFn (/project/src/middle.ts:10:5)';
+        'UnexpectedError: query failed\n    at middleFn (/project/src/middle.ts:10:5)';
       const top = errFn.Timeout('service down', {
         cause: middle,
       });
       top.stack =
-        'Timeout [504]: service down\n    at topFn (/project/src/top.ts:20:8)';
+        'Timeout: service down\n    at topFn (/project/src/top.ts:20:8)';
 
       const result = PrettyStack.print(top);
 
@@ -225,12 +225,12 @@ describe('PrettyStack.print', () => {
       const sharedFrame =
         '    at sharedFn (/project/src/shared.ts:5:3)';
       const root = errFn.NotFound('root');
-      root.stack = `NotFound [404]: root\n${sharedFrame}`;
+      root.stack = `NotFound: root\n${sharedFrame}`;
       const middle = errFn.UnexpectedError('middle', {
         cause: root,
       });
       middle.stack = [
-        'UnexpectedError [571]: middle',
+        'UnexpectedError: middle',
         sharedFrame,
         '    at middleFn (/project/src/middle.ts:10:5)',
       ].join('\n');
@@ -238,7 +238,7 @@ describe('PrettyStack.print', () => {
         cause: middle,
       });
       top.stack = [
-        'Timeout [504]: top',
+        'Timeout: top',
         sharedFrame,
         '    at topFn (/project/src/top.ts:20:8)',
       ].join('\n');
@@ -261,12 +261,9 @@ describe('PrettyStack.print', () => {
       assert.match(result, /└── caused by/u);
       assert.match(
         result,
-        /UnexpectedError \[571\]: query failed/u,
+        /UnexpectedError: query failed/u,
       );
-      assert.match(
-        result,
-        /NotFound \[404\]: record missing/u,
-      );
+      assert.match(result, /NotFound: record missing/u);
     });
 
     it('emits one connector per nesting level', () => {
@@ -301,10 +298,7 @@ describe('PrettyStack.print', () => {
 
       const result = PrettyStack.print(error);
 
-      assert.match(
-        result,
-        /UnexpectedError \[571\]: wrapped/u,
-      );
+      assert.match(result, /UnexpectedError: wrapped/u);
       assert.match(result, /└── caused by/u);
       assert.match(result, /Error: native boom/u);
     });
@@ -315,12 +309,12 @@ describe('PrettyStack.print', () => {
       const sharedFrame =
         '    at sharedFn (/project/src/shared.ts:5:3)';
       const root = errFn.NotFound('root error');
-      root.stack = `NotFound [404]: root error\n${sharedFrame}`;
+      root.stack = `NotFound: root error\n${sharedFrame}`;
       const top = errFn.UnexpectedError('top error', {
         cause: root,
       });
       top.stack = [
-        'UnexpectedError [571]: top error',
+        'UnexpectedError: top error',
         sharedFrame,
         '    at otherFn (/project/src/other.ts:10:5)',
       ].join('\n');
@@ -337,7 +331,7 @@ describe('PrettyStack.print', () => {
     it('replaces process.cwd() with ~', () => {
       const cwd = process.cwd();
       const error = errFn.UnexpectedError('path test');
-      error.stack = `UnexpectedError [571]: path test\n    at myFn (${cwd}/src/foo.ts:10:5)`;
+      error.stack = `UnexpectedError: path test\n    at myFn (${cwd}/src/foo.ts:10:5)`;
 
       const result = PrettyStack.print(error);
 
@@ -348,7 +342,7 @@ describe('PrettyStack.print', () => {
     it('replaces all occurrences of cwd in a single frame', () => {
       const cwd = process.cwd();
       const error = errFn.UnexpectedError('path test');
-      error.stack = `UnexpectedError [571]: path test\n    at myFn (${cwd}/src/foo.ts:10:5) ${cwd}/other.ts`;
+      error.stack = `UnexpectedError: path test\n    at myFn (${cwd}/src/foo.ts:10:5) ${cwd}/other.ts`;
 
       const result = PrettyStack.print(error);
 
@@ -624,7 +618,7 @@ describe('PrettyStack.print', () => {
     it('collapses consecutive frames from the same package into a summary', () => {
       const error = errFn.UnexpectedError('render error');
       error.stack = [
-        'UnexpectedError [571]: render error',
+        'UnexpectedError: render error',
         '    at userFn (/project/src/foo.ts:10:5)',
         '    at renderWithHooks (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom-server.js:5062:19)',
         '    at renderElement (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom-server.js:5497:23)',
@@ -644,7 +638,7 @@ describe('PrettyStack.print', () => {
     it('produces a separate summary for each different package', () => {
       const error = errFn.UnexpectedError('error');
       error.stack = [
-        'UnexpectedError [571]: error',
+        'UnexpectedError: error',
         '    at fn1 (/project/node_modules/.pnpm/fastify@5.0.0/node_modules/fastify/lib/server.js:10:5)',
         '    at fn2 (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom.js:20:3)',
       ].join('\n');
@@ -658,7 +652,7 @@ describe('PrettyStack.print', () => {
     it('keeps user frames between node_modules summaries', () => {
       const error = errFn.UnexpectedError('error');
       error.stack = [
-        'UnexpectedError [571]: error',
+        'UnexpectedError: error',
         '    at userFn (/project/src/handler.ts:10:5)',
         '    at renderWithHooks (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom-server.js:5062:19)',
         '    at anotherUserFn (/project/src/component.ts:20:3)',
@@ -682,7 +676,7 @@ describe('PrettyStack.print', () => {
     it('collapses node_modules frames at the end of the stack', () => {
       const error = errFn.UnexpectedError('error');
       error.stack = [
-        'UnexpectedError [571]: error',
+        'UnexpectedError: error',
         '    at userFn (/project/src/handler.ts:10:5)',
         '    at renderWithHooks (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom-server.js:5062:19)',
         '    at renderElement (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom-server.js:5497:23)',
@@ -699,7 +693,7 @@ describe('PrettyStack.print', () => {
     it('handles npm (non-pnpm) node_modules paths', () => {
       const error = errFn.UnexpectedError('error');
       error.stack = [
-        'UnexpectedError [571]: error',
+        'UnexpectedError: error',
         '    at fn1 (/project/node_modules/fastify/lib/server.js:10:5)',
       ].join('\n');
 
@@ -711,7 +705,7 @@ describe('PrettyStack.print', () => {
     it('handles scoped packages in pnpm paths', () => {
       const error = errFn.UnexpectedError('error');
       error.stack = [
-        'UnexpectedError [571]: error',
+        'UnexpectedError: error',
         '    at fn1 (/project/node_modules/.pnpm/@fastify+static@8.0.0/node_modules/@fastify/static/index.js:10:5)',
       ].join('\n');
 

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -12,6 +12,13 @@ import {
 type ValueOf<T> = T[keyof T];
 type Entries<T> = [keyof T, ValueOf<T>][];
 
+// Registry-global brand stamped on every AyamariErr. `Symbol.for` keeps
+// it stable across realms/bundles (and duplicated module copies), so
+// `Ayamari.isAyamariErr` works where `instanceof` can't — AyamariErr is a
+// plain branded object, not a class instance. The same key is recomputed
+// in pretty_stack.ts; keep the two in sync.
+const ayamariBrand = Symbol.for('@daisugi/ayamari');
+
 export interface AyamariGlobalOpts<CustomErrCode> {
   injectStack?: boolean;
   customErrCode?: CustomErrCode;
@@ -21,12 +28,14 @@ export interface AyamariOpts {
   cause?: AyamariErr | Error;
   meta?: unknown;
   injectStack?: boolean;
+  levelValue?: number;
 }
 
 export interface AyamariErr extends Error {
   name: string;
   message: string;
   code: string;
+  levelValue: number;
   stack: string;
   cause: AyamariErr | Error | null | undefined;
   meta: any;
@@ -48,6 +57,17 @@ export type AyamariErrCodeKey<CustomErrCode> =
 
 export class Ayamari<CustomErrCode> {
   static readonly defaultFrameFilter = defaultFrameFilter;
+  // Pino-style numeric severity levels. Higher = more severe, so
+  // monitoring can threshold (e.g. alert when `levelValue >= error`).
+  static level = {
+    off: 100,
+    fatal: 60,
+    error: 50,
+    warn: 40,
+    info: 30,
+    debug: 20,
+    trace: 10,
+  };
   static errCode = {
     CircuitSuspended: 'CircuitSuspended',
     CircularDependencyDetected:
@@ -116,9 +136,11 @@ export class Ayamari<CustomErrCode> {
     ) => {
       const err = {
         __proto__: Error.prototype,
+        [ayamariBrand]: true,
         name,
         message: msg,
         code: errCode,
+        levelValue: opts.levelValue ?? Ayamari.level.error,
         stack: `${name}: ${msg}`,
         cause: opts.cause || null,
         meta: opts.meta ?? null,
@@ -140,10 +162,15 @@ export class Ayamari<CustomErrCode> {
     // Reuse the cause's code when it is a recognized Ayamari error.
     // A native Error (or an unknown code) has no registered name, so
     // fall back to UnexpectedError instead of crashing.
-    const code = (opts.cause as AyamariErr).code;
+    const cause = opts.cause as AyamariErr;
     const errName =
-      this.#errName.get(code) ?? 'UnexpectedError';
-    return this.errFn[errName](msg, opts);
+      this.#errName.get(cause.code) ?? 'UnexpectedError';
+    // Carry the cause's severity through so the wrapper matches it
+    // (a native Error has none, so fall back to the code's default).
+    return this.errFn[errName](msg, {
+      ...opts,
+      levelValue: opts.levelValue ?? cause.levelValue,
+    });
   };
 
   propagateErrRes = (
@@ -158,5 +185,42 @@ export class Ayamari<CustomErrCode> {
     opts: PrettyStackOpts = {},
   ) {
     return PrettyStack.print(err, opts);
+  }
+
+  // Brand-based type guard. Reliable across realms/bundles, unlike
+  // `instanceof` (AyamariErr is a plain branded object, not a class
+  // instance). Native errors carry their own `code`, so don't duck-type.
+  static isAyamariErr(err: unknown): err is AyamariErr {
+    return (
+      typeof err === 'object' &&
+      err !== null &&
+      (err as Record<symbol, unknown>)[ayamariBrand] ===
+        true
+    );
+  }
+
+  // Walk the cause chain (the error itself first) and return the first
+  // error whose `code` matches, or null. Lets a boundary branch on a
+  // failure mode no matter how deeply it was wrapped. Reads `code`
+  // generically, so native errors carrying one (e.g. `ENOENT`) match too.
+  static findCauseByCode(
+    err: AyamariErr | Error | null | undefined,
+    code: string,
+  ): AyamariErr | Error | null {
+    // Guard against cyclic cause chains so a malformed error can't hang.
+    const seen = new Set<unknown>();
+    let cursor: AyamariErr | Error | null | undefined = err;
+    while (
+      cursor &&
+      typeof cursor === 'object' &&
+      !seen.has(cursor)
+    ) {
+      seen.add(cursor);
+      if ((cursor as AyamariErr).code === code) {
+        return cursor;
+      }
+      cursor = (cursor as AyamariErr).cause;
+    }
+    return null;
   }
 }

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -26,7 +26,7 @@ export interface AyamariOpts {
 export interface AyamariErr extends Error {
   name: string;
   message: string;
-  code: number;
+  code: string;
   stack: string;
   cause: AyamariErr | Error | null | undefined;
   meta: any;
@@ -49,15 +49,16 @@ export type AyamariErrCodeKey<CustomErrCode> =
 export class Ayamari<CustomErrCode> {
   static readonly defaultFrameFilter = defaultFrameFilter;
   static errCode = {
-    CircuitSuspended: 572,
-    CircularDependencyDetected: 578,
-    Fail: 575,
-    InvalidArgument: 576,
-    NotFound: 404,
-    StopPropagation: 574,
-    Timeout: 504,
-    UnexpectedError: 571,
-    ValidationFailed: 577,
+    CircuitSuspended: 'CircuitSuspended',
+    CircularDependencyDetected:
+      'CircularDependencyDetected',
+    Fail: 'Fail',
+    InvalidArgument: 'InvalidArgument',
+    NotFound: 'NotFound',
+    StopPropagation: 'StopPropagation',
+    Timeout: 'Timeout',
+    UnexpectedError: 'UnexpectedError',
+    ValidationFailed: 'ValidationFailed',
   };
   errCode = Ayamari.errCode;
   errFn = {} as Record<
@@ -69,7 +70,7 @@ export class Ayamari<CustomErrCode> {
     AyamariCreateErrRes
   >;
   #errName = new Map<
-    number,
+    string,
     AyamariErrCodeKey<CustomErrCode>
   >();
   #injectStack: boolean;
@@ -85,7 +86,7 @@ export class Ayamari<CustomErrCode> {
     for (const [errName, errCode] of Object.entries(
       this.errCode,
     ) as Entries<
-      Record<AyamariErrCodeKey<CustomErrCode>, number>
+      Record<AyamariErrCodeKey<CustomErrCode>, string>
     >) {
       this.errFn[errName] = this.createErrCreator(
         errName,
@@ -106,9 +107,9 @@ export class Ayamari<CustomErrCode> {
 
   createErrCreator(
     errName: AyamariErrCodeKey<CustomErrCode>,
-    errCode: number,
+    errCode: string,
   ) {
-    const name = `${errName as string} [${errCode}]`;
+    const name = errName as string;
     const createErr = (
       msg: string,
       opts: AyamariOpts = {},

--- a/packages/ayamari/src/pretty_stack.ts
+++ b/packages/ayamari/src/pretty_stack.ts
@@ -74,7 +74,7 @@ const standardErrorKeys = new Set([
 ]);
 
 /** AyamariErr internal fields that are already surfaced elsewhere in the log */
-const ayamariErrKeys = new Set(['code']);
+const ayamariErrKeys = new Set(['code', 'levelValue']);
 
 /** Default frame filter: drop Node internal (`node:`) frames. */
 export const defaultFrameFilter: FrameFilter = (frame) =>
@@ -172,8 +172,17 @@ function safeStringify(value: unknown): string {
   }
 }
 
+// Registry-global brand stamped by Ayamari on every AyamariErr. Recomputed
+// here (rather than imported) to avoid a value cycle with ayamari.ts;
+// `Symbol.for` guarantees it resolves to the same symbol. Keep in sync.
+const ayamariBrand = Symbol.for('@daisugi/ayamari');
+
 function isAyamariErr(err: AyamariErr | Error): boolean {
-  return 'meta' in err;
+  return (
+    (err as unknown as Record<symbol, unknown>)[
+      ayamariBrand
+    ] === true
+  );
 }
 
 function formatExtraProps(

--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -114,7 +114,7 @@ const { container } = new Kado({ errFn });
 ```
 
 When no `errFn` is provided, Kado throws native `Error`s that mirror
-Ayamari's contract (e.g. `name: 'NotFound [404]'`, `code: 404`). The
+Ayamari's contract (e.g. `name: 'NotFound'`, `code: 'NotFound'`). The
 `code` is not required by the factory contract, so a custom `errFn` may
 return plain `Error`s without one; Kado accepts either.
 

--- a/packages/kado/src/__tests__/kado_child_container_test.ts
+++ b/packages/kado/src/__tests__/kado_child_container_test.ts
@@ -5,7 +5,7 @@ import { Kado } from '../kado.js';
 
 // Kado throws native `Error`s; an injected factory may enrich them with
 // a `code` (e.g. `@daisugi/ayamari`), so it is optional here.
-type ThrownErr = Error & { code?: number };
+type ThrownErr = Error & { code?: string };
 
 describe('child container', () => {
   it('falls through to the parent for unregistered tokens', async () => {
@@ -37,7 +37,10 @@ describe('child container', () => {
     await assert.rejects(
       child.resolve('Missing'),
       (err) => {
-        assert.strictEqual((err as ThrownErr).code, 404);
+        assert.strictEqual(
+          (err as ThrownErr).code,
+          'NotFound',
+        );
         return true;
       },
     );
@@ -304,7 +307,10 @@ describe('circular dependency across containers', () => {
     await assert.rejects(
       child.resolve('Controller'),
       (err) => {
-        assert.strictEqual((err as ThrownErr).code, 578);
+        assert.strictEqual(
+          (err as ThrownErr).code,
+          'CircularDependencyDetected',
+        );
         return true;
       },
     );
@@ -373,7 +379,10 @@ describe('get() across the chain', () => {
     assert.throws(
       () => child.get('Missing'),
       (err) => {
-        assert.strictEqual((err as ThrownErr).code, 404);
+        assert.strictEqual(
+          (err as ThrownErr).code,
+          'NotFound',
+        );
         return true;
       },
     );

--- a/packages/kado/src/__tests__/kado_test.ts
+++ b/packages/kado/src/__tests__/kado_test.ts
@@ -9,7 +9,7 @@ import {
 
 // Kado throws native `Error`s; an injected factory may enrich them with
 // a `code` (e.g. `@daisugi/ayamari`), so it is optional here.
-type ThrownErr = Error & { code?: number };
+type ThrownErr = Error & { code?: string };
 
 describe('Kado', () => {
   it('should have proper api', () => {
@@ -427,10 +427,13 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve unregistered dependency token: "a".',
         );
-        assert.strictEqual((err as ThrownErr).code, 404);
+        assert.strictEqual(
+          (err as ThrownErr).code,
+          'NotFound',
+        );
         assert.strictEqual(
           (err as ThrownErr).name,
-          'NotFound [404]',
+          'NotFound',
         );
       }
     });
@@ -451,10 +454,13 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve unregistered dependency token: "b".',
         );
-        assert.strictEqual((err as ThrownErr).code, 404);
+        assert.strictEqual(
+          (err as ThrownErr).code,
+          'NotFound',
+        );
         assert.strictEqual(
           (err as ThrownErr).name,
-          'NotFound [404]',
+          'NotFound',
         );
       }
     });
@@ -489,10 +495,13 @@ describe('Kado', () => {
           (err as ThrownErr).message,
           'Attempted to resolve circular dependency: "a" ➡️ "b" ➡️ "c" 🔄 "a".',
         );
-        assert.strictEqual((err as ThrownErr).code, 578);
+        assert.strictEqual(
+          (err as ThrownErr).code,
+          'CircularDependencyDetected',
+        );
         assert.strictEqual(
           (err as ThrownErr).name,
-          'CircularDependencyDetected [578]',
+          'CircularDependencyDetected',
         );
       }
     });
@@ -541,12 +550,12 @@ describe('Kado', () => {
         NotFound: (msg: string) =>
           Object.assign(new Error(msg), {
             name: 'Custom NotFound',
-            code: 1001,
+            code: 'CustomNotFound',
           }),
         CircularDependencyDetected: (msg: string) =>
           Object.assign(new Error(msg), {
             name: 'Custom CircularDependencyDetected',
-            code: 1002,
+            code: 'CustomCircularDependencyDetected',
           }),
       };
       const { container } = new Kado({ errFn });
@@ -554,7 +563,10 @@ describe('Kado', () => {
       await assert.rejects(
         container.resolve('missing'),
         (err) => {
-          assert.strictEqual((err as ThrownErr).code, 1001);
+          assert.strictEqual(
+            (err as ThrownErr).code,
+            'CustomNotFound',
+          );
           assert.strictEqual(
             (err as ThrownErr).name,
             'Custom NotFound',

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -30,13 +30,13 @@ export interface KadoOpts {
 const defaultErrFn: KadoErrFn = {
   NotFound: (msg) =>
     Object.assign(new Error(msg), {
-      name: 'NotFound [404]',
-      code: 404,
+      name: 'NotFound',
+      code: 'NotFound',
     }),
   CircularDependencyDetected: (msg) =>
     Object.assign(new Error(msg), {
-      name: 'CircularDependencyDetected [578]',
-      code: 578,
+      name: 'CircularDependencyDetected',
+      code: 'CircularDependencyDetected',
     }),
 };
 

--- a/packages/kintsugi/README.md
+++ b/packages/kintsugi/README.md
@@ -65,6 +65,7 @@ const rockSolidFn = withCache(
     - [`deferredPromise()`](#deferredpromise)
     - [`randomIntBetween(min, max)`](#randomintbetweenmin-max)
     - [`hashFNV1A(input)`](#hashfnv1ainput)
+    - [`stringifyArgs(args)`](#stringifyargsargs)
   - [🌸 Etymology](#-etymology)
   - [🌍 Other Projects](#-other-projects)
   - [📜 License](#-license)
@@ -101,7 +102,7 @@ pnpm install @daisugi/kintsugi
 - ✅ In-flight promise de-duplication (`reusePromise`)
 - ✅ Promise helpers (`waitFor`, `deferredPromise`)
 - ✅ A bounded (LRU) in-memory `CacheStore` implementation (`SimpleMemoryStore`)
-- ✅ Small utilities (`randomIntBetween`, `hashFNV1A`)
+- ✅ Small utilities (`randomIntBetween`, `hashFNV1A`, `stringifyArgs`)
 - ✅ Built on [@daisugi/anzen](../anzen) Results and [@daisugi/ayamari](../ayamari) errors
 
 [:top: Back to top](#-table-of-contents)
@@ -491,6 +492,37 @@ hashFNV1A(input: string | Uint8Array): number
 import { hashFNV1A } from '@daisugi/kintsugi';
 
 const hash = hashFNV1A(JSON.stringify({ name: 'Hi Benadryl Cumberbatch.' }));
+```
+
+[:top: Back to top](#-table-of-contents)
+
+---
+
+### `stringifyArgs(args)`
+
+Serializes a function's argument list into a stable string suitable for use as a cache key.
+
+- A single primitive (`null`, number, boolean) becomes a bare token (`"5"`, `"true"`, `"null"`) that cannot collide with any bracketed JSON form.
+- Everything else — multiple arguments or complex values — is JSON-serialized as an array, with object keys sorted for consistency.
+
+```ts
+stringifyArgs(args: unknown[]): string
+```
+
+| Parameter | Type        | Description                    |
+| --------- | ----------- | ------------------------------ |
+| `args`    | `unknown[]` | The arguments array to encode. |
+
+```js
+import { stringifyArgs } from '@daisugi/kintsugi';
+
+stringifyArgs([42]);               // "42"
+stringifyArgs([true]);             // "true"
+stringifyArgs([null]);             // "null"
+stringifyArgs(['hello']);          // '["hello"]'
+stringifyArgs([1, 2]);             // "[1,2]"
+stringifyArgs([{ b: 2, a: 1 }]);   // '[{"a":1,"b":2}]'
+stringifyArgs([[5, 5]]);           // "[[5,5]]"  — array arg, not two args
 ```
 
 [:top: Back to top](#-table-of-contents)

--- a/packages/kintsugi/src/with_retry.ts
+++ b/packages/kintsugi/src/with_retry.ts
@@ -52,7 +52,7 @@ export function calculateRetryDelayMs(
  * Error codes that will never succeed on retry, so retrying is skipped.
  * Kept consistent with how `withCache` treats `NotFound`.
  */
-const nonRetryableErrCodes: number[] = [
+const nonRetryableErrCodes: string[] = [
   Ayamari.errCode.NotFound,
 ];
 


### PR DESCRIPTION
## Summary

Reworks Ayamari's error contract around string codes and adds error-introspection helpers, with the matching updates in the packages that consume them.

### `refactor(ayamari,kado,kintsugi)!: use string error codes`
- `AyamariErr.code` is now a string equal to the error name (e.g. `"NotFound"`) instead of a number (e.g. `404`); `errCode` map values are PascalCase strings; `name` drops its `[code]` suffix.
- `kado`'s `defaultErrFn` mirrors the new contract (`code: "NotFound"` / `"CircularDependencyDetected"`).
- `kintsugi`'s `nonRetryableErrCodes` retyped to `string[]`.

### `feat(ayamari): add levelValue severity, isAyamariErr guard, findCauseByCode`
- **`levelValue`** — numeric Pino-style severity on every error (`Ayamari.level`: `trace`10 … `fatal`60), defaulting to `error` (50), overridable via `opts.levelValue`. `propagateErr` carries the cause's level through to the wrapper.
- **`isAyamariErr`** — `Symbol`-brand type guard, reliable across realms/bundles unlike `instanceof`. `pretty_stack` now discriminates via the brand instead of duck-typing on `meta` (which misclassified native errors carrying a `code`).
- **`findCauseByCode`** — walks the cause chain (self first) for the first error with a matching `code`; cycle-safe; matches native errors (e.g. `ENOENT`) by code too.

### `docs: document kintsugi stringifyArgs; drop stale style-guide link`
- Documents the already-exported `stringifyArgs` utility; removes a dead link in the root README.

## Breaking changes
`@daisugi/ayamari` and `@daisugi/kado` error `code`s are now strings (e.g. `"NotFound"`) rather than numbers (e.g. `404`). Consumers pattern-matching on numeric codes must switch to the string names (use the `errCode` map / `findCauseByCode`).

## Testing
All package suites pass: ayamari 61, kintsugi 59, daisugi 18, kado 49, anzen 32, land 1. `oxfmt`/`oxlint` clean; all changed packages build.
