### PR TITLE
refactor(ayamari)!: tree-shakeable named exports + smaller errors (perf)

### DIFF
--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -18,6 +18,7 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
 - 🤝 Used in production
+- 🌳 Tree-shakeable
 - 🔀 Supports both ES Modules and CommonJS
 
 ---
@@ -25,7 +26,7 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 ## 🚀 Usage
 
 ```js
-import { Ayamari } from '@daisugi/ayamari';
+import { Ayamari, prettifyStack } from '@daisugi/ayamari';
 
 const { errFn } = new Ayamari();
 
@@ -36,7 +37,7 @@ try {
     cause: err,
   });
 
-  console.error(Ayamari.prettifyStack(appErr, { color: true }));
+  console.error(prettifyStack(appErr, { color: true }));
 }
 ```
 
@@ -51,15 +52,15 @@ try {
   - [📦 Installation](#-installation)
   - [🔍 Overview](#-overview)
   - [📚 API](#-api)
-    - [new Ayamari(opts?)](#new-ayamariopts)
-    - [errFn](#errfn)
-    - [errFnRes](#errfnres)
-    - [errCode](#errcode)
-    - [Ayamari.level](#ayamarilevel)
-    - [propagateErr / propagateErrRes](#propagateerr--propagateerrres)
-    - [Ayamari.prettifyStack](#ayamariprettifystack)
-    - [Ayamari.isAyamariErr](#ayamariisayamarierr)
-    - [Ayamari.findCauseByCode](#ayamarifindcausebycode)
+    - [`new Ayamari(opts?)`](#new-ayamariopts)
+    - [`errFn`](#errfn)
+    - [`errFnRes`](#errfnres)
+    - [`errCode`](#errcode)
+    - [`level`](#level)
+    - [`propagateErr` / `propagateErrRes`](#propagateerr--propagateerrres)
+    - [`prettifyStack`](#prettifystack)
+    - [`isAyamariErr`](#isayamarierr)
+    - [`findCauseByCode`](#findcausebycode)
     - [Custom error codes](#custom-error-codes)
   - [🌍 Other Projects](#-other-projects)
   - [📜 License](#-license)
@@ -132,19 +133,19 @@ errFn.<Name>(message: string, opts?: AyamariOpts): AyamariErr
 | `cause`       | `AyamariErr \| Error` | —                | The underlying error that caused this one.                             |
 | `meta`        | `unknown`             | `null`           | Arbitrary extra data attached to the error (surfaced in pretty-print). |
 | `injectStack` | `boolean`             | instance default | Override stack injection per call.                                     |
-| `levelValue`  | `number`              | `error`          | Override the error's severity (see [`Ayamari.level`](#ayamarilevel)).  |
+| `levelValue`  | `number`              | `error`          | Override the error's severity (see [`level`](#level)).                 |
 
 Every created error is a lightweight object (`AyamariErr`) — its prototype is `Error.prototype`, so `err instanceof Error` is `true`, but no native `Error` is constructed (no stack-capture cost unless `injectStack` is enabled). It has these fields:
 
-| Field     | Type                          | Description                                                               |
-| --------- | ----------------------------- | ------------------------------------------------------------------------- |
-| `name`    | `string`                      | The error name, e.g. `"Fail"`.                                            |
-| `message` | `string`                      | The message you passed.                                                   |
-| `code`    | `string`                      | String error code (equal to the error name), e.g. `"Fail"`.              |
-| `levelValue` | `number`                   | Numeric severity (see [`Ayamari.level`](#ayamarilevel)); defaults to `error`. |
-| `stack`   | `string`                      | `"<name>: <message>"` — or a real stack trace when `injectStack` is true. |
-| `cause`   | `AyamariErr \| Error \| null` | Chained cause.                                                            |
-| `meta`    | `unknown`                     | Extra context data.                                                       |
+| Field        | Type                          | Description                                                               |
+| ------------ | ----------------------------- | ------------------------------------------------------------------------- |
+| `name`       | `string`                      | The error name, e.g. `"Fail"`.                                            |
+| `message`    | `string`                      | The message you passed.                                                   |
+| `code`       | `string`                      | String error code (equal to the error name), e.g. `"Fail"`.               |
+| `levelValue` | `number`                      | Numeric severity (see [`level`](#level)); defaults to `error`.            |
+| `stack`      | `string`                      | `"<name>: <message>"` — or a real stack trace when `injectStack` is true. |
+| `cause`      | `AyamariErr \| Error \| null` | Chained cause.                                                            |
+| `meta`       | `unknown`                     | Extra context data.                                                       |
 
 ```ts
 const { errFn } = new Ayamari();
@@ -197,7 +198,7 @@ Built-in codes:
 | Name                         | Code                           | Description                                 |
 | ---------------------------- | ------------------------------ | ------------------------------------------- |
 | `UnexpectedError`            | `"UnexpectedError"`            | Catch-all for unhandled exceptions.         |
-| `CircuitSuspended`           | `"CircuitSuspended"`            | Circuit breaker is open.                    |
+| `CircuitSuspended`           | `"CircuitSuspended"`           | Circuit breaker is open.                    |
 | `StopPropagation`            | `"StopPropagation"`            | Signals that error propagation should halt. |
 | `Fail`                       | `"Fail"`                       | Generic failure.                            |
 | `InvalidArgument`            | `"InvalidArgument"`            | Bad input.                                  |
@@ -208,9 +209,9 @@ Built-in codes:
 
 ---
 
-### `Ayamari.level`
+### `level`
 
-Pino-style numeric severity levels. Higher means more severe, so monitoring can threshold on them (e.g. alert when `err.levelValue >= Ayamari.level.error`, ship `>= warn` to a dashboard).
+Pino-style numeric severity levels. Higher means more severe, so monitoring can threshold on them (e.g. alert when `err.levelValue >= level.error`, ship `>= warn` to a dashboard).
 
 | Name    | Value |
 | ------- | ----- |
@@ -228,7 +229,7 @@ Every error carries a `levelValue`, defaulting to `error` (50). Override per err
 const { errFn } = new Ayamari();
 
 errFn.NotFound('missing').levelValue;                          // 50 (error, the default)
-errFn.NotFound('missing', { levelValue: Ayamari.level.debug }) // 20 (overridden)
+errFn.NotFound('missing', { levelValue: level.debug }) // 20 (overridden)
   .levelValue;
 ```
 
@@ -262,12 +263,12 @@ The propagated error has the same code as `cause` so callers can pattern-match o
 
 ---
 
-### `Ayamari.prettifyStack`
+### `prettifyStack`
 
-Static method that formats an error (and its cause chain) as a human-readable string.
+Standalone function that formats an error (and its cause chain) as a human-readable string. Import it only where you print errors; modules that just create errors won't bundle the prettifier.
 
 ```ts
-Ayamari.prettifyStack(
+prettifyStack(
   err: AyamariErr | Error,
   opts?: PrettyStackOpts,
 ): string
@@ -279,11 +280,11 @@ interface PrettyStackOpts {
 }
 ```
 
-| Option          | Description                                                                                                                         |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `color`         | Enable ANSI color codes. Disable when writing to log files or non-TTY streams.                                                      |
-| `sensitiveKeys` | Property names to redact from the extra-props section (e.g. `['config', 'response']` for Axios errors).                             |
-| `frameFilter`   | Predicate to keep or drop individual stack frames. The default filter (`Ayamari.defaultFrameFilter`) drops `node:` built-in frames. |
+| Option          | Description                                                                                                                 |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `color`         | Enable ANSI color codes. Disable when writing to log files or non-TTY streams.                                              |
+| `sensitiveKeys` | Property names to redact from the extra-props section (e.g. `['config', 'response']` for Axios errors).                     |
+| `frameFilter`   | Predicate to keep or drop individual stack frames. The default filter (`defaultFrameFilter`) drops `node:` built-in frames. |
 
 Features of the formatted output:
 
@@ -303,7 +304,7 @@ const err = errFn.UnexpectedError('Request failed', {
   meta: { url: '/api/users' },
 });
 
-console.error(Ayamari.prettifyStack(err, { color: true }));
+console.error(prettifyStack(err, { color: true }));
 ```
 
 Example output:
@@ -323,22 +324,24 @@ Example output:
 To filter frames by file path (e.g. keep only your own source):
 
 ```ts
-Ayamari.prettifyStack(err, {
+prettifyStack(err, {
   frameFilter: (frame) => frame.file.startsWith('/home/me/project/src'),
 });
 ```
 
 ---
 
-### `Ayamari.isAyamariErr`
+### `isAyamariErr`
 
 Type guard that tells whether a value is an error created by Ayamari. Use it in a `catch` to safely read `code` / `levelValue` / `meta`:
 
 ```ts
+import { isAyamariErr } from '@daisugi/ayamari';
+
 try {
   await doWork();
 } catch (e) {
-  if (Ayamari.isAyamariErr(e)) {
+  if (isAyamariErr(e)) {
     // e is typed as AyamariErr here
     console.log(e.code, e.levelValue);
   }
@@ -349,7 +352,7 @@ It checks an internal brand (a registry-global `Symbol`), not the shape of the o
 
 ---
 
-### `Ayamari.findCauseByCode`
+### `findCauseByCode`
 
 Walks an error's cause chain (the error itself first) and returns the first error whose `code` matches, or `null`. Lets a boundary branch on a failure mode no matter how many times it was wrapped on the way up:
 
@@ -357,8 +360,8 @@ Walks an error's cause chain (the error itself first) and returns the first erro
 try {
   await query();
 } catch (e) {
-  if (Ayamari.findCauseByCode(e, errCode.Timeout)) return retry();
-  const notFound = Ayamari.findCauseByCode(e, errCode.NotFound);
+  if (findCauseByCode(e, errCode.Timeout)) return retry();
+  const notFound = findCauseByCode(e, errCode.NotFound); // errCode is a named export
   if (notFound) return respond(404);
   throw e;
 }

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -147,6 +147,8 @@ Every created error is a lightweight object (`AyamariErr`) — its prototype is 
 | `cause`      | `AyamariErr \| Error \| null` | Chained cause.                                                            |
 | `meta`       | `unknown`                     | Extra context data.                                                       |
 
+> `stack` is a lazily derived accessor (`"<name>: <message>"`, built only when read) inherited from a shared prototype; enabling `injectStack` stores a real captured trace as an own property instead. Because the default form is inherited rather than an own property, it is not emitted by `JSON.stringify(err)` unless `injectStack` is set — read `err.stack` directly (loggers do).
+
 ```ts
 const { errFn } = new Ayamari();
 

--- a/packages/ayamari/src/__tests__/ayamari_test.ts
+++ b/packages/ayamari/src/__tests__/ayamari_test.ts
@@ -92,17 +92,11 @@ describe('Ayamari', () => {
   describe('isAyamariErr', () => {
     it('should be true for an Ayamari error', () => {
       const { errFn } = new Ayamari();
-      assert.equal(
-        isAyamariErr(errFn.Fail('boom')),
-        true,
-      );
+      assert.equal(isAyamariErr(errFn.Fail('boom')), true);
     });
 
     it('should be false for native errors and non-errors', () => {
-      assert.equal(
-        isAyamariErr(new Error('boom')),
-        false,
-      );
+      assert.equal(isAyamariErr(new Error('boom')), false);
       // A native error carrying its own `code`/`meta` must not be
       // mistaken for an Ayamari error (the brand, not duck-typing).
       assert.equal(
@@ -157,19 +151,13 @@ describe('Ayamari', () => {
       const root = errFn.NotFound('missing');
       const middle = errFn.Fail('mid', { cause: root });
       const top = errFn.Timeout('top', { cause: middle });
-      assert.equal(
-        findCauseByCode(top, 'NotFound'),
-        root,
-      );
+      assert.equal(findCauseByCode(top, 'NotFound'), root);
     });
 
     it('should match the error itself', () => {
       const { errFn } = new Ayamari();
       const err = errFn.NotFound('missing');
-      assert.equal(
-        findCauseByCode(err, 'NotFound'),
-        err,
-      );
+      assert.equal(findCauseByCode(err, 'NotFound'), err);
     });
 
     it('should match a native error in the chain by its code', () => {
@@ -178,23 +166,14 @@ describe('Ayamari', () => {
         code: 'ENOENT',
       });
       const err = errFn.Fail('wrapped', { cause: native });
-      assert.equal(
-        findCauseByCode(err, 'ENOENT'),
-        native,
-      );
+      assert.equal(findCauseByCode(err, 'ENOENT'), native);
     });
 
     it('should return null when no cause matches', () => {
       const { errFn } = new Ayamari();
       const err = errFn.Fail('boom');
-      assert.equal(
-        findCauseByCode(err, 'NotFound'),
-        null,
-      );
-      assert.equal(
-        findCauseByCode(null, 'NotFound'),
-        null,
-      );
+      assert.equal(findCauseByCode(err, 'NotFound'), null);
+      assert.equal(findCauseByCode(null, 'NotFound'), null);
     });
 
     it('should not hang on a cyclic cause chain', () => {
@@ -202,10 +181,7 @@ describe('Ayamari', () => {
       const a = errFn.Fail('a');
       const b = errFn.Fail('b', { cause: a });
       a.cause = b;
-      assert.equal(
-        findCauseByCode(b, 'NotFound'),
-        null,
-      );
+      assert.equal(findCauseByCode(b, 'NotFound'), null);
     });
   });
 

--- a/packages/ayamari/src/__tests__/ayamari_test.ts
+++ b/packages/ayamari/src/__tests__/ayamari_test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { Ayamari } from '../ayamari.js';
+import {
+  Ayamari,
+  findCauseByCode,
+  isAyamariErr,
+  level,
+  prettifyStack,
+} from '../ayamari.js';
 
 describe('Ayamari', () => {
   it('should work', () => {
@@ -62,24 +68,24 @@ describe('Ayamari', () => {
       const { errFn } = new Ayamari();
       assert.equal(
         errFn.UnexpectedError('boom').levelValue,
-        Ayamari.level.error,
+        level.error,
       );
       assert.equal(
         errFn.NotFound('missing').levelValue,
-        Ayamari.level.error,
+        level.error,
       );
       assert.equal(
         errFn.StopPropagation('halt').levelValue,
-        Ayamari.level.error,
+        level.error,
       );
     });
 
     it('should let opts.levelValue override the default', () => {
       const { errFn } = new Ayamari();
       const err = errFn.NotFound('missing', {
-        levelValue: Ayamari.level.debug,
+        levelValue: level.debug,
       });
-      assert.equal(err.levelValue, Ayamari.level.debug);
+      assert.equal(err.levelValue, level.debug);
     });
   });
 
@@ -87,23 +93,23 @@ describe('Ayamari', () => {
     it('should be true for an Ayamari error', () => {
       const { errFn } = new Ayamari();
       assert.equal(
-        Ayamari.isAyamariErr(errFn.Fail('boom')),
+        isAyamariErr(errFn.Fail('boom')),
         true,
       );
     });
 
     it('should be false for native errors and non-errors', () => {
       assert.equal(
-        Ayamari.isAyamariErr(new Error('boom')),
+        isAyamariErr(new Error('boom')),
         false,
       );
       // A native error carrying its own `code`/`meta` must not be
       // mistaken for an Ayamari error (the brand, not duck-typing).
       assert.equal(
-        Ayamari.isAyamariErr({ code: 'ENOENT', meta: {} }),
+        isAyamariErr({ code: 'ENOENT', meta: {} }),
         false,
       );
-      assert.equal(Ayamari.isAyamariErr(null), false);
+      assert.equal(isAyamariErr(null), false);
     });
   });
 
@@ -138,10 +144,10 @@ describe('Ayamari', () => {
     it("should carry the cause's levelValue", () => {
       const { errFn, propagateErr } = new Ayamari();
       const cause = errFn.NotFound('missing', {
-        levelValue: Ayamari.level.fatal,
+        levelValue: level.fatal,
       });
       const err = propagateErr('wrapped', { cause });
-      assert.equal(err.levelValue, Ayamari.level.fatal);
+      assert.equal(err.levelValue, level.fatal);
     });
   });
 
@@ -152,7 +158,7 @@ describe('Ayamari', () => {
       const middle = errFn.Fail('mid', { cause: root });
       const top = errFn.Timeout('top', { cause: middle });
       assert.equal(
-        Ayamari.findCauseByCode(top, 'NotFound'),
+        findCauseByCode(top, 'NotFound'),
         root,
       );
     });
@@ -161,7 +167,7 @@ describe('Ayamari', () => {
       const { errFn } = new Ayamari();
       const err = errFn.NotFound('missing');
       assert.equal(
-        Ayamari.findCauseByCode(err, 'NotFound'),
+        findCauseByCode(err, 'NotFound'),
         err,
       );
     });
@@ -173,7 +179,7 @@ describe('Ayamari', () => {
       });
       const err = errFn.Fail('wrapped', { cause: native });
       assert.equal(
-        Ayamari.findCauseByCode(err, 'ENOENT'),
+        findCauseByCode(err, 'ENOENT'),
         native,
       );
     });
@@ -182,11 +188,11 @@ describe('Ayamari', () => {
       const { errFn } = new Ayamari();
       const err = errFn.Fail('boom');
       assert.equal(
-        Ayamari.findCauseByCode(err, 'NotFound'),
+        findCauseByCode(err, 'NotFound'),
         null,
       );
       assert.equal(
-        Ayamari.findCauseByCode(null, 'NotFound'),
+        findCauseByCode(null, 'NotFound'),
         null,
       );
     });
@@ -197,7 +203,7 @@ describe('Ayamari', () => {
       const b = errFn.Fail('b', { cause: a });
       a.cause = b;
       assert.equal(
-        Ayamari.findCauseByCode(b, 'NotFound'),
+        findCauseByCode(b, 'NotFound'),
         null,
       );
     });
@@ -212,7 +218,7 @@ describe('Ayamari', () => {
       cause: nativeErr,
     });
     assert.match(
-      Ayamari.prettifyStack(err, { color: false }),
+      prettifyStack(err, { color: false }),
       /Fail: err/u,
     );
   });
@@ -225,7 +231,7 @@ describe('Ayamari', () => {
         cause: nativeErr,
       });
       assert.match(
-        Ayamari.prettifyStack(err, { color: false }),
+        prettifyStack(err, { color: false }),
         /Fail: err/u,
       );
     });
@@ -235,7 +241,7 @@ describe('Ayamari', () => {
         const { errFn } = new Ayamari();
         const err = errFn.Fail('err');
         assert.match(
-          Ayamari.prettifyStack(err, { color: false }),
+          prettifyStack(err, { color: false }),
           /Fail: err/u,
         );
       });

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -4,8 +4,18 @@ import {
 } from '@daisugi/anzen';
 
 import {
-  defaultFrameFilter,
   PrettyStack,
+  type PrettyStackOpts,
+} from './pretty_stack.js';
+
+// Re-exported so the stack prettifier's option types are reachable from
+// the package root. These are type-only (plus the tiny `defaultFrameFilter`
+// const); none of them retain `PrettyStack`, so error-only consumers still
+// tree-shake `pretty_stack.js` away.
+export {
+  defaultFrameFilter,
+  type FrameFilter,
+  type ParsedFrame,
   type PrettyStackOpts,
 } from './pretty_stack.js';
 
@@ -14,10 +24,35 @@ type Entries<T> = [keyof T, ValueOf<T>][];
 
 // Registry-global brand stamped on every AyamariErr. `Symbol.for` keeps
 // it stable across realms/bundles (and duplicated module copies), so
-// `Ayamari.isAyamariErr` works where `instanceof` can't — AyamariErr is a
+// `isAyamariErr` works where `instanceof` can't — AyamariErr is a
 // plain branded object, not a class instance. The same key is recomputed
 // in pretty_stack.ts; keep the two in sync.
 const ayamariBrand = Symbol.for('@daisugi/ayamari');
+
+// Pino-style numeric severity levels. Higher = more severe, so
+// monitoring can threshold (e.g. alert when `levelValue >= error`).
+export const level = {
+  off: 100,
+  fatal: 60,
+  error: 50,
+  warn: 40,
+  info: 30,
+  debug: 20,
+  trace: 10,
+};
+
+export const errCode = {
+  CircuitSuspended: 'CircuitSuspended',
+  CircularDependencyDetected:
+    'CircularDependencyDetected',
+  Fail: 'Fail',
+  InvalidArgument: 'InvalidArgument',
+  NotFound: 'NotFound',
+  StopPropagation: 'StopPropagation',
+  Timeout: 'Timeout',
+  UnexpectedError: 'UnexpectedError',
+  ValidationFailed: 'ValidationFailed',
+};
 
 export interface AyamariGlobalOpts<CustomErrCode> {
   injectStack?: boolean;
@@ -53,34 +88,57 @@ export type AyamariCreateErrRes = (
 
 export type AyamariErrCodeKey<CustomErrCode> =
   | keyof CustomErrCode
-  | keyof (typeof Ayamari)['errCode'];
+  | keyof typeof errCode;
+
+export function prettifyStack(
+  err: AyamariErr | Error,
+  opts: PrettyStackOpts = {},
+): string {
+  return PrettyStack.print(err, opts);
+}
+
+// Brand-based type guard. Reliable across realms/bundles, unlike
+// `instanceof` (AyamariErr is a plain branded object, not a class
+// instance). Native errors carry their own `code`, so don't duck-type.
+export function isAyamariErr(
+  err: unknown,
+): err is AyamariErr {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as Record<symbol, unknown>)[ayamariBrand] === true
+  );
+}
+
+// Walk the cause chain (the error itself first) and return the first
+// error whose `code` matches, or null. Lets a boundary branch on a
+// failure mode no matter how deeply it was wrapped. Reads `code`
+// generically, so native errors carrying one (e.g. `ENOENT`) match too.
+export function findCauseByCode(
+  err: AyamariErr | Error | null | undefined,
+  code: string,
+): AyamariErr | Error | null {
+  // Guard against cyclic cause chains so a malformed error can't hang.
+  const seen = new Set<unknown>();
+  let cursor: AyamariErr | Error | null | undefined = err;
+  while (
+    cursor &&
+    typeof cursor === 'object' &&
+    !seen.has(cursor)
+  ) {
+    seen.add(cursor);
+    if ((cursor as AyamariErr).code === code) {
+      return cursor;
+    }
+    cursor = (cursor as AyamariErr).cause;
+  }
+  return null;
+}
 
 export class Ayamari<CustomErrCode> {
-  static readonly defaultFrameFilter = defaultFrameFilter;
-  // Pino-style numeric severity levels. Higher = more severe, so
-  // monitoring can threshold (e.g. alert when `levelValue >= error`).
-  static level = {
-    off: 100,
-    fatal: 60,
-    error: 50,
-    warn: 40,
-    info: 30,
-    debug: 20,
-    trace: 10,
-  };
-  static errCode = {
-    CircuitSuspended: 'CircuitSuspended',
-    CircularDependencyDetected:
-      'CircularDependencyDetected',
-    Fail: 'Fail',
-    InvalidArgument: 'InvalidArgument',
-    NotFound: 'NotFound',
-    StopPropagation: 'StopPropagation',
-    Timeout: 'Timeout',
-    UnexpectedError: 'UnexpectedError',
-    ValidationFailed: 'ValidationFailed',
-  };
-  errCode = Ayamari.errCode;
+  // Defaults to the module-level `errCode`; `customErrCode` is merged in
+  // by the constructor.
+  errCode = errCode;
   errFn = {} as Record<
     AyamariErrCodeKey<CustomErrCode>,
     AyamariCreateErr
@@ -140,7 +198,7 @@ export class Ayamari<CustomErrCode> {
         name,
         message: msg,
         code: errCode,
-        levelValue: opts.levelValue ?? Ayamari.level.error,
+        levelValue: opts.levelValue ?? level.error,
         stack: `${name}: ${msg}`,
         cause: opts.cause || null,
         meta: opts.meta ?? null,
@@ -179,48 +237,4 @@ export class Ayamari<CustomErrCode> {
   ) => {
     return Result.failure(this.propagateErr(msg, opts));
   };
-
-  static prettifyStack(
-    err: AyamariErr | Error,
-    opts: PrettyStackOpts = {},
-  ) {
-    return PrettyStack.print(err, opts);
-  }
-
-  // Brand-based type guard. Reliable across realms/bundles, unlike
-  // `instanceof` (AyamariErr is a plain branded object, not a class
-  // instance). Native errors carry their own `code`, so don't duck-type.
-  static isAyamariErr(err: unknown): err is AyamariErr {
-    return (
-      typeof err === 'object' &&
-      err !== null &&
-      (err as Record<symbol, unknown>)[ayamariBrand] ===
-        true
-    );
-  }
-
-  // Walk the cause chain (the error itself first) and return the first
-  // error whose `code` matches, or null. Lets a boundary branch on a
-  // failure mode no matter how deeply it was wrapped. Reads `code`
-  // generically, so native errors carrying one (e.g. `ENOENT`) match too.
-  static findCauseByCode(
-    err: AyamariErr | Error | null | undefined,
-    code: string,
-  ): AyamariErr | Error | null {
-    // Guard against cyclic cause chains so a malformed error can't hang.
-    const seen = new Set<unknown>();
-    let cursor: AyamariErr | Error | null | undefined = err;
-    while (
-      cursor &&
-      typeof cursor === 'object' &&
-      !seen.has(cursor)
-    ) {
-      seen.add(cursor);
-      if ((cursor as AyamariErr).code === code) {
-        return cursor;
-      }
-      cursor = (cursor as AyamariErr).cause;
-    }
-    return null;
-  }
 }

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -43,8 +43,7 @@ export const level = {
 
 export const errCode = {
   CircuitSuspended: 'CircuitSuspended',
-  CircularDependencyDetected:
-    'CircularDependencyDetected',
+  CircularDependencyDetected: 'CircularDependencyDetected',
   Fail: 'Fail',
   InvalidArgument: 'InvalidArgument',
   NotFound: 'NotFound',
@@ -75,6 +74,32 @@ export interface AyamariErr extends Error {
   cause: AyamariErr | Error | null | undefined;
   meta: any;
 }
+
+// Shared prototype for every AyamariErr. Inheriting the brand and a lazily
+// derived `stack` from here (instead of stamping both onto each error) keeps
+// instances smaller and skips building `stack` until it is actually read.
+// `injectStack` installs an own `stack` via captureStackTrace that shadows
+// the getter; the setter lets callers assign `err.stack` directly too.
+const ayamariErrProto = Object.create(
+  Error.prototype,
+) as object;
+Object.defineProperty(ayamariErrProto, ayamariBrand, {
+  value: true,
+});
+Object.defineProperty(ayamariErrProto, 'stack', {
+  configurable: true,
+  get(this: AyamariErr): string {
+    return `${this.name}: ${this.message}`;
+  },
+  set(this: AyamariErr, value: string): void {
+    Object.defineProperty(this, 'stack', {
+      value,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  },
+});
 
 export type AyamariCreateErr = (
   msg: string,
@@ -161,19 +186,19 @@ export class Ayamari<CustomErrCode> {
         ...opts.customErrCode,
       };
     }
-    for (const [errName, errCode] of Object.entries(
+    for (const [errName, code] of Object.entries(
       this.errCode,
     ) as Entries<
       Record<AyamariErrCodeKey<CustomErrCode>, string>
     >) {
       this.errFn[errName] = this.createErrCreator(
         errName,
-        errCode,
+        code,
       );
       this.errFnRes[errName] = this.createErrResCreator(
         this.errFn[errName],
       );
-      this.#errName.set(errCode, errName);
+      this.#errName.set(code, errName);
     }
   }
 
@@ -185,24 +210,23 @@ export class Ayamari<CustomErrCode> {
 
   createErrCreator(
     errName: AyamariErrCodeKey<CustomErrCode>,
-    errCode: string,
+    code: string,
   ) {
     const name = errName as string;
+    const errorLevel = level.error;
     const createErr = (
       msg: string,
       opts: AyamariOpts = {},
     ) => {
       const err = {
-        __proto__: Error.prototype,
-        [ayamariBrand]: true,
+        __proto__: ayamariErrProto,
         name,
         message: msg,
-        code: errCode,
-        levelValue: opts.levelValue ?? level.error,
-        stack: `${name}: ${msg}`,
+        code,
+        levelValue: opts.levelValue ?? errorLevel,
         cause: opts.cause || null,
         meta: opts.meta ?? null,
-      } as AyamariErr;
+      } as unknown as AyamariErr;
       if (opts.injectStack ?? this.#injectStack) {
         Error.captureStackTrace(err, createErr);
       }

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -80,26 +80,23 @@ export interface AyamariErr extends Error {
 // instances smaller and skips building `stack` until it is actually read.
 // `injectStack` installs an own `stack` via captureStackTrace that shadows
 // the getter; the setter lets callers assign `err.stack` directly too.
-const ayamariErrProto = Object.create(
-  Error.prototype,
-) as object;
-Object.defineProperty(ayamariErrProto, ayamariBrand, {
-  value: true,
-});
-Object.defineProperty(ayamariErrProto, 'stack', {
-  configurable: true,
-  get(this: AyamariErr): string {
-    return `${this.name}: ${this.message}`;
+const ayamariErrProto = Object.create(Error.prototype, {
+  [ayamariBrand]: { value: true },
+  stack: {
+    configurable: true,
+    get(this: AyamariErr): string {
+      return `${this.name}: ${this.message}`;
+    },
+    set(this: AyamariErr, value: string): void {
+      Object.defineProperty(this, 'stack', {
+        value,
+        writable: true,
+        configurable: true,
+        enumerable: true,
+      });
+    },
   },
-  set(this: AyamariErr, value: string): void {
-    Object.defineProperty(this, 'stack', {
-      value,
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    });
-  },
-});
+}) as object;
 
 export type AyamariCreateErr = (
   msg: string,

--- a/packages/ayamari/src/pretty_stack.ts
+++ b/packages/ayamari/src/pretty_stack.ts
@@ -1,4 +1,7 @@
-import type { AyamariErr } from './ayamari.js';
+import {
+  type AyamariErr,
+  isAyamariErr,
+} from './ayamari.js';
 
 export interface ParsedFrame {
   methodName: string;
@@ -170,19 +173,6 @@ function safeStringify(value: unknown): string {
   } catch (err) {
     return `[Unserializable: ${(err as Error).message}]`;
   }
-}
-
-// Registry-global brand stamped by Ayamari on every AyamariErr. Recomputed
-// here (rather than imported) to avoid a value cycle with ayamari.ts;
-// `Symbol.for` guarantees it resolves to the same symbol. Keep in sync.
-const ayamariBrand = Symbol.for('@daisugi/ayamari');
-
-function isAyamariErr(err: AyamariErr | Error): boolean {
-  return (
-    (err as unknown as Record<symbol, unknown>)[
-      ayamariBrand
-    ] === true
-  );
 }
 
 function formatExtraProps(

--- a/packages/kintsugi/src/with_cache.ts
+++ b/packages/kintsugi/src/with_cache.ts
@@ -2,7 +2,7 @@ import type {
   AnzenAnyResult,
   AnzenResultFn,
 } from '@daisugi/anzen';
-import { Ayamari } from '@daisugi/ayamari';
+import { errCode } from '@daisugi/ayamari';
 
 import { randomIntBetween } from './random_int_between.js';
 import { SimpleMemoryStore } from './simple_memory_store.js';
@@ -79,7 +79,7 @@ export function shouldCache(
   // https://docs.fastly.com/en/guides/http-code-codes-cached-by-default
   if (
     response.isFailure &&
-    response.getError().code === Ayamari.errCode.NotFound
+    response.getError().code === errCode.NotFound
   ) {
     return true;
   }

--- a/packages/kintsugi/src/with_retry.ts
+++ b/packages/kintsugi/src/with_retry.ts
@@ -3,7 +3,10 @@ import {
   type AnzenResultFn,
   Result,
 } from '@daisugi/anzen';
-import { Ayamari, type AyamariErr } from '@daisugi/ayamari';
+import {
+  type AyamariErr,
+  errCode,
+} from '@daisugi/ayamari';
 
 import { randomIntBetween } from './random_int_between.js';
 import type { WrappedFn } from './types.js';
@@ -53,7 +56,7 @@ export function calculateRetryDelayMs(
  * Kept consistent with how `withCache` treats `NotFound`.
  */
 const nonRetryableErrCodes: string[] = [
-  Ayamari.errCode.NotFound,
+  errCode.NotFound,
 ];
 
 export function shouldRetry(


### PR DESCRIPTION
Follow-up to #120. Two commits.

## `refactor(ayamari)!: tree-shakeable named exports`
Exposes `level`, `errCode`, `isAyamariErr`, `findCauseByCode`, and `prettifyStack` as **module-level named exports** instead of `Ayamari` statics, so error-only consumers tree-shake `pretty_stack` away. `kintsugi` (`withCache` / `withRetry`) updated to the new imports.

**Breaking:** `Ayamari.isAyamariErr` / `Ayamari.findCauseByCode` / `Ayamari.level` / `Ayamari.errCode` / `Ayamari.prettifyStack` are now imported directly: `import { isAyamariErr } from '@daisugi/ayamari'`.

## `perf(ayamari): smaller errors via prototype brand and lazy stack`
Moves the `Symbol` brand and the derived `stack` onto a shared prototype instead of stamping both onto every error, and hoists the default `levelValue` lookup out of the per-error path.

Measured (Node 22.22.2, Intel Core Ultra 7 268V; `--expose-gc`, indicative):

| metric | before | after |
| --- | --- | --- |
| bytes / error (`errFn.Fail`) | ~136 | **~84** (-38%) |
| `new Error()` baseline | ~459 bytes | — |
| creation throughput | ~45-74 ns/op | ~50-60 ns/op (within noise) |

- `stack` is now a lazy accessor built on read (with a setter so `err.stack = …` still works); `injectStack` still installs an own captured trace that shadows it.
- **Behavior note:** the default `stack` is inherited, not an own property, so it is not emitted by `JSON.stringify(err)` unless `injectStack` is set. Read `err.stack` directly (loggers do).

## Testing
All suites pass: ayamari 61, kintsugi 59, daisugi 18, kado 49. `oxfmt`/`oxlint` clean; all changed packages build.
