### PR TITLE
Tree-shakeable Anzen & Kado APIs, Rust-style naming, and docs overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist
 
 # C8
 coverage
+
+# Serena
+.serena/

--- a/README.md
+++ b/README.md
@@ -2,28 +2,197 @@
   <img alt="daisugi" src="https://user-images.githubusercontent.com/22574/125201112-fc787f00-e26d-11eb-8e70-569dbd6997e0.png" width="170">
 </p>
 
+<h1 align="center">Daisugi</h1>
+
 <p align="center">
-  This monorepo contains TypeScript/ESM projects from <code>@daisugi</code>, designed to help build composable applications.
+  <strong>A garden of small, composable TypeScript libraries for building robust applications.</strong>
 </p>
 
-<h2 align="center">Daisugi</h2>
+<p align="center">
+  Pick one. Pick all of them. Each package does one thing well, ships zero (or trusted) dependencies, runs everywhere JavaScript runs, and is designed to compose with the others.
+</p>
 
-## 🌱 Meet the Ecosystem
+<p align="center">
+  <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-strict-3178c6.svg?logo=typescript&logoColor=white">
+  <img alt="Node" src="https://img.shields.io/badge/node-%3E%3D22.13.1-43853d.svg?logo=node.js&logoColor=white">
+  <img alt="Modules: ESM + CJS" src="https://img.shields.io/badge/modules-ESM%20%2B%20CJS-f7df1e.svg">
+  <a href="#-contributing"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
+</p>
 
-Explore the <code>@daisugi</code> ecosystem, a collection of modular tools designed to build robust, composable applications.
+---
 
-| Project                             | Version                                                                                                           | Description                                                                                          |
+## 🌱 Why Daisugi?
+
+Most "frameworks" ask you to adopt everything at once. Daisugi takes the opposite approach, inspired by the Japanese forestry technique it is named after: grow many straight, independent shoots from a single healthy base.
+
+- **🧩 Composable, not monolithic** - Every package is independently published and versioned. Install only what you need; reach for the next one when you need it.
+- **🪶 Tiny and dependency-light** - Minimal bundle footprint, zero or only trusted dependencies. Tree-shakeable down to the functions you actually import.
+- **🌐 Universal** - Runs in the browser and on the server (Node.js). Distributed as **ESM (ES2025)** _and_ **CommonJS**, with full TypeScript typings.
+- **🔬 Type-safe by design** - Errors live in your function signatures (not in `try/catch` you forgot to write), dependencies are wired explicitly, and the compiler is on your side.
+- **🤝 Production-tested** - Used in production, some packages serving millions of users.
+
+---
+
+## 📦 What's Inside
+
+This is a monorepo of six independently versioned packages:
+
+| Package                             | Version                                                                                                           | Description                                                                                          |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| **[Daisugi](./packages/daisugi)**   | [![version](https://img.shields.io/npm/v/@daisugi/daisugi.svg)](https://www.npmjs.com/package/@daisugi/daisugi)   | A minimalist, functional middleware engine.                                                          |
-| **[Kintsugi](./packages/kintsugi)** | [![version](https://img.shields.io/npm/v/@daisugi/kintsugi.svg)](https://www.npmjs.com/package/@daisugi/kintsugi) | A set of utilities for building fault-tolerant services.                                             |
-| **[Kado](./packages/kado)**         | [![version](https://img.shields.io/npm/v/@daisugi/kado.svg)](https://www.npmjs.com/package/@daisugi/kado)         | A lightweight and unobtrusive inversion of control (IoC) container.                                  |
+| **[Daisugi](./packages/daisugi)**   | [![version](https://img.shields.io/npm/v/@daisugi/daisugi.svg)](https://www.npmjs.com/package/@daisugi/daisugi)   | A minimalist, functional middleware engine - organize code into clear execution pipelines.           |
+| **[Kado](./packages/kado)**         | [![version](https://img.shields.io/npm/v/@daisugi/kado.svg)](https://www.npmjs.com/package/@daisugi/kado)         | A lightweight, unobtrusive inversion of control (IoC) container for wiring dependencies.             |
 | **[Anzen](./packages/anzen)**       | [![version](https://img.shields.io/npm/v/@daisugi/anzen.svg)](https://www.npmjs.com/package/@daisugi/anzen)       | A `Result` type for safe error handling without exceptions, inspired by Rust and Haskell.            |
 | **[Ayamari](./packages/ayamari)**   | [![version](https://img.shields.io/npm/v/@daisugi/ayamari.svg)](https://www.npmjs.com/package/@daisugi/ayamari)   | A factory for rich, structured errors with error codes, chained causes, and prettified stack traces. |
-| **[Land](./packages/land)**         | [![version](https://img.shields.io/npm/v/@daisugi/land.svg)](https://www.npmjs.com/package/@daisugi/land)         | A single package that bundles the entire @daisugi toolkit (Daisugi, Kado, Anzen, Ayamari, Kintsugi). |
+| **[Kintsugi](./packages/kintsugi)** | [![version](https://img.shields.io/npm/v/@daisugi/kintsugi.svg)](https://www.npmjs.com/package/@daisugi/kintsugi) | Resilience utilities - retries, timeouts, caching, and pooling for fault-tolerant services.          |
+| **[Land](./packages/land)**         | [![version](https://img.shields.io/npm/v/@daisugi/land.svg)](https://www.npmjs.com/package/@daisugi/land)         | A single package that bundles the entire @daisugi toolkit in one install.                            |
 
-## 📦 Package Features
+> Each package has its own README with a full API reference, motivation, and examples - click any name above.
 
-- **Universal** - every package runs in the browser and on the server (Node.js).
-- Independently versioned.
-- Distributed as **ESM modules (ES2025 syntax)** with **TypeScript typings** and changelogs.
-- Licensed under the **[MIT License](./LICENSE)**.
+---
+
+## 🚀 Quick Taste
+
+Each package stands on its own:
+
+```ts
+// Daisugi - compose functions into a pipeline
+import { Daisugi } from '@daisugi/daisugi';
+const { sequenceOf } = new Daisugi();
+const greet = sequenceOf([(s) => `${s} John`, (s) => `${s} Doe.`]);
+greet('Hi'); // "Hi John Doe."
+```
+
+```ts
+// Anzen - make failure a value, not a surprise
+import { ok, err } from '@daisugi/anzen';
+const parse = (n: string) =>
+  Number.isNaN(+n) ? err('not a number') : ok(+n);
+parse('42').unwrap(); // 42
+```
+
+```ts
+// Kado - wire dependencies without the boilerplate
+import { Kado } from '@daisugi/kado';
+const { container } = new Kado();
+container.register([
+  { token: 'Foo', useClass: Foo, params: ['Bar'] },
+  { token: 'Bar', useClass: Bar },
+]);
+const foo = await container.resolve('Foo');
+```
+
+```ts
+// Kintsugi - wrap a flaky call in resilience
+import { withCache, withRetry, reusePromise } from '@daisugi/kintsugi';
+const rockSolid = withCache(withRetry(reusePromise(fetchUser)));
+```
+
+```ts
+// Ayamari - errors with codes, causes, and pretty stacks
+import { Ayamari, formatStack } from '@daisugi/ayamari';
+const { errs } = new Ayamari();
+throw errs.NotFound('User missing', { cause: dbErr });
+```
+
+---
+
+## 🌳 The Ecosystem in Action
+
+The real payoff is composition. Here every package pulls its weight in a single flow - resilient I/O, explicit errors, dependency wiring, and a readable pipeline:
+
+```ts
+// One install, one import - Land re-exports the entire toolkit.
+import {
+  Daisugi,
+  Kado,
+  ok,
+  Ayamari,
+  withRetry,
+  withTimeout,
+  type AnzenResult,
+  type AyamariErr,
+} from '@daisugi/land';
+
+const { errs, errsResult } = new Ayamari();
+
+// A flaky dependency, hardened with Kintsugi and returning an Anzen Result.
+const fetchUser = withRetry(
+  withTimeout(async (id: string): Promise<AnzenResult<AyamariErr, User>> => {
+    const res = await api.getUser(id);
+    return res ? ok(res) : errsResult.NotFound(`No user ${id}`);
+  }),
+);
+
+// Wire collaborators with Kado, sharing Ayamari's error factory.
+const { container } = new Kado({ errs });
+container.register([{ token: 'Greeter', useClass: Greeter }]);
+
+// Orchestrate the steps as a Daisugi pipeline.
+const { sequenceOf } = new Daisugi();
+const handle = sequenceOf([
+  async (id: string) => (await fetchUser(id)).unwrap(),
+  async (user: User) => (await container.resolve('Greeter')).welcome(user),
+]);
+
+await handle('u_123');
+```
+
+No magic, no globals - just small pieces that fit together. See [`@daisugi/anzen`](./packages/anzen#-composition-styles-side-by-side) for a deeper, real-world checkout example.
+
+---
+
+## 📥 Installation
+
+Install just the package you need:
+
+```sh
+npm install @daisugi/anzen
+# or
+pnpm install @daisugi/kintsugi
+```
+
+Or grab the whole toolkit in one go with **[Land](./packages/land)**:
+
+```sh
+pnpm install @daisugi/land
+```
+
+```ts
+import { Daisugi, Kado, Result, Err } from '@daisugi/land';
+```
+
+---
+
+## 🛠️ Development
+
+```sh
+# Install dependencies for every package
+pnpm install
+
+# Build all packages
+pnpm build
+
+# Run the full test suite
+pnpm test
+
+# Lint and format (oxlint + oxfmt)
+pnpm lint
+pnpm format
+```
+
+Each package can also be built and tested in isolation from its own directory (`pnpm --filter @daisugi/anzen test`).
+
+---
+
+## 🤝 Contributing
+
+Contributions, issues, and feature requests are welcome!
+
+Found a bug or have an idea? [Open an issue](https://github.com/daisugiland/daisugi/issues).
+
+---
+
+## 📜 License
+
+[MIT](./LICENSE) © Daisugi contributors

--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@
 
 Explore the <code>@daisugi</code> ecosystem, a collection of modular tools designed to build robust, composable applications.
 
-| Project                                                                             | Version                                                                                                           | Description                                                                               |
-| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| **[Daisugi](./packages/daisugi)**                                                   | [![version](https://img.shields.io/npm/v/@daisugi/daisugi.svg)](https://www.npmjs.com/package/@daisugi/daisugi)   | A minimalist, functional middleware engine.                                               |
-| **[Kintsugi](./packages/kintsugi)**                                                 | [![version](https://img.shields.io/npm/v/@daisugi/kintsugi.svg)](https://www.npmjs.com/package/@daisugi/kintsugi) | A set of utilities for building fault-tolerant services.                                  |
-| **[Kado](./packages/kado)**                                                         | [![version](https://img.shields.io/npm/v/@daisugi/kado.svg)](https://www.npmjs.com/package/@daisugi/kado)         | A lightweight and unobtrusive inversion of control (IoC) container.                       |
-| **[Anzen](./packages/anzen)**                                                       | [![version](https://img.shields.io/npm/v/@daisugi/anzen.svg)](https://www.npmjs.com/package/@daisugi/anzen)       | A `Result` type for safe error handling without exceptions, inspired by Rust and Haskell. |
-| **[Ayamari](./packages/ayamari)**                                                   | [![version](https://img.shields.io/npm/v/@daisugi/ayamari.svg)](https://www.npmjs.com/package/@daisugi/ayamari)   | A factory for rich, structured errors with error codes, chained causes, and prettified stack traces. |
-| **[Land](./packages/land)**                                                         | [![version](https://img.shields.io/npm/v/@daisugi/land.svg)](https://www.npmjs.com/package/@daisugi/land)         | A single package that bundles the entire @daisugi toolkit (Daisugi, Kado, Anzen, Ayamari, Kintsugi). |
+| Project                             | Version                                                                                                           | Description                                                                                          |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **[Daisugi](./packages/daisugi)**   | [![version](https://img.shields.io/npm/v/@daisugi/daisugi.svg)](https://www.npmjs.com/package/@daisugi/daisugi)   | A minimalist, functional middleware engine.                                                          |
+| **[Kintsugi](./packages/kintsugi)** | [![version](https://img.shields.io/npm/v/@daisugi/kintsugi.svg)](https://www.npmjs.com/package/@daisugi/kintsugi) | A set of utilities for building fault-tolerant services.                                             |
+| **[Kado](./packages/kado)**         | [![version](https://img.shields.io/npm/v/@daisugi/kado.svg)](https://www.npmjs.com/package/@daisugi/kado)         | A lightweight and unobtrusive inversion of control (IoC) container.                                  |
+| **[Anzen](./packages/anzen)**       | [![version](https://img.shields.io/npm/v/@daisugi/anzen.svg)](https://www.npmjs.com/package/@daisugi/anzen)       | A `Result` type for safe error handling without exceptions, inspired by Rust and Haskell.            |
+| **[Ayamari](./packages/ayamari)**   | [![version](https://img.shields.io/npm/v/@daisugi/ayamari.svg)](https://www.npmjs.com/package/@daisugi/ayamari)   | A factory for rich, structured errors with error codes, chained causes, and prettified stack traces. |
+| **[Land](./packages/land)**         | [![version](https://img.shields.io/npm/v/@daisugi/land.svg)](https://www.npmjs.com/package/@daisugi/land)         | A single package that bundles the entire @daisugi toolkit (Daisugi, Kado, Anzen, Ayamari, Kintsugi). |
 
 ## 📦 Package Features
 
-- **Universal** - every package runs in both Node.js and the browser.
+- **Universal** - every package runs in the browser and on the server (Node.js).
 - Independently versioned.
 - Distributed as **ESM modules (ES2025 syntax)** with **TypeScript typings** and changelogs.
 - Licensed under the **[MIT License](./LICENSE)**.

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -27,15 +27,15 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 ## 🚀 Usage
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success, failure } from '@daisugi/anzen';
 import { readFileSync } from 'node:fs';
 
 function readFile(path) {
   try {
     const response = readFileSync(path);
-    return Result.success(response);
+    return success(response);
   } catch (err) {
-    return Result.failure(err);
+    return failure(err);
   }
 }
 
@@ -47,6 +47,8 @@ if (result.isFailure) {
 
 return result.getValue();
 ```
+
+Every combinator is a standalone named export, so unused helpers are tree-shaken away — `import { success }` pulls in nothing else.
 
 ---
 
@@ -60,8 +62,8 @@ return result.getValue();
   - [🔍 Overview](#-overview)
   - [🎯 Motivation](#-motivation)
   - [📚 API](#-api)
-    - [`Result.success(value)`](#resultsuccess-value)
-    - [`Result.failure(err)`](#resultfailure-err)
+    - [`success(value)`](#successvalue)
+    - [`failure(err)`](#failureerr)
     - [`result.isSuccess / result.isFailure`](#resultissuccess--resultisfailure)
     - [`result.getValue()`](#resultgetvalue)
     - [`result.getError()`](#resultgeterror)
@@ -73,12 +75,12 @@ return result.getValue();
     - [`result.unwrap(defaultValue?)`](#resultunwrapdefaultvalue)
     - [`result.unsafeUnwrap()`](#resultunsafeunwrap)
     - [`result.toJSON()`](#resulttojson)
-    - [`Result.fromJSON(json)`](#resultfromjsonjson)
-    - [`Result.promiseAll(results)`](#resultpromiseallresults)
-    - [`Result.unwrapPromiseAll([defaults, ...results])`](#resultunwrappromisealldefaults-results)
-    - [`Result.unwrap(defaultValue?)`](#resultunwrapdefaultvalue-1)
-    - [`Result.fromThrowable(fn, parseErr?)`](#resultfromthrowablefn-parseerr)
-    - [`Result.fromSyncThrowable(fn, parseErr?)`](#resultfromsyncthrowablefn-parseerr)
+    - [`fromJSON(json)`](#fromjsonjson)
+    - [`promiseAll(results)`](#promiseallresults)
+    - [`unwrapPromiseAll([defaults, ...results])`](#unwrappromisealldefaults-results)
+    - [`unwrap(defaultValue?)`](#unwrapdefaultvalue)
+    - [`fromThrowable(fn, parseErr?)`](#fromthrowablefn-parseerr)
+    - [`fromSyncThrowable(fn, parseErr?)`](#fromsyncthrowablefn-parseerr)
   - [🔷 TypeScript Support](#-typescript-support)
   - [🎯 Goal](#-goal)
   - [🌍 Other Projects](#-other-projects)
@@ -108,7 +110,7 @@ pnpm install @daisugi/anzen
 
 **Anzen** replaces thrown exceptions with an explicit `Result` type, making error paths visible in function signatures and composable with standard transforms. It provides:
 
-- ✅ `Result.success` and `Result.failure` constructors for wrapping values and errors
+- ✅ `success` and `failure` constructors for wrapping values and errors
 - ✅ Chainable `.map` / `.chain` transforms for success paths
 - ✅ Mirror `.elseMap` / `.elseChain` transforms for failure paths
 - ✅ Async helpers: `promiseAll` and `fromThrowable`
@@ -137,14 +139,14 @@ If you are looking for a robust Result-pattern implementation, Anzen might be th
 
 ## 📚 API
 
-A `Result` instance is either a `ResultSuccess<T>` or a `ResultFailure<E>`. Static methods on `Result` create or combine instances; instance methods transform or extract values.
+A `Result` instance is either a `ResultSuccess<T>` or a `ResultFailure<E>`. The standalone `success` / `failure` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `unwrap` / `fromThrowable` / `fromSyncThrowable` exports create or combine instances; instance methods transform or extract values.
 
-### `Result.success(value)`
+### `success(value)`
 
 Creates a successful Result wrapping the given value.
 
 ```ts
-Result.success<T>(value: T): ResultSuccess<T>
+success<T>(value: T): ResultSuccess<T>
 ```
 
 | Parameter | Type | Description                |
@@ -152,19 +154,19 @@ Result.success<T>(value: T): ResultSuccess<T>
 | `value`   | `T`  | The success value to wrap. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
-const res = Result.success('foo');
+const res = success('foo');
 ```
 
 ---
 
-### `Result.failure(err)`
+### `failure(err)`
 
 Creates a failure Result wrapping the given error.
 
 ```ts
-Result.failure<E>(err: E): ResultFailure<E>
+failure<E>(err: E): ResultFailure<E>
 ```
 
 | Parameter | Type | Description              |
@@ -172,9 +174,9 @@ Result.failure<E>(err: E): ResultFailure<E>
 | `err`     | `E`  | The error value to wrap. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { failure } from '@daisugi/anzen';
 
-const res = Result.failure('err');
+const res = failure('err');
 ```
 
 ---
@@ -184,13 +186,13 @@ const res = Result.failure('err');
 Boolean properties that indicate whether the Result represents a success or a failure. Exactly one is `true` at any time.
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success, failure } from '@daisugi/anzen';
 
-const res = Result.success('foo');
+const res = success('foo');
 console.log(res.isSuccess); // true
 console.log(res.isFailure); // false
 
-const errRes = Result.failure('err');
+const errRes = failure('err');
 console.log(errRes.isSuccess); // false
 console.log(errRes.isFailure); // true
 ```
@@ -206,9 +208,9 @@ result.getValue(): T
 ```
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
-const value = Result.success('foo').getValue();
+const value = success('foo').getValue();
 // 'foo'
 ```
 
@@ -223,9 +225,9 @@ result.getError(): E
 ```
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { failure } from '@daisugi/anzen';
 
-const error = Result.failure('err').getError();
+const error = failure('err').getError();
 // 'err'
 ```
 
@@ -244,9 +246,9 @@ result.getOrElse<V>(defaultValue: V): T | V
 | `defaultValue` | `V`  | Fallback value returned on failure. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { failure } from '@daisugi/anzen';
 
-const value = Result.failure('err').getOrElse('foo');
+const value = failure('err').getOrElse('foo');
 // 'foo'
 ```
 
@@ -254,7 +256,7 @@ const value = Result.failure('err').getOrElse('foo');
 
 ### `result.map(fn)`
 
-Applies `fn` to the success value and wraps the return in a new `Result.success`. Passes through unchanged on failure.
+Applies `fn` to the success value and wraps the return in a new success Result. Passes through unchanged on failure.
 
 ```ts
 result.map<V>(fn: (value: T) => V): ResultSuccess<V> | ResultFailure<E>
@@ -265,9 +267,9 @@ result.map<V>(fn: (value: T) => V): ResultSuccess<V> | ResultFailure<E>
 | `fn`      | `(value: T) => V` | Transform applied to the success value. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
-const result = Result.success('foo')
+const result = success('foo')
   .map((value) => value)
   .getValue();
 // 'foo'
@@ -288,10 +290,10 @@ result.chain<V, F>(fn: (value: T) => AnzenAnyResult<F, V>): AnzenAnyResult<E | F
 | `fn`      | `(value: T) => Result` | Function that produces a new Result from the success value. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
-const result = Result.success('foo')
-  .chain((value) => Result.success(value))
+const result = success('foo')
+  .chain((value) => success(value))
   .getValue();
 // 'foo'
 ```
@@ -311,10 +313,10 @@ result.elseChain<V, F>(fn: (err: E) => AnzenAnyResult<F, V>): AnzenAnyResult<F, 
 | `fn`      | `(err: E) => Result` | Function that produces a recovery Result from the error value. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success, failure } from '@daisugi/anzen';
 
-const result = Result.failure('err')
-  .elseChain((err) => Result.success('foo'))
+const result = failure('err')
+  .elseChain((err) => success('foo'))
   .getValue();
 // 'foo'
 ```
@@ -323,7 +325,7 @@ const result = Result.failure('err')
 
 ### `result.elseMap(fn)`
 
-For a failure Result, transforms the error value using `fn` and wraps the return in a new `Result.success`. Passes through unchanged on success.
+For a failure Result, transforms the error value using `fn` and wraps the return in a new success Result. Passes through unchanged on success.
 
 ```ts
 result.elseMap<V>(fn: (err: E) => V): ResultSuccess<T | V>
@@ -334,9 +336,9 @@ result.elseMap<V>(fn: (err: E) => V): ResultSuccess<T | V>
 | `fn`      | `(err: E) => V` | Transform applied to the error value. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { failure } from '@daisugi/anzen';
 
-const result = Result.failure('err')
+const result = failure('err')
   .elseMap((err) => 'foo')
   .getValue();
 // 'foo'
@@ -361,12 +363,12 @@ result.unwrap<V>(defaultValue?: V): [ResultFailure<E>, V]
 | `defaultValue` | `V`  | Value used as the second tuple element when the Result is a failure. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success, failure } from '@daisugi/anzen';
 
-const [res, value] = Result.success('foo').unwrap();
+const [res, value] = success('foo').unwrap();
 // res is the ResultSuccess instance, value is 'foo'
 
-const [errRes, output] = Result.failure('err').unwrap('foo');
+const [errRes, output] = failure('err').unwrap('foo');
 // errRes is the ResultFailure instance, output is 'foo'
 ```
 
@@ -381,9 +383,9 @@ result.unsafeUnwrap(): T | E
 ```
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { failure } from '@daisugi/anzen';
 
-const output = Result.failure('err').unsafeUnwrap();
+const output = failure('err').unsafeUnwrap();
 // 'err'
 ```
 
@@ -398,23 +400,23 @@ result.toJSON(): string
 ```
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success, failure } from '@daisugi/anzen';
 
-Result.success('foo').toJSON();
+success('foo').toJSON();
 // '{"value":"foo","isSuccess":true}'
 
-Result.failure('err').toJSON();
+failure('err').toJSON();
 // '{"error":"err","isSuccess":false}'
 ```
 
 ---
 
-### `Result.fromJSON(json)`
+### `fromJSON(json)`
 
 Deserializes a JSON string (as produced by `toJSON`) into a Result instance.
 
 ```ts
-Result.fromJSON<E = unknown, T = unknown>(json: string): AnzenAnyResult<E, T>
+fromJSON<E = unknown, T = unknown>(json: string): AnzenAnyResult<E, T>
 ```
 
 | Parameter | Type     | Description                                    |
@@ -422,20 +424,20 @@ Result.fromJSON<E = unknown, T = unknown>(json: string): AnzenAnyResult<E, T>
 | `json`    | `string` | A JSON string previously produced by `toJSON`. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { fromJSON } from '@daisugi/anzen';
 
-const value = Result.fromJSON('{"value":"foo","isSuccess":true}').getValue();
+const value = fromJSON('{"value":"foo","isSuccess":true}').getValue();
 // 'foo'
 ```
 
 ---
 
-### `Result.promiseAll(results)`
+### `promiseAll(results)`
 
 Runs an array of Results or Promises of Results in parallel. Returns a success Result containing an array of all values if every entry succeeds, or the first failure encountered.
 
 ```ts
-Result.promiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
+promiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
   whenRes: T,
 ): Promise<AnzenResultSuccess<ExtractSuccess<T>> | AnzenResultFailure<ExtractFailure<T>>>
 ```
@@ -445,11 +447,11 @@ Result.promiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAny
 | `whenRes` | `(Result \| Promise<Result>)[]` | Results or Promises of Results to run in parallel. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success, promiseAll } from '@daisugi/anzen';
 
-const result = await Result.promiseAll([
-  Result.success('foo'),
-  Promise.resolve(Result.success('bar')),
+const result = await promiseAll([
+  success('foo'),
+  Promise.resolve(success('bar')),
 ]);
 
 result.getValue(); // ['foo', 'bar']
@@ -458,8 +460,10 @@ result.getValue(); // ['foo', 'bar']
 On failure:
 
 ```js
-const result = await Result.promiseAll([
-  Result.failure('err'),
+import { failure, promiseAll } from '@daisugi/anzen';
+
+const result = await promiseAll([
+  failure('err'),
 ]);
 
 result.getError(); // 'err'
@@ -467,12 +471,12 @@ result.getError(); // 'err'
 
 ---
 
-### `Result.unwrapPromiseAll([defaults, ...results])`
+### `unwrapPromiseAll([defaults, ...results])`
 
 Runs an array of Results or Promises of Results in parallel and unwraps them. The first element of the returned tuple is a Result representing the overall outcome; the remaining elements are the individual unwrapped values (or defaults on failure).
 
 ```ts
-Result.unwrapPromiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
+unwrapPromiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
   args: [Partial<ExtractSuccess<T>>, ...T],
 ): Promise<[AnzenResultSuccess<ExtractSuccess<T>> | AnzenResultFailure<ExtractFailure<T>>, ...ExtractSuccess<T>]>
 ```
@@ -483,12 +487,12 @@ Result.unwrapPromiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<An
 | `args[1..n]` | `Result \| Promise<Result>`  | Results or Promises of Results to run in parallel.                                                                                                                     |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { success, unwrapPromiseAll } from '@daisugi/anzen';
 
-const [res, val1, val2] = await Result.unwrapPromiseAll([
+const [res, val1, val2] = await unwrapPromiseAll([
   [], // defaults
-  Result.success('foo'),
-  Promise.resolve(Result.success('bar')),
+  success('foo'),
+  Promise.resolve(success('bar')),
 ]);
 
 res.isSuccess; // true
@@ -498,12 +502,12 @@ val2; // 'bar'
 
 ---
 
-### `Result.unwrap(defaultValue?)`
+### `unwrap(defaultValue?)`
 
 Returns a function that unpacks a Result into a tuple `[result, value]`, for use as a `.then()` callback. The second element is the success value, or `defaultValue` on failure.
 
 ```ts
-Result.unwrap<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [AnzenAnyResult<unknown, unknown>, unknown | V]
+unwrap<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [AnzenAnyResult<unknown, unknown>, unknown | V]
 ```
 
 | Parameter      | Type | Description                                        |
@@ -511,21 +515,21 @@ Result.unwrap<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) =
 | `defaultValue` | `V`  | Value used as the second tuple element on failure. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { failure, unwrap } from '@daisugi/anzen';
 
-const fn = async () => Result.failure('err');
-const [res, output] = await fn().then(Result.unwrap('foo'));
-// res is the Result.failure instance, output is 'foo'
+const fn = async () => failure('err');
+const [res, output] = await fn().then(unwrap('foo'));
+// res is the failure instance, output is 'foo'
 ```
 
 ---
 
-### `Result.fromThrowable(fn, parseErr?)`
+### `fromThrowable(fn, parseErr?)`
 
 Executes an async function that may throw. Returns a success Result with the resolved value, or a failure Result with the error passed through `parseErr`.
 
 ```ts
-Result.fromThrowable<E = unknown, T = unknown>(
+fromThrowable<E = unknown, T = unknown>(
   fn: () => Promise<T>,
   parseErr?: (err: unknown) => E,
 ): Promise<AnzenAnyResult<E, T>>
@@ -537,9 +541,9 @@ Result.fromThrowable<E = unknown, T = unknown>(
 | `parseErr` | `(err: unknown) => E` | Optional transform applied to a caught error. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { fromThrowable } from '@daisugi/anzen';
 
-const result = await Result.fromThrowable(
+const result = await fromThrowable(
   async () => { throw new Error('err') },
   (err) => err.message,
 );
@@ -549,12 +553,12 @@ result.getError(); // 'err'
 
 ---
 
-### `Result.fromSyncThrowable(fn, parseErr?)`
+### `fromSyncThrowable(fn, parseErr?)`
 
 Same as `fromThrowable`, but for synchronous functions.
 
 ```ts
-Result.fromSyncThrowable<E = unknown, T = unknown>(
+fromSyncThrowable<E = unknown, T = unknown>(
   fn: () => T,
   parseErr?: (err: unknown) => E,
 ): AnzenAnyResult<E, T>
@@ -566,9 +570,9 @@ Result.fromSyncThrowable<E = unknown, T = unknown>(
 | `parseErr` | `(err: unknown) => E` | Optional transform applied to a caught error. |
 
 ```js
-import { Result } from '@daisugi/anzen';
+import { fromSyncThrowable } from '@daisugi/anzen';
 
-const result = Result.fromSyncThrowable(
+const result = fromSyncThrowable(
   () => { throw new Error('err') },
   (err) => err.message,
 );
@@ -586,24 +590,25 @@ Anzen is fully written in TypeScript and ships its own types. Both `AnzenResultS
 
 ```ts
 import {
-  Result,
+  success,
+  failure,
   type AnzenResultSuccess,
   type AnzenResultFailure,
 } from '@daisugi/anzen';
 
 function foo(): AnzenResultSuccess<string> {
-  return Result.success('foo');
+  return success('foo');
 }
 
 function bar(): AnzenResultFailure<string> {
-  return Result.failure('err');
+  return failure('err');
 }
 
 function baz(): AnzenResultSuccess<number> | AnzenResultFailure<string> {
   if (Math.random() > 0.5) {
-    return Result.success(42);
+    return success(42);
   }
-  return Result.failure('err');
+  return failure('err');
 }
 ```
 

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -64,6 +64,7 @@ Every combinator is a standalone named export, so unused helpers are tree-shaken
   - [📚 API](#-api)
     - [`success(value)`](#successvalue)
     - [`failure(err)`](#failureerr)
+    - [`isAnzenResult(value)`](#isanzenresultvalue)
     - [`result.isSuccess / result.isFailure`](#resultissuccess--resultisfailure)
     - [`result.unwrap()`](#resultunwrap)
     - [`result.unwrapErr()`](#resultunwraperr)
@@ -177,6 +178,30 @@ failure<E>(err: E): ResultFailure<E>
 import { failure } from '@daisugi/anzen';
 
 const res = failure('err');
+```
+
+---
+
+### `isAnzenResult(value)`
+
+Type guard that narrows an `unknown` value to a `Result`. It checks a
+registry-global brand (`Symbol.for('@daisugi/anzen')`) stamped on every
+Result, so it stays reliable across realms/bundles where `instanceof`
+would fail (e.g. when more than one copy of the package is loaded).
+
+```ts
+isAnzenResult(value: unknown): value is ResultSuccess<unknown> | ResultFailure<unknown>
+```
+
+| Parameter | Type      | Description           |
+| --------- | --------- | --------------------- |
+| `value`   | `unknown` | The value to test.    |
+
+```js
+import { success, isAnzenResult } from '@daisugi/anzen';
+
+isAnzenResult(success('foo')); // true
+isAnzenResult({ isSuccess: true }); // false (not branded)
 ```
 
 ---

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -17,7 +17,9 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 📦 Uses only trusted dependencies
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
-- 🤝 Used in production
+- 🤝 Used in production by millions of users
+- 🌳 Tree-shakeable
+- 🌐 Universal — runs in the browser and on the server (Node.js)
 - 🔀 Supports both ES Modules and CommonJS
 
 ---

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -129,18 +129,14 @@ pnpm install @daisugi/anzen
 
 ## 🎯 Motivation
 
-Anzen was created to provide a simple and predictable way to handle errors, eliminating unexpected exceptions. It is especially useful when:
+Anzen was created to bring explicit, typed error handling to JavaScript without the ceremony of try/catch blocks. If these requirements align with yours, Anzen may be a good fit. Otherwise, alternatives like [True-Myth](https://true-myth.js.org/) or [neverthrow](https://github.com/supermacro/neverthrow) might be worth exploring.
 
-- Early failures need to be caught and handled at the call site.
-- You prefer explicit, sequential error handling over try/catch blocks.
-- You require improved TypeScript support with typed error and value paths.
-- You want a minimal API that covers common use cases without mimicking other languages' patterns entirely.
+### ✅ Key Requirements
 
-**Sequential over chainable.** Anzen intentionally does not ship a chainable `ResultAsync` thenable. In practice, multi-step async flows almost always need earlier bindings available in later steps. A method chain ends up as verbose as the sequential alternative — with added runtime overhead.
-
-**Fail-fast with unsafe unwraps.** `unwrap()` and `unwrapErr()` throw on the wrong variant by design. Use them after an `isOk` / `isErr` guard, or to assert a programmer bug — throwing at the call site surfaces problems earlier than a silent fallback would.
-
-If you are looking for a robust Result-pattern implementation, Anzen might be the right choice. Alternatives include [True-Myth](https://true-myth.js.org/) or [Folktale](https://folktale.origamitower.com/).
+- Errors and values are both typed — no `unknown` catch clauses or silent swallowing.
+- Sequential `await` + `isOk` / `isErr` guards over chainable async pipelines: multi-step flows need earlier bindings in later steps, and a method chain is no less verbose while adding runtime overhead.
+- `unwrap()` / `unwrapErr()` throw on the wrong variant by design — use them after a guard or to assert a programmer bug, so failures surface at the call site rather than propagating silently.
+- Minimal API with no global state, no decorators, and no runtime dependencies.
 
 [:top: Back to top](#-table-of-contents)
 

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -82,6 +82,10 @@ Every combinator is a standalone named export, so unused helpers are tree-shaken
     - [`toTuple(defaultValue?)`](#totupledefaultvalue)
     - [`fromThrowable(fn, parseErr?)`](#fromthrowablefn-parseerr)
     - [`fromSyncThrowable(fn, parseErr?)`](#fromsyncthrowablefn-parseerr)
+    - [`AsyncResult<E, T>`](#asyncresulte-t)
+    - [`okAsync(value)` / `errAsync(error)`](#okasyncvalue--errasyncerror)
+    - [`fromPromise(promise, parseErr?)`](#frompromisepromise-parseerr)
+    - [`fromSafePromise(promise)`](#fromsafepromisepromise)
   - [🔷 TypeScript Support](#-typescript-support)
   - [🎯 Goal](#-goal)
   - [🌍 Other Projects](#-other-projects)
@@ -114,7 +118,7 @@ pnpm install @daisugi/anzen
 - ✅ `ok` and `err` constructors for wrapping values and errors
 - ✅ Chainable `.map` / `.andThen` transforms for Ok paths
 - ✅ Mirror `.mapErr` / `.orElse` transforms for Err paths
-- ✅ Async helpers: `promiseAll` and `fromThrowable`
+- ✅ Async helpers: `promiseAll`, `fromThrowable`, and a chainable `AsyncResult` (`okAsync` / `errAsync` / `fromPromise`)
 - ✅ JSON serialization and deserialization
 - ✅ TypeScript-first with full type inference on all operations
 - ✅ Integration with [@daisugi/ayamari](../ayamari) for rich, structured error objects
@@ -603,6 +607,102 @@ const result = fromSyncThrowable(
 );
 
 result.unwrapErr(); // 'err'
+```
+
+[:top: Back to top](#-table-of-contents)
+
+---
+
+### `AsyncResult<E, T>`
+
+A thenable that carries the Result combinators across an async boundary, so I/O-heavy code can keep chaining instead of awaiting and re-wrapping at every step. `await`-ing an `AsyncResult` yields the underlying `Result`. Built with `okAsync` / `errAsync` / `fromPromise` / `fromSafePromise`.
+
+It mirrors the synchronous combinators — `map`, `mapErr`, `andThen`, `orElse` — whose callbacks may be sync or async, plus the awaitable terminals `unwrap()` / `unwrapErr()` / `unwrapOr(defaultValue)` (each returns a `Promise`).
+
+```ts
+class AsyncResult<E, T> implements PromiseLike<ResultOk<T> | ResultErr<E>> {
+  map<U>(fn: (val: T) => U | Promise<U>): AsyncResult<E, U>;
+  mapErr<U>(fn: (error: E) => U | Promise<U>): AsyncResult<U, T>;
+  andThen<U, F>(fn: (val: T) => Result<F, U> | AsyncResult<F, U> | Promise<Result<F, U>>): AsyncResult<E | F, U>;
+  orElse<U, F>(fn: (error: E) => Result<F, U> | AsyncResult<F, U> | Promise<Result<F, U>>): AsyncResult<F, T | U>;
+  unwrap(): Promise<T>;
+  unwrapErr(): Promise<E>;
+  unwrapOr<V>(defaultValue: V): Promise<T | V>;
+}
+```
+
+```js
+import { fromPromise } from '@daisugi/anzen';
+
+const res = await fromPromise(fetch('/api/user'), (e) => e.message)
+  .andThen((response) => fromPromise(response.json(), (e) => e.message))
+  .map((user) => user.name);
+
+if (res.isOk) {
+  console.log(res.unwrap());
+}
+```
+
+[:top: Back to top](#-table-of-contents)
+
+---
+
+### `okAsync(value)` / `errAsync(error)`
+
+Create an already-settled `AsyncResult`, the async counterparts of `ok` / `err`.
+
+```ts
+okAsync<T>(value: T): AsyncResult<never, T>
+errAsync<E>(error: E): AsyncResult<E, never>
+```
+
+```js
+import { okAsync, errAsync } from '@daisugi/anzen';
+
+await okAsync(1).map((x) => x + 1); // Ok(2)
+await errAsync('boom').unwrapOr(0); // 0
+```
+
+[:top: Back to top](#-table-of-contents)
+
+---
+
+### `fromPromise(promise, parseErr?)`
+
+Lifts a `Promise` that may reject into an `AsyncResult`: a resolved value becomes `Ok`, a rejection becomes `Err`. Without `parseErr` the error type is `unknown` — pass `parseErr` to obtain a typed error (matching neverthrow's `fromPromise(promise, errorFn)` contract).
+
+```ts
+fromPromise<T, E = unknown>(promise: Promise<T>, parseErr?: (error: unknown) => E): AsyncResult<E, T>
+```
+
+| Parameter  | Type                       | Description                                |
+| ---------- | -------------------------- | ------------------------------------------ |
+| `promise`  | `Promise<T>`               | A promise that may reject.                 |
+| `parseErr` | `(error: unknown) => E`    | Optional. Maps a rejection to a typed `E`. |
+
+```js
+import { fromPromise } from '@daisugi/anzen';
+
+const res = await fromPromise(Promise.reject(new Error('x')), (e) => e.message);
+res.unwrapErr(); // 'x'
+```
+
+[:top: Back to top](#-table-of-contents)
+
+---
+
+### `fromSafePromise(promise)`
+
+Lifts a `Promise` that is already known not to reject (it resolves to a `Result`) into an `AsyncResult`.
+
+```ts
+fromSafePromise<E, T>(promise: Promise<ResultOk<T> | ResultErr<E>>): AsyncResult<E, T>
+```
+
+```js
+import { ok, fromSafePromise } from '@daisugi/anzen';
+
+await fromSafePromise(Promise.resolve(ok(1))).map((x) => x + 1); // Ok(2)
 ```
 
 [:top: Back to top](#-table-of-contents)

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -619,9 +619,25 @@ function safeTry<E, T>(
 | --------- | ----------------------------------- | ---------------------------------------------------------------- |
 | `body`    | `() => Generator \| AsyncGenerator` | Generator that `yield*`s Results and returns the final `Result`. |
 
+**Sync example** — plain `function*`, returns a `Result` directly (no `Promise`):
+
 ```js
 import { safeTry, ok, err } from '@daisugi/anzen';
 
+const divide = (a, b) =>
+  safeTry(function* () {
+    const validated = yield* validatePositive(b); // short-circuits on Err
+    return ok(a / validated);
+  });
+
+const res = divide(10, 0);
+if (res.isErr) console.warn(res.unwrapErr()); // { kind: 'nonPositive' }
+else console.log(res.unwrap());               // number
+```
+
+**Async example** — `async function*`, returns a `Promise<Result>`:
+
+```js
 const checkout = (userId, amount) =>
   safeTry(async function* () {
     const user = yield* await userRepo.find(userId);

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -27,28 +27,24 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 ## 🚀 Usage
 
 ```js
-import { ok, err } from '@daisugi/anzen';
+import { fromThrowable } from '@daisugi/anzen';
 import { readFileSync } from 'node:fs';
 
-function readFile(path) {
-  try {
-    const response = readFileSync(path);
-    return ok(response);
-  } catch (error) {
-    return err(error);
-  }
-}
+// Adapt the throwing API once, at the boundary, into a reusable
+// Result-returning function. No hand-written try/catch at the call site.
+const readFile = fromThrowable(
+  (path) => readFileSync(path, 'utf8'),
+  (error) => error.message,
+);
 
 const result = readFile('test.txt');
 
 if (result.isErr) {
-  return result.unwrapErr();
+  console.error(result.unwrapErr()); // the parsed error message
+} else {
+  console.log(result.unwrap()); // the file contents
 }
-
-return result.unwrap();
 ```
-
-Every combinator is a standalone named export, so unused helpers are tree-shaken away — `import { ok }` pulls in nothing else.
 
 ---
 
@@ -133,9 +129,9 @@ Anzen was created to bring explicit, typed error handling to JavaScript without 
 
 ### ✅ Key Requirements
 
-- Errors and values are both typed — no `unknown` catch clauses or silent swallowing.
+- Errors and values are both typed - no `unknown` catch clauses or silent swallowing.
 - Sequential `await` + `isOk` / `isErr` guards over chainable async pipelines: multi-step flows need earlier bindings in later steps, and a method chain is no less verbose while adding runtime overhead.
-- `unwrap()` / `unwrapErr()` throw on the wrong variant by design — use them after a guard or to assert a programmer bug, so failures surface at the call site rather than propagating silently.
+- `unwrap()` / `unwrapErr()` throw on the wrong variant by design - use them after a guard or to assert a programmer bug, so failures surface at the call site rather than propagating silently.
 - Minimal API with no global state, no decorators, and no runtime dependencies.
 
 [:top: Back to top](#-table-of-contents)
@@ -230,7 +226,7 @@ console.log(errRes.isErr); // true
 
 ### `result.unwrap()`
 
-Returns the Ok value. Throws if the Result is an Err — guard with `result.isOk` or use `unwrapOr` for a safe alternative.
+Returns the Ok value. Throws if the Result is an Err - guard with `result.isOk` or use `unwrapOr` for a safe alternative.
 
 ```ts
 result.unwrap(): T
@@ -247,7 +243,7 @@ const value = ok('foo').unwrap();
 
 ### `result.unwrapErr()`
 
-Returns the error value. Throws if the Result is an Ok — guard with `result.isErr`.
+Returns the error value. Throws if the Result is an Ok - guard with `result.isErr`.
 
 ```ts
 result.unwrapErr(): E
@@ -380,10 +376,10 @@ const result = err('err')
 Returns a tuple `[result, value]`. On Ok, the second element is the wrapped value. On Err, the second element is `defaultValue` (or `undefined` if omitted).
 
 ```ts
-// On ResultOk — no argument needed:
+// On ResultOk - no argument needed:
 result.toTuple(): [ResultOk<T>, T]
 
-// On ResultErr — optional default:
+// On ResultErr - optional default:
 result.toTuple<V>(defaultValue?: V): [ResultErr<E>, V]
 ```
 
@@ -602,7 +598,7 @@ if (res.isOk) console.log(res.unwrap());
 
 ### `safeTry(body)`
 
-Rust's `?`-operator for Results, built on generators. Inside the generator body, `yield* result` unwraps an `Ok` to its value or aborts the whole body, making `safeTry` return that `Err`. This keeps a chain of dependent, fallible steps in plain control flow — local `const`s, `if` branches, loops — without an `isErr` guard after every call.
+Rust's `?`-operator for Results, built on generators. Inside the generator body, `yield* result` unwraps an `Ok` to its value or aborts the whole body, making `safeTry` return that `Err`. This keeps a chain of dependent, fallible steps in plain control flow - local `const`s, `if` branches, loops - without an `isErr` guard after every call.
 
 A synchronous generator (`function*`) returns a `Result`; an async one (`async function*`, using `yield* await ...`) returns a `Promise` of one. The error type is inferred as the union of every yielded Result's error.
 
@@ -619,7 +615,7 @@ function safeTry<E, T>(
 | --------- | ----------------------------------- | ---------------------------------------------------------------- |
 | `body`    | `() => Generator \| AsyncGenerator` | Generator that `yield*`s Results and returns the final `Result`. |
 
-**Sync example** — plain `function*`, returns a `Result` directly (no `Promise`):
+**Sync example** - plain `function*`, returns a `Result` directly (no `Promise`):
 
 ```js
 import { safeTry, ok, err } from '@daisugi/anzen';
@@ -635,7 +631,7 @@ if (res.isErr) console.warn(res.unwrapErr()); // { kind: 'nonPositive' }
 else console.log(res.unwrap());               // number
 ```
 
-**Async example** — `async function*`, returns a `Promise<Result>`:
+**Async example** - `async function*`, returns a `Promise<Result>`:
 
 ```js
 const checkout = (userId, amount) =>
@@ -645,7 +641,7 @@ const checkout = (userId, amount) =>
 
     const receipt = yield* await payments.charge(user.cardToken, amount);
 
-    // Return the final Result directly — do not `yield*` it, or you would
+    // Return the final Result directly - do not `yield*` it, or you would
     // return the unwrapped value instead of a Result.
     return await userRepo.saveOrder({
       userId: user.id,
@@ -667,7 +663,7 @@ The first `Err` short-circuits: every step after it is skipped and that error fl
 
 ## 🧩 Composition Styles Side by Side
 
-The same flow — look up a user, charge their card, persist the order — written two ways. Each step is async and fallible. Both share **one boundary layer**: every throwing dependency is adapted to a Result exactly once with `fromAsyncThrowable`, so neither call site repeats that wrapping.
+The same flow - look up a user, charge their card, persist the order - written two ways. Each step is async and fallible. Both share **one boundary layer**: every throwing dependency is adapted to a Result exactly once with `fromAsyncThrowable`, so neither call site repeats that wrapping.
 
 ```ts
 import {

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -27,28 +27,28 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 ## 🚀 Usage
 
 ```js
-import { success, failure } from '@daisugi/anzen';
+import { ok, err } from '@daisugi/anzen';
 import { readFileSync } from 'node:fs';
 
 function readFile(path) {
   try {
     const response = readFileSync(path);
-    return success(response);
-  } catch (err) {
-    return failure(err);
+    return ok(response);
+  } catch (error) {
+    return err(error);
   }
 }
 
 const result = readFile('test.txt');
 
-if (result.isFailure) {
+if (result.isErr) {
   return result.unwrapErr();
 }
 
 return result.unwrap();
 ```
 
-Every combinator is a standalone named export, so unused helpers are tree-shaken away — `import { success }` pulls in nothing else.
+Every combinator is a standalone named export, so unused helpers are tree-shaken away — `import { ok }` pulls in nothing else.
 
 ---
 
@@ -62,10 +62,10 @@ Every combinator is a standalone named export, so unused helpers are tree-shaken
   - [🔍 Overview](#-overview)
   - [🎯 Motivation](#-motivation)
   - [📚 API](#-api)
-    - [`success(value)`](#successvalue)
-    - [`failure(err)`](#failureerr)
+    - [`ok(value)`](#okvalue)
+    - [`err(error)`](#errerror)
     - [`isAnzenResult(value)`](#isanzenresultvalue)
-    - [`result.isSuccess / result.isFailure`](#resultissuccess--resultisfailure)
+    - [`result.isOk / result.isErr`](#resultisok--resultiserr)
     - [`result.unwrap()`](#resultunwrap)
     - [`result.unwrapErr()`](#resultunwraperr)
     - [`result.unwrapOr(defaultValue)`](#resultunwrapordefaultvalue)
@@ -111,9 +111,9 @@ pnpm install @daisugi/anzen
 
 **Anzen** replaces thrown exceptions with an explicit `Result` type, making error paths visible in function signatures and composable with standard transforms. It provides:
 
-- ✅ `success` and `failure` constructors for wrapping values and errors
-- ✅ Chainable `.map` / `.andThen` transforms for success paths
-- ✅ Mirror `.mapErr` / `.orElse` transforms for failure paths
+- ✅ `ok` and `err` constructors for wrapping values and errors
+- ✅ Chainable `.map` / `.andThen` transforms for Ok paths
+- ✅ Mirror `.mapErr` / `.orElse` transforms for Err paths
 - ✅ Async helpers: `promiseAll` and `fromThrowable`
 - ✅ JSON serialization and deserialization
 - ✅ TypeScript-first with full type inference on all operations
@@ -140,44 +140,44 @@ If you are looking for a robust Result-pattern implementation, Anzen might be th
 
 ## 📚 API
 
-A `Result` instance is either a `ResultSuccess<T>` or a `ResultFailure<E>`. The standalone `success` / `failure` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `toTuple` / `fromThrowable` / `fromSyncThrowable` exports create or combine instances; instance methods transform or extract values.
+A `Result` instance is either a `ResultOk<T>` or a `ResultErr<E>`. The standalone `ok` / `err` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `toTuple` / `fromThrowable` / `fromSyncThrowable` exports create or combine instances; instance methods transform or extract values.
 
-### `success(value)`
+### `ok(value)`
 
 Creates a successful Result wrapping the given value.
 
 ```ts
-success<T>(value: T): ResultSuccess<T>
+ok<T>(value: T): ResultOk<T>
 ```
 
 | Parameter | Type | Description                |
 | --------- | ---- | -------------------------- |
-| `value`   | `T`  | The success value to wrap. |
+| `value`   | `T`  | The Ok value to wrap. |
 
 ```js
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
-const res = success('foo');
+const res = ok('foo');
 ```
 
 ---
 
-### `failure(err)`
+### `err(error)`
 
-Creates a failure Result wrapping the given error.
+Creates an Err Result wrapping the given error.
 
 ```ts
-failure<E>(err: E): ResultFailure<E>
+err<E>(error: E): ResultErr<E>
 ```
 
 | Parameter | Type | Description              |
 | --------- | ---- | ------------------------ |
-| `err`     | `E`  | The error value to wrap. |
+| `error`   | `E`  | The error value to wrap. |
 
 ```js
-import { failure } from '@daisugi/anzen';
+import { err } from '@daisugi/anzen';
 
-const res = failure('err');
+const res = err('err');
 ```
 
 ---
@@ -190,7 +190,7 @@ Result, so it stays reliable across realms/bundles where `instanceof`
 would fail (e.g. when more than one copy of the package is loaded).
 
 ```ts
-isAnzenResult(value: unknown): value is ResultSuccess<unknown> | ResultFailure<unknown>
+isAnzenResult(value: unknown): value is ResultOk<unknown> | ResultErr<unknown>
 ```
 
 | Parameter | Type      | Description           |
@@ -198,44 +198,44 @@ isAnzenResult(value: unknown): value is ResultSuccess<unknown> | ResultFailure<u
 | `value`   | `unknown` | The value to test.    |
 
 ```js
-import { success, isAnzenResult } from '@daisugi/anzen';
+import { ok, isAnzenResult } from '@daisugi/anzen';
 
-isAnzenResult(success('foo')); // true
-isAnzenResult({ isSuccess: true }); // false (not branded)
+isAnzenResult(ok('foo')); // true
+isAnzenResult({ isOk: true }); // false (not branded)
 ```
 
 ---
 
-### `result.isSuccess / result.isFailure`
+### `result.isOk / result.isErr`
 
-Boolean properties that indicate whether the Result represents a success or a failure. Exactly one is `true` at any time.
+Boolean properties that indicate whether the Result represents an Ok or an Err. Exactly one is `true` at any time.
 
 ```js
-import { success, failure } from '@daisugi/anzen';
+import { ok, err } from '@daisugi/anzen';
 
-const res = success('foo');
-console.log(res.isSuccess); // true
-console.log(res.isFailure); // false
+const res = ok('foo');
+console.log(res.isOk); // true
+console.log(res.isErr); // false
 
-const errRes = failure('err');
-console.log(errRes.isSuccess); // false
-console.log(errRes.isFailure); // true
+const errRes = err('err');
+console.log(errRes.isOk); // false
+console.log(errRes.isErr); // true
 ```
 
 ---
 
 ### `result.unwrap()`
 
-Returns the success value. Throws if the Result is a failure — guard with `result.isSuccess` or use `unwrapOr` for a safe alternative.
+Returns the Ok value. Throws if the Result is an Err — guard with `result.isOk` or use `unwrapOr` for a safe alternative.
 
 ```ts
 result.unwrap(): T
 ```
 
 ```js
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
-const value = success('foo').unwrap();
+const value = ok('foo').unwrap();
 // 'foo'
 ```
 
@@ -243,16 +243,16 @@ const value = success('foo').unwrap();
 
 ### `result.unwrapErr()`
 
-Returns the error value. Throws if the Result is a success — guard with `result.isFailure`.
+Returns the error value. Throws if the Result is an Ok — guard with `result.isErr`.
 
 ```ts
 result.unwrapErr(): E
 ```
 
 ```js
-import { failure } from '@daisugi/anzen';
+import { err } from '@daisugi/anzen';
 
-const error = failure('err').unwrapErr();
+const error = err('err').unwrapErr();
 // 'err'
 ```
 
@@ -260,7 +260,7 @@ const error = failure('err').unwrapErr();
 
 ### `result.unwrapOr(defaultValue)`
 
-Returns the success value, or `defaultValue` if the Result is a failure. Never throws.
+Returns the Ok value, or `defaultValue` if the Result is an Err. Never throws.
 
 ```ts
 result.unwrapOr<V>(defaultValue: V): T | V
@@ -268,12 +268,12 @@ result.unwrapOr<V>(defaultValue: V): T | V
 
 | Parameter      | Type | Description                         |
 | -------------- | ---- | ----------------------------------- |
-| `defaultValue` | `V`  | Fallback value returned on failure. |
+| `defaultValue` | `V`  | Fallback value returned on Err. |
 
 ```js
-import { failure } from '@daisugi/anzen';
+import { err } from '@daisugi/anzen';
 
-const value = failure('err').unwrapOr('foo');
+const value = err('err').unwrapOr('foo');
 // 'foo'
 ```
 
@@ -281,20 +281,20 @@ const value = failure('err').unwrapOr('foo');
 
 ### `result.map(fn)`
 
-Applies `fn` to the success value and wraps the return in a new success Result. Passes through unchanged on failure.
+Applies `fn` to the Ok value and wraps the return in a new Ok Result. Passes through unchanged on Err.
 
 ```ts
-result.map<V>(fn: (value: T) => V): ResultSuccess<V> | ResultFailure<E>
+result.map<V>(fn: (value: T) => V): ResultOk<V> | ResultErr<E>
 ```
 
 | Parameter | Type              | Description                             |
 | --------- | ----------------- | --------------------------------------- |
-| `fn`      | `(value: T) => V` | Transform applied to the success value. |
+| `fn`      | `(value: T) => V` | Transform applied to the Ok value. |
 
 ```js
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
-const result = success('foo')
+const result = ok('foo')
   .map((value) => value)
   .unwrap();
 // 'foo'
@@ -304,7 +304,7 @@ const result = success('foo')
 
 ### `result.andThen(fn)`
 
-Applies `fn` to the success value, where `fn` returns a new `Result`. Passes through unchanged on failure. Useful for sequencing operations that may themselves fail.
+Applies `fn` to the Ok value, where `fn` returns a new `Result`. Passes through unchanged on Err. Useful for sequencing operations that may themselves fail.
 
 ```ts
 result.andThen<V, F>(fn: (value: T) => AnzenAnyResult<F, V>): AnzenAnyResult<E | F, V>
@@ -312,13 +312,13 @@ result.andThen<V, F>(fn: (value: T) => AnzenAnyResult<F, V>): AnzenAnyResult<E |
 
 | Parameter | Type                   | Description                                                 |
 | --------- | ---------------------- | ----------------------------------------------------------- |
-| `fn`      | `(value: T) => Result` | Function that produces a new Result from the success value. |
+| `fn`      | `(value: T) => Result` | Function that produces a new Result from the Ok value. |
 
 ```js
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
-const result = success('foo')
-  .andThen((value) => success(value))
+const result = ok('foo')
+  .andThen((value) => ok(value))
   .unwrap();
 // 'foo'
 ```
@@ -327,7 +327,7 @@ const result = success('foo')
 
 ### `result.orElse(fn)`
 
-For a failure Result, applies `fn` to the error value, where `fn` returns a new Result. Passes through unchanged on success. Useful for recovering from errors.
+For an Err Result, applies `fn` to the error value, where `fn` returns a new Result. Passes through unchanged on Ok. Useful for recovering from errors.
 
 ```ts
 result.orElse<V, F>(fn: (err: E) => AnzenAnyResult<F, V>): AnzenAnyResult<F, T | V>
@@ -338,10 +338,10 @@ result.orElse<V, F>(fn: (err: E) => AnzenAnyResult<F, V>): AnzenAnyResult<F, T |
 | `fn`      | `(err: E) => Result` | Function that produces a recovery Result from the error value. |
 
 ```js
-import { success, failure } from '@daisugi/anzen';
+import { ok, err } from '@daisugi/anzen';
 
-const result = failure('err')
-  .orElse((err) => success('foo'))
+const result = err('err')
+  .orElse((err) => ok('foo'))
   .unwrap();
 // 'foo'
 ```
@@ -350,10 +350,10 @@ const result = failure('err')
 
 ### `result.mapErr(fn)`
 
-For a failure Result, transforms the error value using `fn` and wraps the return in a new success Result. Passes through unchanged on success.
+For an Err Result, transforms the error value using `fn` and wraps the return in a new Ok Result. Passes through unchanged on Ok.
 
 ```ts
-result.mapErr<V>(fn: (err: E) => V): ResultSuccess<T | V>
+result.mapErr<V>(fn: (err: E) => V): ResultOk<T | V>
 ```
 
 | Parameter | Type            | Description                           |
@@ -361,9 +361,9 @@ result.mapErr<V>(fn: (err: E) => V): ResultSuccess<T | V>
 | `fn`      | `(err: E) => V` | Transform applied to the error value. |
 
 ```js
-import { failure } from '@daisugi/anzen';
+import { err } from '@daisugi/anzen';
 
-const result = failure('err')
+const result = err('err')
   .mapErr((err) => 'foo')
   .unwrap();
 // 'foo'
@@ -373,44 +373,44 @@ const result = failure('err')
 
 ### `result.toTuple(defaultValue?)`
 
-Returns a tuple `[result, value]`. On success, the second element is the wrapped value. On failure, the second element is `defaultValue` (or `undefined` if omitted).
+Returns a tuple `[result, value]`. On Ok, the second element is the wrapped value. On Err, the second element is `defaultValue` (or `undefined` if omitted).
 
 ```ts
-// On ResultSuccess — no argument needed:
-result.toTuple(): [ResultSuccess<T>, T]
+// On ResultOk — no argument needed:
+result.toTuple(): [ResultOk<T>, T]
 
-// On ResultFailure — optional default:
-result.toTuple<V>(defaultValue?: V): [ResultFailure<E>, V]
+// On ResultErr — optional default:
+result.toTuple<V>(defaultValue?: V): [ResultErr<E>, V]
 ```
 
 | Parameter      | Type | Description                                                          |
 | -------------- | ---- | -------------------------------------------------------------------- |
-| `defaultValue` | `V`  | Value used as the second tuple element when the Result is a failure. |
+| `defaultValue` | `V`  | Value used as the second tuple element when the Result is an Err. |
 
 ```js
-import { success, failure } from '@daisugi/anzen';
+import { ok, err } from '@daisugi/anzen';
 
-const [res, value] = success('foo').toTuple();
-// res is the ResultSuccess instance, value is 'foo'
+const [res, value] = ok('foo').toTuple();
+// res is the ResultOk instance, value is 'foo'
 
-const [errRes, output] = failure('err').toTuple('foo');
-// errRes is the ResultFailure instance, output is 'foo'
+const [errRes, output] = err('err').toTuple('foo');
+// errRes is the ResultErr instance, output is 'foo'
 ```
 
 ---
 
 ### `result.getRaw()`
 
-Returns the inner value or error without any safety checks. Prefer `unwrap` / `unwrapErr` with an `isSuccess` / `isFailure` guard.
+Returns the inner value or error without any safety checks. Prefer `unwrap` / `unwrapErr` with an `isOk` / `isErr` guard.
 
 ```ts
 result.getRaw(): T | E
 ```
 
 ```js
-import { failure } from '@daisugi/anzen';
+import { err } from '@daisugi/anzen';
 
-const output = failure('err').getRaw();
+const output = err('err').getRaw();
 // 'err'
 ```
 
@@ -425,13 +425,13 @@ result.toJSON(): string
 ```
 
 ```js
-import { success, failure } from '@daisugi/anzen';
+import { ok, err } from '@daisugi/anzen';
 
-success('foo').toJSON();
-// '{"value":"foo","isSuccess":true}'
+ok('foo').toJSON();
+// '{"value":"foo","isOk":true}'
 
-failure('err').toJSON();
-// '{"error":"err","isSuccess":false}'
+err('err').toJSON();
+// '{"error":"err","isOk":false}'
 ```
 
 ---
@@ -451,7 +451,7 @@ fromJSON<E = unknown, T = unknown>(json: string): AnzenAnyResult<E, T>
 ```js
 import { fromJSON } from '@daisugi/anzen';
 
-const value = fromJSON('{"value":"foo","isSuccess":true}').unwrap();
+const value = fromJSON('{"value":"foo","isOk":true}').unwrap();
 // 'foo'
 ```
 
@@ -459,12 +459,12 @@ const value = fromJSON('{"value":"foo","isSuccess":true}').unwrap();
 
 ### `promiseAll(results)`
 
-Runs an array of Results or Promises of Results in parallel. Returns a success Result containing an array of all values if every entry succeeds, or the first failure encountered.
+Runs an array of Results or Promises of Results in parallel. Returns an Ok Result containing an array of all values if every entry succeeds, or the first Err encountered.
 
 ```ts
 promiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
   whenRes: T,
-): Promise<AnzenResultSuccess<ExtractSuccess<T>> | AnzenResultFailure<ExtractFailure<T>>>
+): Promise<AnzenResultOk<ExtractOk<T>> | AnzenResultErr<ExtractErr<T>>>
 ```
 
 | Parameter | Type                            | Description                                        |
@@ -472,23 +472,23 @@ promiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<
 | `whenRes` | `(Result \| Promise<Result>)[]` | Results or Promises of Results to run in parallel. |
 
 ```js
-import { success, promiseAll } from '@daisugi/anzen';
+import { ok, promiseAll } from '@daisugi/anzen';
 
 const result = await promiseAll([
-  success('foo'),
-  Promise.resolve(success('bar')),
+  ok('foo'),
+  Promise.resolve(ok('bar')),
 ]);
 
 result.unwrap(); // ['foo', 'bar']
 ```
 
-On failure:
+On Err:
 
 ```js
-import { failure, promiseAll } from '@daisugi/anzen';
+import { err, promiseAll } from '@daisugi/anzen';
 
 const result = await promiseAll([
-  failure('err'),
+  err('err'),
 ]);
 
 result.unwrapErr(); // 'err'
@@ -498,29 +498,29 @@ result.unwrapErr(); // 'err'
 
 ### `unwrapPromiseAll([defaults, ...results])`
 
-Runs an array of Results or Promises of Results in parallel and unwraps them. The first element of the returned tuple is a Result representing the overall outcome; the remaining elements are the individual unwrapped values (or defaults on failure).
+Runs an array of Results or Promises of Results in parallel and unwraps them. The first element of the returned tuple is a Result representing the overall outcome; the remaining elements are the individual unwrapped values (or defaults on Err).
 
 ```ts
 unwrapPromiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
-  args: [Partial<ExtractSuccess<T>>, ...T],
-): Promise<[AnzenResultSuccess<ExtractSuccess<T>> | AnzenResultFailure<ExtractFailure<T>>, ...ExtractSuccess<T>]>
+  args: [Partial<ExtractOk<T>>, ...T],
+): Promise<[AnzenResultOk<ExtractOk<T>> | AnzenResultErr<ExtractErr<T>>, ...ExtractOk<T>]>
 ```
 
 | Parameter    | Type                         | Description                                                                                                                                                            |
 | ------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `args[0]`    | `Partial<ExtractSuccess<T>>` | Default values returned as the remaining tuple elements on failure. Each default is type-checked against the corresponding success value type; pass `[]` to omit them. |
+| `args[0]`    | `Partial<ExtractOk<T>>` | Default values returned as the remaining tuple elements on Err. Each default is type-checked against the corresponding Ok value type; pass `[]` to omit them. |
 | `args[1..n]` | `Result \| Promise<Result>`  | Results or Promises of Results to run in parallel.                                                                                                                     |
 
 ```js
-import { success, unwrapPromiseAll } from '@daisugi/anzen';
+import { ok, unwrapPromiseAll } from '@daisugi/anzen';
 
 const [res, val1, val2] = await unwrapPromiseAll([
   [], // defaults
-  success('foo'),
-  Promise.resolve(success('bar')),
+  ok('foo'),
+  Promise.resolve(ok('bar')),
 ]);
 
-res.isSuccess; // true
+res.isOk; // true
 val1; // 'foo'
 val2; // 'bar'
 ```
@@ -529,7 +529,7 @@ val2; // 'bar'
 
 ### `toTuple(defaultValue?)`
 
-Returns a function that unpacks a Result into a tuple `[result, value]`, for use as a `.then()` callback. The second element is the success value, or `defaultValue` on failure.
+Returns a function that unpacks a Result into a tuple `[result, value]`, for use as a `.then()` callback. The second element is the Ok value, or `defaultValue` on Err.
 
 ```ts
 toTuple<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [AnzenAnyResult<unknown, unknown>, unknown | V]
@@ -537,21 +537,21 @@ toTuple<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [Anz
 
 | Parameter      | Type | Description                                        |
 | -------------- | ---- | -------------------------------------------------- |
-| `defaultValue` | `V`  | Value used as the second tuple element on failure. |
+| `defaultValue` | `V`  | Value used as the second tuple element on Err. |
 
 ```js
-import { failure, toTuple } from '@daisugi/anzen';
+import { err, toTuple } from '@daisugi/anzen';
 
-const fn = async () => failure('err');
+const fn = async () => err('err');
 const [res, output] = await fn().then(toTuple('foo'));
-// res is the failure instance, output is 'foo'
+// res is the Err instance, output is 'foo'
 ```
 
 ---
 
 ### `fromThrowable(fn, parseErr?)`
 
-Executes an async function that may throw. Returns a success Result with the resolved value, or a failure Result with the error passed through `parseErr`.
+Executes an async function that may throw. Returns an Ok Result with the resolved value, or an Err Result with the error passed through `parseErr`.
 
 ```ts
 fromThrowable<E = unknown, T = unknown>(
@@ -611,29 +611,29 @@ result.unwrapErr(); // 'err'
 
 ## 🔷 TypeScript Support
 
-Anzen is fully written in TypeScript and ships its own types. Both `AnzenResultSuccess<T>` and `AnzenResultFailure<E>` are exported for use in function signatures.
+Anzen is fully written in TypeScript and ships its own types. Both `AnzenResultOk<T>` and `AnzenResultErr<E>` are exported for use in function signatures.
 
 ```ts
 import {
-  success,
-  failure,
-  type AnzenResultSuccess,
-  type AnzenResultFailure,
+  ok,
+  err,
+  type AnzenResultOk,
+  type AnzenResultErr,
 } from '@daisugi/anzen';
 
-function foo(): AnzenResultSuccess<string> {
-  return success('foo');
+function foo(): AnzenResultOk<string> {
+  return ok('foo');
 }
 
-function bar(): AnzenResultFailure<string> {
-  return failure('err');
+function bar(): AnzenResultErr<string> {
+  return err('err');
 }
 
-function baz(): AnzenResultSuccess<number> | AnzenResultFailure<string> {
+function baz(): AnzenResultOk<number> | AnzenResultErr<string> {
   if (Math.random() > 0.5) {
-    return success(42);
+    return ok(42);
   }
-  return failure('err');
+  return err('err');
 }
 ```
 

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -446,7 +446,7 @@ const value = fromJSON('{"value":"foo","isOk":true}').unwrap();
 
 ### `promiseAll(results)`
 
-Runs an array of Results or Promises of Results in parallel. Returns an Ok Result containing an array of all values if every entry succeeds, or the first Err encountered. The failure branch is typed `unknown` because a wrapped Promise may reject with anything; use `fromAsyncThrowable`/`fromPromise` with a `parseErr` upstream if you need a typed error.
+Runs an array of Results or Promises of Results in parallel. Waits for every input to settle, then returns an Ok Result containing an array of all values if every entry succeeds, or the first Err in array order. The failure branch is typed `unknown` because a wrapped Promise may reject with anything; use `fromAsyncThrowable`/`fromPromise` with a `parseErr` upstream if you need a typed error.
 
 ```ts
 promiseAll<T extends (AnzenResult<unknown, unknown> | Promise<AnzenResult<unknown, unknown>>)[]>(

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -19,7 +19,7 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 🧪 Well-tested
 - 🤝 Used in production by millions of users
 - 🌳 Tree-shakeable
-- 🌐 Universal — runs in the browser and on the server (Node.js)
+- 🌐 Universal - runs in the browser and on the server (Node.js)
 - 🔀 Supports both ES Modules and CommonJS
 
 ---
@@ -154,8 +154,8 @@ Creates a successful Result wrapping the given value.
 ok<T>(value: T): ResultOk<T>
 ```
 
-| Parameter | Type | Description                |
-| --------- | ---- | -------------------------- |
+| Parameter | Type | Description           |
+| --------- | ---- | --------------------- |
 | `value`   | `T`  | The Ok value to wrap. |
 
 ```js
@@ -197,9 +197,9 @@ would fail (e.g. when more than one copy of the package is loaded).
 isAnzenResult(value: unknown): value is ResultOk<unknown> | ResultErr<unknown>
 ```
 
-| Parameter | Type      | Description           |
-| --------- | --------- | --------------------- |
-| `value`   | `unknown` | The value to test.    |
+| Parameter | Type      | Description        |
+| --------- | --------- | ------------------ |
+| `value`   | `unknown` | The value to test. |
 
 ```js
 import { ok, isAnzenResult } from '@daisugi/anzen';
@@ -270,8 +270,8 @@ Returns the Ok value, or `defaultValue` if the Result is an Err. Never throws.
 result.unwrapOr<V>(defaultValue: V): T | V
 ```
 
-| Parameter      | Type | Description                         |
-| -------------- | ---- | ----------------------------------- |
+| Parameter      | Type | Description                     |
+| -------------- | ---- | ------------------------------- |
 | `defaultValue` | `V`  | Fallback value returned on Err. |
 
 ```js
@@ -291,8 +291,8 @@ Applies `fn` to the Ok value and wraps the return in a new Ok Result. Passes thr
 result.map<V>(fn: (value: T) => V): ResultOk<V> | ResultErr<E>
 ```
 
-| Parameter | Type              | Description                             |
-| --------- | ----------------- | --------------------------------------- |
+| Parameter | Type              | Description                        |
+| --------- | ----------------- | ---------------------------------- |
 | `fn`      | `(value: T) => V` | Transform applied to the Ok value. |
 
 ```js
@@ -314,8 +314,8 @@ Applies `fn` to the Ok value, where `fn` returns a new `Result`. Passes through 
 result.andThen<V, F>(fn: (value: T) => AnzenAnyResult<F, V>): AnzenAnyResult<E | F, V>
 ```
 
-| Parameter | Type                   | Description                                                 |
-| --------- | ---------------------- | ----------------------------------------------------------- |
+| Parameter | Type                   | Description                                            |
+| --------- | ---------------------- | ------------------------------------------------------ |
 | `fn`      | `(value: T) => Result` | Function that produces a new Result from the Ok value. |
 
 ```js
@@ -387,8 +387,8 @@ result.toTuple(): [ResultOk<T>, T]
 result.toTuple<V>(defaultValue?: V): [ResultErr<E>, V]
 ```
 
-| Parameter      | Type | Description                                                          |
-| -------------- | ---- | -------------------------------------------------------------------- |
+| Parameter      | Type | Description                                                       |
+| -------------- | ---- | ----------------------------------------------------------------- |
 | `defaultValue` | `V`  | Value used as the second tuple element when the Result is an Err. |
 
 ```js
@@ -463,12 +463,12 @@ const value = fromJSON('{"value":"foo","isOk":true}').unwrap();
 
 ### `promiseAll(results)`
 
-Runs an array of Results or Promises of Results in parallel. Returns an Ok Result containing an array of all values if every entry succeeds, or the first Err encountered.
+Runs an array of Results or Promises of Results in parallel. Returns an Ok Result containing an array of all values if every entry succeeds, or the first Err encountered. The failure branch is typed `unknown` because a wrapped Promise may reject with anything; use `fromThrowable`/`fromPromise` with a `parseErr` upstream if you need a typed error.
 
 ```ts
 promiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
   whenRes: T,
-): Promise<AnzenResultOk<ExtractOk<T>> | AnzenResultErr<ExtractErr<T>>>
+): Promise<AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>>
 ```
 
 | Parameter | Type                            | Description                                        |
@@ -502,24 +502,24 @@ result.unwrapErr(); // 'err'
 
 ### `unwrapPromiseAll([defaults, ...results])`
 
-Runs an array of Results or Promises of Results in parallel and unwraps them. The first element of the returned tuple is a Result representing the overall outcome; the remaining elements are the individual unwrapped values (or defaults on Err).
+Runs an array of Results or Promises of Results in parallel and unwraps them. The first element of the returned tuple is a Result representing the overall outcome; the remaining elements are the individual unwrapped values (or the defaults on Err).
 
 ```ts
 unwrapPromiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
-  args: [Partial<ExtractOk<T>>, ...T],
-): Promise<[AnzenResultOk<ExtractOk<T>> | AnzenResultErr<ExtractErr<T>>, ...ExtractOk<T>]>
+  args: [ExtractOk<T>, ...T],
+): Promise<[AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>, ...ExtractOk<T>]>
 ```
 
-| Parameter    | Type                         | Description                                                                                                                                                            |
-| ------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `args[0]`    | `Partial<ExtractOk<T>>` | Default values returned as the remaining tuple elements on Err. Each default is type-checked against the corresponding Ok value type; pass `[]` to omit them. |
-| `args[1..n]` | `Result \| Promise<Result>`  | Results or Promises of Results to run in parallel.                                                                                                                     |
+| Parameter    | Type                        | Description                                                                                                                                                   |
+| ------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `args[0]`    | `ExtractOk<T>`              | A **full-length** tuple of default values, returned as the remaining tuple elements on Err. Each default is type-checked against the corresponding Ok value type. A partial/short tuple is a type error: on Err it is spread into the value positions, so a missing default would leave an `undefined` the return type claims is a present value. |
+| `args[1..n]` | `Result \| Promise<Result>` | Results or Promises of Results to run in parallel.                                                                                                            |
 
 ```js
 import { ok, unwrapPromiseAll } from '@daisugi/anzen';
 
 const [res, val1, val2] = await unwrapPromiseAll([
-  [], // defaults
+  ['', ''], // one default per result
   ok('foo'),
   Promise.resolve(ok('bar')),
 ]);
@@ -539,8 +539,8 @@ Returns a function that unpacks a Result into a tuple `[result, value]`, for use
 toTuple<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [AnzenAnyResult<unknown, unknown>, unknown | V]
 ```
 
-| Parameter      | Type | Description                                        |
-| -------------- | ---- | -------------------------------------------------- |
+| Parameter      | Type | Description                                    |
+| -------------- | ---- | ---------------------------------------------- |
 | `defaultValue` | `V`  | Value used as the second tuple element on Err. |
 
 ```js
@@ -675,10 +675,10 @@ Lifts a `Promise` that may reject into an `AsyncResult`: a resolved value become
 fromPromise<T, E = unknown>(promise: Promise<T>, parseErr?: (error: unknown) => E): AsyncResult<E, T>
 ```
 
-| Parameter  | Type                       | Description                                |
-| ---------- | -------------------------- | ------------------------------------------ |
-| `promise`  | `Promise<T>`               | A promise that may reject.                 |
-| `parseErr` | `(error: unknown) => E`    | Optional. Maps a rejection to a typed `E`. |
+| Parameter  | Type                    | Description                                |
+| ---------- | ----------------------- | ------------------------------------------ |
+| `promise`  | `Promise<T>`            | A promise that may reject.                 |
+| `parseErr` | `(error: unknown) => E` | Optional. Maps a rejection to a typed `E`. |
 
 ```js
 import { fromPromise } from '@daisugi/anzen';

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -74,15 +74,14 @@ Every combinator is a standalone named export, so unused helpers are tree-shaken
     - [`result.orElse(fn)`](#resultorelsefn)
     - [`result.mapErr(fn)`](#resultmaperrfn)
     - [`result.toTuple(defaultValue?)`](#resulttotupledefaultvalue)
-    - [`result.getRaw()`](#resultgetraw)
     - [`result.toJSON()`](#resulttojson)
     - [`fromJSON(json)`](#fromjsonjson)
     - [`promiseAll(results)`](#promiseallresults)
     - [`unwrapPromiseAll([defaults, ...results])`](#unwrappromisealldefaults-results)
     - [`toTuple(defaultValue?)`](#totupledefaultvalue)
+    - [`fromAsyncThrowable(fn, parseErr?)`](#fromasyncthrowablefn-parseerr)
     - [`fromThrowable(fn, parseErr?)`](#fromthrowablefn-parseerr)
-    - [`fromSyncThrowable(fn, parseErr?)`](#fromsyncthrowablefn-parseerr)
-    - [`AsyncResult<E, T>`](#asyncresulte-t)
+    - [`ResultAsync<E, T>`](#resultasynce-t)
     - [`okAsync(value)` / `errAsync(error)`](#okasyncvalue--errasyncerror)
     - [`fromPromise(promise, parseErr?)`](#frompromisepromise-parseerr)
     - [`fromSafePromise(promise)`](#fromsafepromisepromise)
@@ -118,7 +117,7 @@ pnpm install @daisugi/anzen
 - ✅ `ok` and `err` constructors for wrapping values and errors
 - ✅ Chainable `.map` / `.andThen` transforms for Ok paths
 - ✅ Mirror `.mapErr` / `.orElse` transforms for Err paths
-- ✅ Async helpers: `promiseAll`, `fromThrowable`, and a chainable `AsyncResult` (`okAsync` / `errAsync` / `fromPromise`)
+- ✅ Async helpers: `promiseAll`, `fromAsyncThrowable`, and a chainable `ResultAsync` (`okAsync` / `errAsync` / `fromPromise`)
 - ✅ JSON serialization and deserialization
 - ✅ TypeScript-first with full type inference on all operations
 - ✅ Integration with [@daisugi/ayamari](../ayamari) for rich, structured error objects
@@ -144,7 +143,7 @@ If you are looking for a robust Result-pattern implementation, Anzen might be th
 
 ## 📚 API
 
-A `Result` instance is either a `ResultOk<T>` or a `ResultErr<E>`. The standalone `ok` / `err` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `toTuple` / `fromThrowable` / `fromSyncThrowable` exports create or combine instances; instance methods transform or extract values.
+A `Result` instance is either a `ResultOk<T>` or a `ResultErr<E>`. The standalone `ok` / `err` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `toTuple` / `fromAsyncThrowable` / `fromThrowable` exports create or combine instances; instance methods transform or extract values.
 
 ### `ok(value)`
 
@@ -311,7 +310,7 @@ const result = ok('foo')
 Applies `fn` to the Ok value, where `fn` returns a new `Result`. Passes through unchanged on Err. Useful for sequencing operations that may themselves fail.
 
 ```ts
-result.andThen<V, F>(fn: (value: T) => AnzenAnyResult<F, V>): AnzenAnyResult<E | F, V>
+result.andThen<V, F>(fn: (value: T) => AnzenResult<F, V>): AnzenResult<E | F, V>
 ```
 
 | Parameter | Type                   | Description                                            |
@@ -334,7 +333,7 @@ const result = ok('foo')
 For an Err Result, applies `fn` to the error value, where `fn` returns a new Result. Passes through unchanged on Ok. Useful for recovering from errors.
 
 ```ts
-result.orElse<V, F>(fn: (err: E) => AnzenAnyResult<F, V>): AnzenAnyResult<F, T | V>
+result.orElse<V, F>(fn: (err: E) => AnzenResult<F, V>): AnzenResult<F, T | V>
 ```
 
 | Parameter | Type                 | Description                                                    |
@@ -403,23 +402,6 @@ const [errRes, output] = err('err').toTuple('foo');
 
 ---
 
-### `result.getRaw()`
-
-Returns the inner value or error without any safety checks. Prefer `unwrap` / `unwrapErr` with an `isOk` / `isErr` guard.
-
-```ts
-result.getRaw(): T | E
-```
-
-```js
-import { err } from '@daisugi/anzen';
-
-const output = err('err').getRaw();
-// 'err'
-```
-
----
-
 ### `result.toJSON()`
 
 Serializes the Result to a JSON string.
@@ -445,7 +427,7 @@ err('err').toJSON();
 Deserializes a JSON string (as produced by `toJSON`) into a Result instance.
 
 ```ts
-fromJSON<E = unknown, T = unknown>(json: string): AnzenAnyResult<E, T>
+fromJSON<E = unknown, T = unknown>(json: string): AnzenResult<E, T>
 ```
 
 | Parameter | Type     | Description                                    |
@@ -463,10 +445,10 @@ const value = fromJSON('{"value":"foo","isOk":true}').unwrap();
 
 ### `promiseAll(results)`
 
-Runs an array of Results or Promises of Results in parallel. Returns an Ok Result containing an array of all values if every entry succeeds, or the first Err encountered. The failure branch is typed `unknown` because a wrapped Promise may reject with anything; use `fromThrowable`/`fromPromise` with a `parseErr` upstream if you need a typed error.
+Runs an array of Results or Promises of Results in parallel. Returns an Ok Result containing an array of all values if every entry succeeds, or the first Err encountered. The failure branch is typed `unknown` because a wrapped Promise may reject with anything; use `fromAsyncThrowable`/`fromPromise` with a `parseErr` upstream if you need a typed error.
 
 ```ts
-promiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
+promiseAll<T extends (AnzenResult<unknown, unknown> | Promise<AnzenResult<unknown, unknown>>)[]>(
   whenRes: T,
 ): Promise<AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>>
 ```
@@ -505,7 +487,7 @@ result.unwrapErr(); // 'err'
 Runs an array of Results or Promises of Results in parallel and unwraps them. The first element of the returned tuple is a Result representing the overall outcome; the remaining elements are the individual unwrapped values (or the defaults on Err).
 
 ```ts
-unwrapPromiseAll<T extends (AnzenAnyResult<unknown, unknown> | Promise<AnzenAnyResult<unknown, unknown>>)[]>(
+unwrapPromiseAll<T extends (AnzenResult<unknown, unknown> | Promise<AnzenResult<unknown, unknown>>)[]>(
   args: [ExtractOk<T>, ...T],
 ): Promise<[AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>, ...ExtractOk<T>]>
 ```
@@ -536,7 +518,7 @@ val2; // 'bar'
 Returns a function that unpacks a Result into a tuple `[result, value]`, for use as a `.then()` callback. The second element is the Ok value, or `defaultValue` on Err.
 
 ```ts
-toTuple<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [AnzenAnyResult<unknown, unknown>, unknown | V]
+toTuple<V>(defaultValue?: V): (result: AnzenResult<unknown, unknown>) => [AnzenResult<unknown, unknown>, unknown | V]
 ```
 
 | Parameter      | Type | Description                                    |
@@ -553,15 +535,15 @@ const [res, output] = await fn().then(toTuple('foo'));
 
 ---
 
-### `fromThrowable(fn, parseErr?)`
+### `fromAsyncThrowable(fn, parseErr?)`
 
 Executes an async function that may throw. Returns an Ok Result with the resolved value, or an Err Result with the error passed through `parseErr`.
 
 ```ts
-fromThrowable<E = unknown, T = unknown>(
+fromAsyncThrowable<E = unknown, T = unknown>(
   fn: () => Promise<T>,
   parseErr?: (err: unknown) => E,
-): Promise<AnzenAnyResult<E, T>>
+): Promise<AnzenResult<E, T>>
 ```
 
 | Parameter  | Type                  | Description                                   |
@@ -570,9 +552,9 @@ fromThrowable<E = unknown, T = unknown>(
 | `parseErr` | `(err: unknown) => E` | Optional transform applied to a caught error. |
 
 ```js
-import { fromThrowable } from '@daisugi/anzen';
+import { fromAsyncThrowable } from '@daisugi/anzen';
 
-const result = await fromThrowable(
+const result = await fromAsyncThrowable(
   async () => { throw new Error('err') },
   (err) => err.message,
 );
@@ -582,15 +564,15 @@ result.unwrapErr(); // 'err'
 
 ---
 
-### `fromSyncThrowable(fn, parseErr?)`
+### `fromThrowable(fn, parseErr?)`
 
-Same as `fromThrowable`, but for synchronous functions.
+Same as `fromAsyncThrowable`, but for synchronous functions.
 
 ```ts
-fromSyncThrowable<E = unknown, T = unknown>(
+fromThrowable<E = unknown, T = unknown>(
   fn: () => T,
   parseErr?: (err: unknown) => E,
-): AnzenAnyResult<E, T>
+): AnzenResult<E, T>
 ```
 
 | Parameter  | Type                  | Description                                   |
@@ -599,9 +581,9 @@ fromSyncThrowable<E = unknown, T = unknown>(
 | `parseErr` | `(err: unknown) => E` | Optional transform applied to a caught error. |
 
 ```js
-import { fromSyncThrowable } from '@daisugi/anzen';
+import { fromThrowable } from '@daisugi/anzen';
 
-const result = fromSyncThrowable(
+const result = fromThrowable(
   () => { throw new Error('err') },
   (err) => err.message,
 );
@@ -613,18 +595,18 @@ result.unwrapErr(); // 'err'
 
 ---
 
-### `AsyncResult<E, T>`
+### `ResultAsync<E, T>`
 
-A thenable that carries the Result combinators across an async boundary, so I/O-heavy code can keep chaining instead of awaiting and re-wrapping at every step. `await`-ing an `AsyncResult` yields the underlying `Result`. Built with `okAsync` / `errAsync` / `fromPromise` / `fromSafePromise`.
+A thenable that carries the Result combinators across an async boundary, so I/O-heavy code can keep chaining instead of awaiting and re-wrapping at every step. `await`-ing an `ResultAsync` yields the underlying `Result`. Built with `okAsync` / `errAsync` / `fromPromise` / `fromSafePromise`.
 
 It mirrors the synchronous combinators — `map`, `mapErr`, `andThen`, `orElse` — whose callbacks may be sync or async, plus the awaitable terminals `unwrap()` / `unwrapErr()` / `unwrapOr(defaultValue)` (each returns a `Promise`).
 
 ```ts
-class AsyncResult<E, T> implements PromiseLike<ResultOk<T> | ResultErr<E>> {
-  map<U>(fn: (val: T) => U | Promise<U>): AsyncResult<E, U>;
-  mapErr<U>(fn: (error: E) => U | Promise<U>): AsyncResult<U, T>;
-  andThen<U, F>(fn: (val: T) => Result<F, U> | AsyncResult<F, U> | Promise<Result<F, U>>): AsyncResult<E | F, U>;
-  orElse<U, F>(fn: (error: E) => Result<F, U> | AsyncResult<F, U> | Promise<Result<F, U>>): AsyncResult<F, T | U>;
+class ResultAsync<E, T> implements PromiseLike<ResultOk<T> | ResultErr<E>> {
+  map<U>(fn: (val: T) => U | Promise<U>): ResultAsync<E, U>;
+  mapErr<U>(fn: (error: E) => U | Promise<U>): ResultAsync<U, T>;
+  andThen<U, F>(fn: (val: T) => Result<F, U> | ResultAsync<F, U> | Promise<Result<F, U>>): ResultAsync<E | F, U>;
+  orElse<U, F>(fn: (error: E) => Result<F, U> | ResultAsync<F, U> | Promise<Result<F, U>>): ResultAsync<F, T | U>;
   unwrap(): Promise<T>;
   unwrapErr(): Promise<E>;
   unwrapOr<V>(defaultValue: V): Promise<T | V>;
@@ -649,11 +631,11 @@ if (res.isOk) {
 
 ### `okAsync(value)` / `errAsync(error)`
 
-Create an already-settled `AsyncResult`, the async counterparts of `ok` / `err`.
+Create an already-settled `ResultAsync`, the async counterparts of `ok` / `err`.
 
 ```ts
-okAsync<T>(value: T): AsyncResult<never, T>
-errAsync<E>(error: E): AsyncResult<E, never>
+okAsync<T>(value: T): ResultAsync<never, T>
+errAsync<E>(error: E): ResultAsync<E, never>
 ```
 
 ```js
@@ -669,10 +651,10 @@ await errAsync('boom').unwrapOr(0); // 0
 
 ### `fromPromise(promise, parseErr?)`
 
-Lifts a `Promise` that may reject into an `AsyncResult`: a resolved value becomes `Ok`, a rejection becomes `Err`. Without `parseErr` the error type is `unknown` — pass `parseErr` to obtain a typed error (matching neverthrow's `fromPromise(promise, errorFn)` contract).
+Lifts a `Promise` that may reject into an `ResultAsync`: a resolved value becomes `Ok`, a rejection becomes `Err`. Without `parseErr` the error type is `unknown` — pass `parseErr` to obtain a typed error (matching neverthrow's `fromPromise(promise, errorFn)` contract).
 
 ```ts
-fromPromise<T, E = unknown>(promise: Promise<T>, parseErr?: (error: unknown) => E): AsyncResult<E, T>
+fromPromise<T, E = unknown>(promise: Promise<T>, parseErr?: (error: unknown) => E): ResultAsync<E, T>
 ```
 
 | Parameter  | Type                    | Description                                |
@@ -693,10 +675,10 @@ res.unwrapErr(); // 'x'
 
 ### `fromSafePromise(promise)`
 
-Lifts a `Promise` that is already known not to reject (it resolves to a `Result`) into an `AsyncResult`.
+Lifts a `Promise` that is already known not to reject (it resolves to a `Result`) into an `ResultAsync`.
 
 ```ts
-fromSafePromise<E, T>(promise: Promise<ResultOk<T> | ResultErr<E>>): AsyncResult<E, T>
+fromSafePromise<E, T>(promise: Promise<ResultOk<T> | ResultErr<E>>): ResultAsync<E, T>
 ```
 
 ```js

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -138,7 +138,7 @@ Anzen was created to provide a simple and predictable way to handle errors, elim
 
 **Sequential over chainable.** Anzen intentionally does not ship a chainable `ResultAsync` thenable. In practice, multi-step async flows almost always need earlier bindings available in later steps. A method chain ends up as verbose as the sequential alternative — with added runtime overhead.
 
-**Fail-fast with unsafe unwraps.** `unwrap()` and `unwrapErr()` are intentionally unsafe — they throw if called on the wrong variant. The pattern is deliberate: use them only after a guard check (`isOk` / `isErr`), or to assert that a path is a programmer bug, not a recoverable error. Throwing loudly at the point of misuse surfaces problems earlier and in a more precise location than a silent fallback would.
+**Fail-fast with unsafe unwraps.** `unwrap()` and `unwrapErr()` throw on the wrong variant by design. Use them after an `isOk` / `isErr` guard, or to assert a programmer bug — throwing at the call site surfaces problems earlier than a silent fallback would.
 
 If you are looking for a robust Result-pattern implementation, Anzen might be the right choice. Alternatives include [True-Myth](https://true-myth.js.org/) or [Folktale](https://folktale.origamitower.com/).
 

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -138,6 +138,8 @@ Anzen was created to provide a simple and predictable way to handle errors, elim
 
 **Sequential over chainable.** Anzen intentionally does not ship a chainable `ResultAsync` thenable. In practice, multi-step async flows almost always need earlier bindings available in later steps. A method chain ends up as verbose as the sequential alternative — with added runtime overhead.
 
+**Fail-fast with unsafe unwraps.** `unwrap()` and `unwrapErr()` are intentionally unsafe — they throw if called on the wrong variant. The pattern is deliberate: use them only after a guard check (`isOk` / `isErr`), or to assert that a path is a programmer bug, not a recoverable error. Throwing loudly at the point of misuse surfaces problems earlier and in a more precise location than a silent fallback would.
+
 If you are looking for a robust Result-pattern implementation, Anzen might be the right choice. Alternatives include [True-Myth](https://true-myth.js.org/) or [Folktale](https://folktale.origamitower.com/).
 
 [:top: Back to top](#-table-of-contents)

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -42,10 +42,10 @@ function readFile(path) {
 const result = readFile('test.txt');
 
 if (result.isFailure) {
-  return result.getError();
+  return result.unwrapErr();
 }
 
-return result.getValue();
+return result.unwrap();
 ```
 
 Every combinator is a standalone named export, so unused helpers are tree-shaken away — `import { success }` pulls in nothing else.
@@ -65,20 +65,20 @@ Every combinator is a standalone named export, so unused helpers are tree-shaken
     - [`success(value)`](#successvalue)
     - [`failure(err)`](#failureerr)
     - [`result.isSuccess / result.isFailure`](#resultissuccess--resultisfailure)
-    - [`result.getValue()`](#resultgetvalue)
-    - [`result.getError()`](#resultgeterror)
-    - [`result.getOrElse(defaultValue)`](#resultgetorelsedefaultvalue)
+    - [`result.unwrap()`](#resultunwrap)
+    - [`result.unwrapErr()`](#resultunwraperr)
+    - [`result.unwrapOr(defaultValue)`](#resultunwrapordefaultvalue)
     - [`result.map(fn)`](#resultmapfn)
-    - [`result.chain(fn)`](#resultchainfn)
-    - [`result.elseChain(fn)`](#resultelsechainfn)
-    - [`result.elseMap(fn)`](#resultelsemapfn)
-    - [`result.unwrap(defaultValue?)`](#resultunwrapdefaultvalue)
-    - [`result.unsafeUnwrap()`](#resultunsafeunwrap)
+    - [`result.andThen(fn)`](#resultandthenfn)
+    - [`result.orElse(fn)`](#resultorelsefn)
+    - [`result.mapErr(fn)`](#resultmaperrfn)
+    - [`result.toTuple(defaultValue?)`](#resulttotupledefaultvalue)
+    - [`result.getRaw()`](#resultgetraw)
     - [`result.toJSON()`](#resulttojson)
     - [`fromJSON(json)`](#fromjsonjson)
     - [`promiseAll(results)`](#promiseallresults)
     - [`unwrapPromiseAll([defaults, ...results])`](#unwrappromisealldefaults-results)
-    - [`unwrap(defaultValue?)`](#unwrapdefaultvalue)
+    - [`toTuple(defaultValue?)`](#totupledefaultvalue)
     - [`fromThrowable(fn, parseErr?)`](#fromthrowablefn-parseerr)
     - [`fromSyncThrowable(fn, parseErr?)`](#fromsyncthrowablefn-parseerr)
   - [🔷 TypeScript Support](#-typescript-support)
@@ -111,8 +111,8 @@ pnpm install @daisugi/anzen
 **Anzen** replaces thrown exceptions with an explicit `Result` type, making error paths visible in function signatures and composable with standard transforms. It provides:
 
 - ✅ `success` and `failure` constructors for wrapping values and errors
-- ✅ Chainable `.map` / `.chain` transforms for success paths
-- ✅ Mirror `.elseMap` / `.elseChain` transforms for failure paths
+- ✅ Chainable `.map` / `.andThen` transforms for success paths
+- ✅ Mirror `.mapErr` / `.orElse` transforms for failure paths
 - ✅ Async helpers: `promiseAll` and `fromThrowable`
 - ✅ JSON serialization and deserialization
 - ✅ TypeScript-first with full type inference on all operations
@@ -139,7 +139,7 @@ If you are looking for a robust Result-pattern implementation, Anzen might be th
 
 ## 📚 API
 
-A `Result` instance is either a `ResultSuccess<T>` or a `ResultFailure<E>`. The standalone `success` / `failure` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `unwrap` / `fromThrowable` / `fromSyncThrowable` exports create or combine instances; instance methods transform or extract values.
+A `Result` instance is either a `ResultSuccess<T>` or a `ResultFailure<E>`. The standalone `success` / `failure` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `toTuple` / `fromThrowable` / `fromSyncThrowable` exports create or combine instances; instance methods transform or extract values.
 
 ### `success(value)`
 
@@ -199,46 +199,46 @@ console.log(errRes.isFailure); // true
 
 ---
 
-### `result.getValue()`
+### `result.unwrap()`
 
-Returns the success value. Throws if the Result is a failure — guard with `result.isSuccess` or use `getOrElse` for a safe alternative.
+Returns the success value. Throws if the Result is a failure — guard with `result.isSuccess` or use `unwrapOr` for a safe alternative.
 
 ```ts
-result.getValue(): T
+result.unwrap(): T
 ```
 
 ```js
 import { success } from '@daisugi/anzen';
 
-const value = success('foo').getValue();
+const value = success('foo').unwrap();
 // 'foo'
 ```
 
 ---
 
-### `result.getError()`
+### `result.unwrapErr()`
 
 Returns the error value. Throws if the Result is a success — guard with `result.isFailure`.
 
 ```ts
-result.getError(): E
+result.unwrapErr(): E
 ```
 
 ```js
 import { failure } from '@daisugi/anzen';
 
-const error = failure('err').getError();
+const error = failure('err').unwrapErr();
 // 'err'
 ```
 
 ---
 
-### `result.getOrElse(defaultValue)`
+### `result.unwrapOr(defaultValue)`
 
 Returns the success value, or `defaultValue` if the Result is a failure. Never throws.
 
 ```ts
-result.getOrElse<V>(defaultValue: V): T | V
+result.unwrapOr<V>(defaultValue: V): T | V
 ```
 
 | Parameter      | Type | Description                         |
@@ -248,7 +248,7 @@ result.getOrElse<V>(defaultValue: V): T | V
 ```js
 import { failure } from '@daisugi/anzen';
 
-const value = failure('err').getOrElse('foo');
+const value = failure('err').unwrapOr('foo');
 // 'foo'
 ```
 
@@ -271,18 +271,18 @@ import { success } from '@daisugi/anzen';
 
 const result = success('foo')
   .map((value) => value)
-  .getValue();
+  .unwrap();
 // 'foo'
 ```
 
 ---
 
-### `result.chain(fn)`
+### `result.andThen(fn)`
 
 Applies `fn` to the success value, where `fn` returns a new `Result`. Passes through unchanged on failure. Useful for sequencing operations that may themselves fail.
 
 ```ts
-result.chain<V, F>(fn: (value: T) => AnzenAnyResult<F, V>): AnzenAnyResult<E | F, V>
+result.andThen<V, F>(fn: (value: T) => AnzenAnyResult<F, V>): AnzenAnyResult<E | F, V>
 ```
 
 | Parameter | Type                   | Description                                                 |
@@ -293,19 +293,19 @@ result.chain<V, F>(fn: (value: T) => AnzenAnyResult<F, V>): AnzenAnyResult<E | F
 import { success } from '@daisugi/anzen';
 
 const result = success('foo')
-  .chain((value) => success(value))
-  .getValue();
+  .andThen((value) => success(value))
+  .unwrap();
 // 'foo'
 ```
 
 ---
 
-### `result.elseChain(fn)`
+### `result.orElse(fn)`
 
 For a failure Result, applies `fn` to the error value, where `fn` returns a new Result. Passes through unchanged on success. Useful for recovering from errors.
 
 ```ts
-result.elseChain<V, F>(fn: (err: E) => AnzenAnyResult<F, V>): AnzenAnyResult<F, T | V>
+result.orElse<V, F>(fn: (err: E) => AnzenAnyResult<F, V>): AnzenAnyResult<F, T | V>
 ```
 
 | Parameter | Type                 | Description                                                    |
@@ -316,19 +316,19 @@ result.elseChain<V, F>(fn: (err: E) => AnzenAnyResult<F, V>): AnzenAnyResult<F, 
 import { success, failure } from '@daisugi/anzen';
 
 const result = failure('err')
-  .elseChain((err) => success('foo'))
-  .getValue();
+  .orElse((err) => success('foo'))
+  .unwrap();
 // 'foo'
 ```
 
 ---
 
-### `result.elseMap(fn)`
+### `result.mapErr(fn)`
 
 For a failure Result, transforms the error value using `fn` and wraps the return in a new success Result. Passes through unchanged on success.
 
 ```ts
-result.elseMap<V>(fn: (err: E) => V): ResultSuccess<T | V>
+result.mapErr<V>(fn: (err: E) => V): ResultSuccess<T | V>
 ```
 
 | Parameter | Type            | Description                           |
@@ -339,23 +339,23 @@ result.elseMap<V>(fn: (err: E) => V): ResultSuccess<T | V>
 import { failure } from '@daisugi/anzen';
 
 const result = failure('err')
-  .elseMap((err) => 'foo')
-  .getValue();
+  .mapErr((err) => 'foo')
+  .unwrap();
 // 'foo'
 ```
 
 ---
 
-### `result.unwrap(defaultValue?)`
+### `result.toTuple(defaultValue?)`
 
 Returns a tuple `[result, value]`. On success, the second element is the wrapped value. On failure, the second element is `defaultValue` (or `undefined` if omitted).
 
 ```ts
 // On ResultSuccess — no argument needed:
-result.unwrap(): [ResultSuccess<T>, T]
+result.toTuple(): [ResultSuccess<T>, T]
 
 // On ResultFailure — optional default:
-result.unwrap<V>(defaultValue?: V): [ResultFailure<E>, V]
+result.toTuple<V>(defaultValue?: V): [ResultFailure<E>, V]
 ```
 
 | Parameter      | Type | Description                                                          |
@@ -365,27 +365,27 @@ result.unwrap<V>(defaultValue?: V): [ResultFailure<E>, V]
 ```js
 import { success, failure } from '@daisugi/anzen';
 
-const [res, value] = success('foo').unwrap();
+const [res, value] = success('foo').toTuple();
 // res is the ResultSuccess instance, value is 'foo'
 
-const [errRes, output] = failure('err').unwrap('foo');
+const [errRes, output] = failure('err').toTuple('foo');
 // errRes is the ResultFailure instance, output is 'foo'
 ```
 
 ---
 
-### `result.unsafeUnwrap()`
+### `result.getRaw()`
 
-Returns the inner value or error without any safety checks. Prefer `getValue` / `getError` with an `isSuccess` / `isFailure` guard.
+Returns the inner value or error without any safety checks. Prefer `unwrap` / `unwrapErr` with an `isSuccess` / `isFailure` guard.
 
 ```ts
-result.unsafeUnwrap(): T | E
+result.getRaw(): T | E
 ```
 
 ```js
 import { failure } from '@daisugi/anzen';
 
-const output = failure('err').unsafeUnwrap();
+const output = failure('err').getRaw();
 // 'err'
 ```
 
@@ -426,7 +426,7 @@ fromJSON<E = unknown, T = unknown>(json: string): AnzenAnyResult<E, T>
 ```js
 import { fromJSON } from '@daisugi/anzen';
 
-const value = fromJSON('{"value":"foo","isSuccess":true}').getValue();
+const value = fromJSON('{"value":"foo","isSuccess":true}').unwrap();
 // 'foo'
 ```
 
@@ -454,7 +454,7 @@ const result = await promiseAll([
   Promise.resolve(success('bar')),
 ]);
 
-result.getValue(); // ['foo', 'bar']
+result.unwrap(); // ['foo', 'bar']
 ```
 
 On failure:
@@ -466,7 +466,7 @@ const result = await promiseAll([
   failure('err'),
 ]);
 
-result.getError(); // 'err'
+result.unwrapErr(); // 'err'
 ```
 
 ---
@@ -502,12 +502,12 @@ val2; // 'bar'
 
 ---
 
-### `unwrap(defaultValue?)`
+### `toTuple(defaultValue?)`
 
 Returns a function that unpacks a Result into a tuple `[result, value]`, for use as a `.then()` callback. The second element is the success value, or `defaultValue` on failure.
 
 ```ts
-unwrap<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [AnzenAnyResult<unknown, unknown>, unknown | V]
+toTuple<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [AnzenAnyResult<unknown, unknown>, unknown | V]
 ```
 
 | Parameter      | Type | Description                                        |
@@ -515,10 +515,10 @@ unwrap<V>(defaultValue?: V): (result: AnzenAnyResult<unknown, unknown>) => [Anze
 | `defaultValue` | `V`  | Value used as the second tuple element on failure. |
 
 ```js
-import { failure, unwrap } from '@daisugi/anzen';
+import { failure, toTuple } from '@daisugi/anzen';
 
 const fn = async () => failure('err');
-const [res, output] = await fn().then(unwrap('foo'));
+const [res, output] = await fn().then(toTuple('foo'));
 // res is the failure instance, output is 'foo'
 ```
 
@@ -548,7 +548,7 @@ const result = await fromThrowable(
   (err) => err.message,
 );
 
-result.getError(); // 'err'
+result.unwrapErr(); // 'err'
 ```
 
 ---
@@ -577,7 +577,7 @@ const result = fromSyncThrowable(
   (err) => err.message,
 );
 
-result.getError(); // 'err'
+result.unwrapErr(); // 'err'
 ```
 
 [:top: Back to top](#-table-of-contents)

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -77,7 +77,7 @@ Every combinator is a standalone named export, so unused helpers are tree-shaken
     - [`result.toJSON()`](#resulttojson)
     - [`fromJSON(json)`](#fromjsonjson)
     - [`promiseAll(results)`](#promiseallresults)
-    - [`unwrapPromiseAll([defaults, ...results])`](#unwrappromisealldefaults-results)
+    - [`promiseAllTuple([defaults, ...results])`](#promisealltuple-defaults-results)
     - [`toTuple(defaultValue?)`](#totupledefaultvalue)
     - [`fromAsyncThrowable(fn, parseErr?)`](#fromasyncthrowablefn-parseerr)
     - [`fromThrowable(fn, parseErr?)`](#fromthrowablefn-parseerr)
@@ -148,7 +148,7 @@ If you are looking for a robust Result-pattern implementation, Anzen might be th
 
 ## 📚 API
 
-A `Result` instance is either a `ResultOk<T>` or a `ResultErr<E>`. The standalone `ok` / `err` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `toTuple` / `fromThrowable` / `fromAsyncThrowable` exports create or combine instances; instance methods transform or extract values.
+A `Result` instance is either a `ResultOk<T>` or a `ResultErr<E>`. The standalone `ok` / `err` / `fromJSON` / `promiseAll` / `promiseAllTuple` / `toTuple` / `fromThrowable` / `fromAsyncThrowable` exports create or combine instances; instance methods transform or extract values.
 
 ### `ok(value)`
 
@@ -487,12 +487,12 @@ result.unwrapErr(); // 'err'
 
 ---
 
-### `unwrapPromiseAll([defaults, ...results])`
+### `promiseAllTuple([defaults, ...results])`
 
 Runs an array of Results or Promises of Results in parallel and unwraps them. The first element of the returned tuple is a Result representing the overall outcome; the remaining elements are the individual unwrapped values (or the defaults on Err).
 
 ```ts
-unwrapPromiseAll<T extends (AnzenResult<unknown, unknown> | Promise<AnzenResult<unknown, unknown>>)[]>(
+promiseAllTuple<T extends (AnzenResult<unknown, unknown> | Promise<AnzenResult<unknown, unknown>>)[]>(
   args: [ExtractOk<T>, ...T],
 ): Promise<[AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>, ...ExtractOk<T>]>
 ```
@@ -503,9 +503,9 @@ unwrapPromiseAll<T extends (AnzenResult<unknown, unknown> | Promise<AnzenResult<
 | `args[1..n]` | `Result \| Promise<Result>` | Results or Promises of Results to run in parallel.                                                                                                                                                                                                                                                                                                |
 
 ```js
-import { ok, unwrapPromiseAll } from '@daisugi/anzen';
+import { ok, promiseAllTuple } from '@daisugi/anzen';
 
-const [res, val1, val2] = await unwrapPromiseAll([
+const [res, val1, val2] = await promiseAllTuple([
   ['', ''], // one default per result
   ok('foo'),
   Promise.resolve(ok('bar')),

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -81,11 +81,11 @@ Every combinator is a standalone named export, so unused helpers are tree-shaken
     - [`toTuple(defaultValue?)`](#totupledefaultvalue)
     - [`fromAsyncThrowable(fn, parseErr?)`](#fromasyncthrowablefn-parseerr)
     - [`fromThrowable(fn, parseErr?)`](#fromthrowablefn-parseerr)
-    - [`wrapAsyncThrowable(fn, parseErr?)`](#wrapasyncthrowablefn-parseerr)
-    - [`ResultAsync<E, T>`](#resultasynce-t)
-    - [`okAsync(value)` / `errAsync(error)`](#okasyncvalue--errasyncerror)
-    - [`fromPromise(promise, parseErr?)`](#frompromisepromise-parseerr)
-    - [`fromSafePromise(promise)`](#fromsafepromisepromise)
+    - [`safeTry(body)`](#safetrybody)
+  - [🧩 Composition Styles Side by Side](#-composition-styles-side-by-side)
+    - [1. Sequential `Result`](#1-sequential-result)
+    - [2. `safeTry` (generator, Rust `?`-style)](#2-safetry-generator-rust--style)
+    - [Which to reach for](#which-to-reach-for)
   - [🔷 TypeScript Support](#-typescript-support)
   - [🎯 Goal](#-goal)
   - [🌍 Other Projects](#-other-projects)
@@ -118,7 +118,7 @@ pnpm install @daisugi/anzen
 - ✅ `ok` and `err` constructors for wrapping values and errors
 - ✅ Chainable `.map` / `.andThen` transforms for Ok paths
 - ✅ Mirror `.mapErr` / `.orElse` transforms for Err paths
-- ✅ Async helpers: `promiseAll`, `fromAsyncThrowable`, and a chainable `ResultAsync` (`okAsync` / `errAsync` / `fromPromise`)
+- ✅ Async helpers: `promiseAll`, `fromAsyncThrowable`, and `safeTry` for generator-based `?`-style propagation
 - ✅ JSON serialization and deserialization
 - ✅ TypeScript-first with full type inference on all operations
 - ✅ Integration with [@daisugi/ayamari](../ayamari) for rich, structured error objects
@@ -132,9 +132,11 @@ pnpm install @daisugi/anzen
 Anzen was created to provide a simple and predictable way to handle errors, eliminating unexpected exceptions. It is especially useful when:
 
 - Early failures need to be caught and handled at the call site.
-- You prefer a clean, chainable style of error handling over try/catch blocks.
+- You prefer explicit, sequential error handling over try/catch blocks.
 - You require improved TypeScript support with typed error and value paths.
 - You want a minimal API that covers common use cases without mimicking other languages' patterns entirely.
+
+**Sequential over chainable.** Anzen intentionally does not ship a chainable `ResultAsync` thenable. In practice, multi-step async flows almost always need earlier bindings available in later steps. A method chain ends up as verbose as the sequential alternative — with added runtime overhead.
 
 If you are looking for a robust Result-pattern implementation, Anzen might be the right choice. Alternatives include [True-Myth](https://true-myth.js.org/) or [Folktale](https://folktale.origamitower.com/).
 
@@ -144,7 +146,7 @@ If you are looking for a robust Result-pattern implementation, Anzen might be th
 
 ## 📚 API
 
-A `Result` instance is either a `ResultOk<T>` or a `ResultErr<E>`. The standalone `ok` / `err` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `toTuple` / `fromAsyncThrowable` / `fromThrowable` exports create or combine instances; instance methods transform or extract values.
+A `Result` instance is either a `ResultOk<T>` or a `ResultErr<E>`. The standalone `ok` / `err` / `fromJSON` / `promiseAll` / `unwrapPromiseAll` / `toTuple` / `fromThrowable` / `fromAsyncThrowable` exports create or combine instances; instance methods transform or extract values.
 
 ### `ok(value)`
 
@@ -493,10 +495,10 @@ unwrapPromiseAll<T extends (AnzenResult<unknown, unknown> | Promise<AnzenResult<
 ): Promise<[AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>, ...ExtractOk<T>]>
 ```
 
-| Parameter    | Type                        | Description                                                                                                                                                   |
-| ------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter    | Type                        | Description                                                                                                                                                                                                                                                                                                                                       |
+| ------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `args[0]`    | `ExtractOk<T>`              | A **full-length** tuple of default values, returned as the remaining tuple elements on Err. Each default is type-checked against the corresponding Ok value type. A partial/short tuple is a type error: on Err it is spread into the value positions, so a missing default would leave an `undefined` the return type claims is a present value. |
-| `args[1..n]` | `Result \| Promise<Result>` | Results or Promises of Results to run in parallel.                                                                                                            |
+| `args[1..n]` | `Result \| Promise<Result>` | Results or Promises of Results to run in parallel.                                                                                                                                                                                                                                                                                                |
 
 ```js
 import { ok, unwrapPromiseAll } from '@daisugi/anzen';
@@ -538,30 +540,33 @@ const [res, output] = await fn().then(toTuple('foo'));
 
 ### `fromAsyncThrowable(fn, parseErr?)`
 
-Executes an async function that may throw. Returns an Ok Result with the resolved value, or an Err Result with the error passed through `parseErr`.
+Adapts an async function that may throw or reject into a reusable Result-returning function, preserving its parameters. A synchronous throw at the call site is caught too. Adapt a throwing function once, at the boundary, and reuse it throughout.
 
 ```ts
-fromAsyncThrowable<E = unknown, T = unknown>(
-  fn: () => Promise<T>,
+fromAsyncThrowable<E = unknown, T = unknown, A extends readonly unknown[] = []>(
+  fn: (...args: A) => Promise<T>,
   parseErr?: (err: unknown) => E,
-): Promise<AnzenResult<E, T>>
+): (...args: A) => Promise<AnzenResult<E, T>>
 ```
 
-| Parameter  | Type                  | Description                                   |
-| ---------- | --------------------- | --------------------------------------------- |
-| `fn`       | `() => Promise<T>`    | Async function to execute.                    |
-| `parseErr` | `(err: unknown) => E` | Optional transform applied to a caught error. |
+| Parameter  | Type                         | Description                                   |
+| ---------- | ---------------------------- | --------------------------------------------- |
+| `fn`       | `(...args: A) => Promise<T>` | Async function to adapt.                      |
+| `parseErr` | `(err: unknown) => E`        | Optional transform applied to a caught error. |
 
 ```js
 import { fromAsyncThrowable } from '@daisugi/anzen';
 
-const result = await fromAsyncThrowable(
-  async () => { throw new Error('err') },
+const fetchUser = fromAsyncThrowable(
+  async (id) => { /* may throw */ return await db.findUser(id); },
   (err) => err.message,
 );
 
-result.unwrapErr(); // 'err'
+const res = await fetchUser(42);
+if (res.isOk) console.log(res.unwrap());
 ```
+
+[:top: Back to top](#-table-of-contents)
 
 ---
 
@@ -570,54 +575,26 @@ result.unwrapErr(); // 'err'
 Same as `fromAsyncThrowable`, but for synchronous functions.
 
 ```ts
-fromThrowable<E = unknown, T = unknown>(
-  fn: () => T,
+fromThrowable<E = unknown, T = unknown, A extends readonly unknown[] = []>(
+  fn: (...args: A) => T,
   parseErr?: (err: unknown) => E,
-): AnzenResult<E, T>
+): (...args: A) => AnzenResult<E, T>
 ```
 
 | Parameter  | Type                  | Description                                   |
 | ---------- | --------------------- | --------------------------------------------- |
-| `fn`       | `() => T`             | Synchronous function to execute.              |
+| `fn`       | `(...args: A) => T`   | Synchronous function to adapt.                |
 | `parseErr` | `(err: unknown) => E` | Optional transform applied to a caught error. |
 
 ```js
 import { fromThrowable } from '@daisugi/anzen';
 
-const result = fromThrowable(
-  () => { throw new Error('err') },
+const parseJSON = fromThrowable(
+  (raw) => JSON.parse(raw),
   (err) => err.message,
 );
 
-result.unwrapErr(); // 'err'
-```
-
-[:top: Back to top](#-table-of-contents)
-
----
-
-### `wrapAsyncThrowable(fn, parseErr?)`
-
-The lazy counterpart of `fromAsyncThrowable`: adapts an async function that may throw or reject into a reusable Result-returning function (an `AnzenResultFn`), preserving its parameters. Lift a throwing function once and reuse it — e.g. behind `@daisugi/kintsugi` wrappers — instead of wrapping each call in `fromAsyncThrowable`.
-
-```ts
-wrapAsyncThrowable<A extends readonly unknown[], T, E = unknown>(
-  fn: (...args: A) => Promise<T>,
-  parseErr?: (err: unknown) => E,
-): (...args: A) => Promise<AnzenResult<E, T>>
-```
-
-| Parameter  | Type                         | Description                                   |
-| ---------- | ---------------------------- | --------------------------------------------- |
-| `fn`       | `(...args: A) => Promise<T>` | Async function to adapt.                       |
-| `parseErr` | `(err: unknown) => E`        | Optional transform applied to a caught error. |
-
-```js
-import { wrapAsyncThrowable } from '@daisugi/anzen';
-
-const fetchUserResult = wrapAsyncThrowable(fetchUser, (err) => err.message);
-
-const res = await fetchUserResult(42);
+const res = parseJSON('{"ok":true}');
 if (res.isOk) console.log(res.unwrap());
 ```
 
@@ -625,97 +602,152 @@ if (res.isOk) console.log(res.unwrap());
 
 ---
 
-### `ResultAsync<E, T>`
+### `safeTry(body)`
 
-A thenable that carries the Result combinators across an async boundary, so I/O-heavy code can keep chaining instead of awaiting and re-wrapping at every step. `await`-ing an `ResultAsync` yields the underlying `Result`. Built with `okAsync` / `errAsync` / `fromPromise` / `fromSafePromise`.
+Rust's `?`-operator for Results, built on generators. Inside the generator body, `yield* result` unwraps an `Ok` to its value or aborts the whole body, making `safeTry` return that `Err`. This keeps a chain of dependent, fallible steps in plain control flow — local `const`s, `if` branches, loops — without an `isErr` guard after every call.
 
-It mirrors the synchronous combinators — `map`, `mapErr`, `andThen`, `orElse` — whose callbacks may be sync or async, plus the awaitable terminals `unwrap()` / `unwrapErr()` / `unwrapOr(defaultValue)` (each returns a `Promise`).
+A synchronous generator (`function*`) returns a `Result`; an async one (`async function*`, using `yield* await ...`) returns a `Promise` of one. The error type is inferred as the union of every yielded Result's error.
 
 ```ts
-class ResultAsync<E, T> implements PromiseLike<ResultOk<T> | ResultErr<E>> {
-  map<U>(fn: (val: T) => U | Promise<U>): ResultAsync<E, U>;
-  mapErr<U>(fn: (error: E) => U | Promise<U>): ResultAsync<U, T>;
-  andThen<U, F>(fn: (val: T) => Result<F, U> | ResultAsync<F, U> | Promise<Result<F, U>>): ResultAsync<E | F, U>;
-  orElse<U, F>(fn: (error: E) => Result<F, U> | ResultAsync<F, U> | Promise<Result<F, U>>): ResultAsync<F, T | U>;
-  unwrap(): Promise<T>;
-  unwrapErr(): Promise<E>;
-  unwrapOr<V>(defaultValue: V): Promise<T | V>;
+function safeTry<E, T>(
+  body: () => Generator<AnzenResultErr<E>, AnzenResult<E, T>>,
+): AnzenResult<E, T>;
+function safeTry<E, T>(
+  body: () => AsyncGenerator<AnzenResultErr<E>, AnzenResult<E, T>>,
+): Promise<AnzenResult<E, T>>;
+```
+
+| Parameter | Type                                | Description                                                      |
+| --------- | ----------------------------------- | ---------------------------------------------------------------- |
+| `body`    | `() => Generator \| AsyncGenerator` | Generator that `yield*`s Results and returns the final `Result`. |
+
+```js
+import { safeTry, ok, err } from '@daisugi/anzen';
+
+const checkout = (userId, amount) =>
+  safeTry(async function* () {
+    const user = yield* await userRepo.find(userId);
+    if (!user) return err({ kind: 'userNotFound', userId });
+
+    const receipt = yield* await payments.charge(user.cardToken, amount);
+
+    // Return the final Result directly — do not `yield*` it, or you would
+    // return the unwrapped value instead of a Result.
+    return await userRepo.saveOrder({
+      userId: user.id,
+      amount,
+      receiptId: receipt.id,
+    });
+  });
+
+const res = await checkout('u_123', 4999);
+if (res.isErr) console.warn(res.unwrapErr());
+else handleOrder(res.unwrap());
+```
+
+The first `Err` short-circuits: every step after it is skipped and that error flows straight out. `safeTry` is the idiomatic choice when the flow needs branching, loops, or several intermediate values in scope at once; sequential `await` + `isErr` guards are preferred for simpler linear flows.
+
+[:top: Back to top](#-table-of-contents)
+
+---
+
+## 🧩 Composition Styles Side by Side
+
+The same flow — look up a user, charge their card, persist the order — written two ways. Each step is async and fallible. Both share **one boundary layer**: every throwing dependency is adapted to a Result exactly once with `fromAsyncThrowable`, so neither call site repeats that wrapping.
+
+```ts
+import {
+  ok,
+  err,
+  safeTry,
+  fromAsyncThrowable,
+  type AnzenResult,
+} from '@daisugi/anzen';
+
+type CheckoutErr =
+  | { kind: 'userNotFound'; userId: string }
+  | { kind: 'cardDeclined'; reason: string }
+  | { kind: 'dbWriteFailed'; cause: unknown };
+
+// Adapt each throwing call once, at the boundary.
+const userRepo = {
+  find: fromAsyncThrowable(
+    db.findUser,
+    (cause): CheckoutErr => ({ kind: 'dbWriteFailed', cause }),
+  ),
+  saveOrder: fromAsyncThrowable(
+    db.saveOrder,
+    (cause): CheckoutErr => ({ kind: 'dbWriteFailed', cause }),
+  ),
+};
+const payments = {
+  charge: fromAsyncThrowable(
+    rawPayments.charge,
+    (e): CheckoutErr => ({ kind: 'cardDeclined', reason: String(e) }),
+  ),
+};
+// userRepo.find:      (userId)     => Promise<AnzenResult<CheckoutErr, User | null>>
+// payments.charge:    (token, amt) => Promise<AnzenResult<CheckoutErr, Receipt>>
+// userRepo.saveOrder: (order)      => Promise<AnzenResult<CheckoutErr, Order>>
+```
+
+The call site is identical for all three:
+
+```ts
+const res = await checkout('u_123', 4999);
+if (res.isErr) log.warn('checkout failed', res.unwrapErr());
+else fulfil(res.unwrap());
+```
+
+### 1. Sequential `Result`
+
+```ts
+async function checkout(
+  userId: string,
+  amount: number,
+): Promise<AnzenResult<CheckoutErr, Order>> {
+  const userRes = await userRepo.find(userId);
+  if (userRes.isErr) return userRes;
+  const user = userRes.unwrap();
+  if (!user) return err({ kind: 'userNotFound', userId });
+
+  const chargeRes = await payments.charge(user.cardToken, amount);
+  if (chargeRes.isErr) return chargeRes;
+
+  return userRepo.saveOrder({
+    userId: user.id,
+    amount,
+    receiptId: chargeRes.unwrap().id,
+  });
 }
 ```
 
-```js
-import { fromPromise } from '@daisugi/anzen';
+### 2. `safeTry` (generator, Rust `?`-style)
 
-const res = await fromPromise(fetch('/api/user'), (e) => e.message)
-  .andThen((response) => fromPromise(response.json(), (e) => e.message))
-  .map((user) => user.name);
 
-if (res.isOk) {
-  console.log(res.unwrap());
+```ts
+function checkout(userId: string, amount: number) {
+  return safeTry(async function* () {
+    const user = yield* await userRepo.find(userId);
+    if (!user) return err<CheckoutErr>({ kind: 'userNotFound', userId });
+
+    const receipt = yield* await payments.charge(user.cardToken, amount);
+
+    return await userRepo.saveOrder({
+      userId: user.id,
+      amount,
+      receiptId: receipt.id,
+    });
+  });
 }
 ```
 
-[:top: Back to top](#-table-of-contents)
+### Which to reach for
 
----
-
-### `okAsync(value)` / `errAsync(error)`
-
-Create an already-settled `ResultAsync`, the async counterparts of `ok` / `err`.
-
-```ts
-okAsync<T>(value: T): ResultAsync<never, T>
-errAsync<E>(error: E): ResultAsync<E, never>
-```
-
-```js
-import { okAsync, errAsync } from '@daisugi/anzen';
-
-await okAsync(1).map((x) => x + 1); // Ok(2)
-await errAsync('boom').unwrapOr(0); // 0
-```
-
-[:top: Back to top](#-table-of-contents)
-
----
-
-### `fromPromise(promise, parseErr?)`
-
-Lifts a `Promise` that may reject into an `ResultAsync`: a resolved value becomes `Ok`, a rejection becomes `Err`. Without `parseErr` the error type is `unknown` — pass `parseErr` to obtain a typed error (matching neverthrow's `fromPromise(promise, errorFn)` contract).
-
-```ts
-fromPromise<T, E = unknown>(promise: Promise<T>, parseErr?: (error: unknown) => E): ResultAsync<E, T>
-```
-
-| Parameter  | Type                    | Description                                |
-| ---------- | ----------------------- | ------------------------------------------ |
-| `promise`  | `Promise<T>`            | A promise that may reject.                 |
-| `parseErr` | `(error: unknown) => E` | Optional. Maps a rejection to a typed `E`. |
-
-```js
-import { fromPromise } from '@daisugi/anzen';
-
-const res = await fromPromise(Promise.reject(new Error('x')), (e) => e.message);
-res.unwrapErr(); // 'x'
-```
-
-[:top: Back to top](#-table-of-contents)
-
----
-
-### `fromSafePromise(promise)`
-
-Lifts a `Promise` that is already known not to reject (it resolves to a `Result`) into an `ResultAsync`.
-
-```ts
-fromSafePromise<E, T>(promise: Promise<ResultOk<T> | ResultErr<E>>): ResultAsync<E, T>
-```
-
-```js
-import { ok, fromSafePromise } from '@daisugi/anzen';
-
-await fromSafePromise(Promise.resolve(ok(1))).map((x) => x + 1); // Ok(2)
-```
+| Style               | Best when                                              | Notes                                                                                                                                                     |
+| ------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Sequential `Result` | Branches, loops, several intermediate values in scope  | Leanest at runtime; most explicit (`isErr` per step)                                                                                                      |
+| `safeTry`           | Multi-step flows where you want guard-free propagation | Generator overhead is negligible for I/O-bound work; see the [`safeTry`](#safetrybody) caveats (no throw-catching, no `finally` cleanup on short-circuit) |
 
 [:top: Back to top](#-table-of-contents)
 

--- a/packages/anzen/README.md
+++ b/packages/anzen/README.md
@@ -81,6 +81,7 @@ Every combinator is a standalone named export, so unused helpers are tree-shaken
     - [`toTuple(defaultValue?)`](#totupledefaultvalue)
     - [`fromAsyncThrowable(fn, parseErr?)`](#fromasyncthrowablefn-parseerr)
     - [`fromThrowable(fn, parseErr?)`](#fromthrowablefn-parseerr)
+    - [`wrapAsyncThrowable(fn, parseErr?)`](#wrapasyncthrowablefn-parseerr)
     - [`ResultAsync<E, T>`](#resultasynce-t)
     - [`okAsync(value)` / `errAsync(error)`](#okasyncvalue--errasyncerror)
     - [`fromPromise(promise, parseErr?)`](#frompromisepromise-parseerr)
@@ -589,6 +590,35 @@ const result = fromThrowable(
 );
 
 result.unwrapErr(); // 'err'
+```
+
+[:top: Back to top](#-table-of-contents)
+
+---
+
+### `wrapAsyncThrowable(fn, parseErr?)`
+
+The lazy counterpart of `fromAsyncThrowable`: adapts an async function that may throw or reject into a reusable Result-returning function (an `AnzenResultFn`), preserving its parameters. Lift a throwing function once and reuse it — e.g. behind `@daisugi/kintsugi` wrappers — instead of wrapping each call in `fromAsyncThrowable`.
+
+```ts
+wrapAsyncThrowable<A extends readonly unknown[], T, E = unknown>(
+  fn: (...args: A) => Promise<T>,
+  parseErr?: (err: unknown) => E,
+): (...args: A) => Promise<AnzenResult<E, T>>
+```
+
+| Parameter  | Type                         | Description                                   |
+| ---------- | ---------------------------- | --------------------------------------------- |
+| `fn`       | `(...args: A) => Promise<T>` | Async function to adapt.                       |
+| `parseErr` | `(err: unknown) => E`        | Optional transform applied to a caught error. |
+
+```js
+import { wrapAsyncThrowable } from '@daisugi/anzen';
+
+const fetchUserResult = wrapAsyncThrowable(fetchUser, (err) => err.message);
+
+const res = await fetchUserResult(42);
+if (res.isOk) console.log(res.unwrap());
 ```
 
 [:top: Back to top](#-table-of-contents)

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -535,15 +535,16 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof res,
-          | AnzenResultErr<unknown>
-          | AnzenResultOk<[number]>
+          AnzenResultErr<unknown> | AnzenResultOk<[number]>
         >,
         Equal<typeof results, [number]>
       >();
       assert.equal(res.isErr, true);
       if (res.isErr) {
         // After narrowing, unwrapErr() yields the raw caught value as unknown.
-        checkType<Equal<typeof res, AnzenResultErr<unknown>>>();
+        checkType<
+          Equal<typeof res, AnzenResultErr<unknown>>
+        >();
       }
     });
 

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -14,7 +14,7 @@ import {
   ok,
   safeTry,
   toTuple,
-  unwrapPromiseAll,
+  promiseAllTuple,
 } from '../anzen.js';
 import { type Equal, checkType } from './utils/types.js';
 
@@ -302,7 +302,7 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof errPair,
-          [AnzenResultErr<number>, undefined]
+          [AnzenResultErr<number>, never]
         >
       >();
       const errWithDefault = err(1).toTuple(2);
@@ -431,12 +431,12 @@ describe('Result', () => {
     });
   });
 
-  describe('unwrapPromiseAll', () => {
+  describe('promiseAllTuple', () => {
     it('when all promises are resolved with success, should return expected value', async () => {
       const promise1 = Promise.resolve(ok(1));
       const promise2 = Promise.resolve(ok(2));
       const promise3 = Promise.resolve(ok('A'));
-      const [res, ...results] = await unwrapPromiseAll([
+      const [res, ...results] = await promiseAllTuple([
         [0, 0, ''],
         promise1,
         promise2,
@@ -458,11 +458,11 @@ describe('Result', () => {
     it('when an input fails, returns the provided defaults as values', async () => {
       const failing: Promise<AnzenResult<string, number>> =
         Promise.resolve(err('boom'));
-      const [res, ...results] = await unwrapPromiseAll([
+      const [res, ...results] = await promiseAllTuple([
         [0],
         failing,
       ]);
-      // Assert the type before any narrowing access to `res`.
+      // Assert shape before any narrowing access to `res`.
       checkType<
         Equal<
           typeof res,
@@ -481,7 +481,7 @@ describe('Result', () => {
       const promise1 = Promise.resolve(ok(1));
       const promise2 = async () => ok(2);
       const promise3 = () => ok('A');
-      const [res, ...results] = await unwrapPromiseAll([
+      const [res, ...results] = await promiseAllTuple([
         [0, 0, '', 0],
         promise1,
         promise2(),
@@ -505,23 +505,63 @@ describe('Result', () => {
       const promise1 = Promise.resolve(ok(1));
       const promise2 = Promise.resolve(ok(2));
       // A full, correctly-typed defaults tuple is allowed.
-      await unwrapPromiseAll([[0, 0], promise1, promise2]);
-      await unwrapPromiseAll([
+      await promiseAllTuple([[0, 0], promise1, promise2]);
+      await promiseAllTuple([
         // @ts-expect-error short defaults are rejected: need 2, got 1.
         [0],
         promise1,
         promise2,
       ]);
-      await unwrapPromiseAll([
+      await promiseAllTuple([
         // @ts-expect-error empty defaults are rejected when results exist.
         [],
         promise1,
       ]);
-      await unwrapPromiseAll([
+      await promiseAllTuple([
         // @ts-expect-error default must match the success value type.
         ['not a number'],
         promise1,
       ]);
+    });
+
+    it('types a raw (non-Result) rejection as unknown (B2)', async () => {
+      const raw = Promise.reject(
+        new Error('raw'),
+      ) as Promise<AnzenResult<never, number>>;
+      const [res, ...results] = await promiseAllTuple([
+        [0],
+        raw,
+      ]);
+      checkType<
+        Equal<
+          typeof res,
+          | AnzenResultErr<unknown>
+          | AnzenResultOk<[number]>
+        >,
+        Equal<typeof results, [number]>
+      >();
+      assert.equal(res.isErr, true);
+      if (res.isErr) {
+        // After narrowing, unwrapErr() yields the raw caught value as unknown.
+        checkType<Equal<typeof res, AnzenResultErr<unknown>>>();
+      }
+    });
+
+    it('narrows to ok-only branch when all inputs are statically Ok', async () => {
+      const [res, n, s] = await promiseAllTuple([
+        [0, ''],
+        ok(1),
+        ok('a'),
+      ]);
+      checkType<
+        Equal<
+          typeof res,
+          | AnzenResultErr<unknown>
+          | AnzenResultOk<[number, string]>
+        >
+      >();
+      checkType<Equal<typeof n, number>>();
+      checkType<Equal<typeof s, string>>();
     });
   });
 
@@ -541,7 +581,7 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof result2,
-          [AnzenResultErr<number>, undefined]
+          [AnzenResultErr<number>, never]
         >
       >();
       const result3 = await fn2().then(toTuple(1));
@@ -563,7 +603,7 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof res,
-          | [AnzenResultErr<'err'>, undefined]
+          | [AnzenResultErr<'err'>, never]
           | [AnzenResultOk<number>, number]
         >
       >();
@@ -586,7 +626,7 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof good,
-          | [AnzenResultErr<never>, undefined]
+          | [AnzenResultErr<never>, never]
           | [AnzenResultOk<number>, number]
         >
       >();
@@ -597,7 +637,7 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof bad,
-          | [AnzenResultErr<string>, undefined]
+          | [AnzenResultErr<string>, never]
           | [AnzenResultOk<never>, never]
         >
       >();

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -5,11 +5,16 @@ import {
   type AnzenAnyResult,
   type AnzenResultErr,
   type AnzenResultOk,
+  AsyncResult,
   err,
+  errAsync,
   fromJSON,
+  fromPromise,
+  fromSafePromise,
   fromSyncThrowable,
   fromThrowable,
   isAnzenResult,
+  okAsync,
   promiseAll,
   ok,
   toTuple,
@@ -696,6 +701,154 @@ describe('Result', () => {
       assert.equal(res.isOk, true);
       assert.equal(res.isErr, false);
       assert.equal(res.unwrap(), 1);
+    });
+  });
+});
+
+describe('AsyncResult', () => {
+  describe('okAsync / errAsync', () => {
+    it('should build awaitable Results', async () => {
+      const okRes = await okAsync(1);
+      assert.equal(okRes.unwrap(), 1);
+      const errRes = await errAsync('boom');
+      assert.equal(errRes.unwrapErr(), 'boom');
+      checkType<Equal<typeof okAsync, typeof okAsync>>();
+    });
+  });
+
+  describe('then', () => {
+    it('should be awaitable to the underlying Result', async () => {
+      const res = await okAsync(1);
+      checkType<
+        Equal<typeof res, AnzenAnyResult<never, number>>
+      >();
+      assert.equal(res.isOk, true);
+    });
+  });
+
+  describe('map', () => {
+    it('should transform the Ok value with sync or async fn', async () => {
+      const res = await okAsync(1)
+        .map((x) => x + 1)
+        .map(async (x) => x * 10);
+      assert.equal(res.unwrap(), 20);
+      const passthrough = await errAsync<string>(
+        'boom',
+      ).map((x: number) => x + 1);
+      assert.equal(passthrough.unwrapErr(), 'boom');
+    });
+  });
+
+  describe('mapErr', () => {
+    it('should transform the Err value with sync or async fn', async () => {
+      const res = await errAsync('boom').mapErr(
+        async (e) => `${e}!`,
+      );
+      assert.equal(res.unwrapErr(), 'boom!');
+      const passthrough = await okAsync(1).mapErr(
+        (e: string) => `${e}!`,
+      );
+      assert.equal(passthrough.unwrap(), 1);
+    });
+  });
+
+  describe('andThen', () => {
+    it('should sequence Result / AsyncResult / Promise returns', async () => {
+      const viaResult = await okAsync(1).andThen((x) =>
+        ok(x + 1),
+      );
+      assert.equal(viaResult.unwrap(), 2);
+      const viaAsync = await okAsync(1).andThen((x) =>
+        okAsync(x + 2),
+      );
+      assert.equal(viaAsync.unwrap(), 3);
+      const viaPromise = await okAsync(1).andThen((x) =>
+        Promise.resolve(ok(x + 3)),
+      );
+      assert.equal(viaPromise.unwrap(), 4);
+      const short = await errAsync<string>('boom').andThen(
+        (x: number) => ok(x + 1),
+      );
+      assert.equal(short.unwrapErr(), 'boom');
+    });
+
+    it('should union the error type', async () => {
+      const res = await okAsync<number>(1).andThen((x) =>
+        x > 0 ? ok(x) : err('neg'),
+      );
+      checkType<
+        Equal<typeof res, AnzenAnyResult<string, number>>
+      >();
+    });
+  });
+
+  describe('orElse', () => {
+    it('should recover from an Err', async () => {
+      const recovered = await errAsync('boom').orElse(() =>
+        ok('foo'),
+      );
+      assert.equal(recovered.unwrap(), 'foo');
+      const passthrough = await okAsync(1).orElse(() =>
+        ok(2),
+      );
+      assert.equal(passthrough.unwrap(), 1);
+    });
+  });
+
+  describe('unwrap / unwrapErr / unwrapOr', () => {
+    it('should resolve the awaited terminals', async () => {
+      assert.equal(await okAsync(1).unwrap(), 1);
+      assert.equal(
+        await errAsync('boom').unwrapErr(),
+        'boom',
+      );
+      assert.equal(await errAsync('boom').unwrapOr(2), 2);
+      assert.equal(await okAsync(1).unwrapOr(2), 1);
+      await assert.rejects(
+        () => errAsync('boom').unwrap(),
+        {
+          message: 'Cannot get the value of an Err result.',
+        },
+      );
+    });
+  });
+
+  describe('fromPromise', () => {
+    it('should wrap a resolved promise as Ok', async () => {
+      const res = await fromPromise(Promise.resolve(1));
+      assert.equal(res.unwrap(), 1);
+    });
+
+    it('should wrap a rejection as Err, typed unknown by default', async () => {
+      const res = await fromPromise(
+        Promise.reject(new Error('x')),
+      );
+      assert.equal(res.isErr, true);
+      const error = res.unwrapErr();
+      checkType<Equal<typeof error, unknown>>();
+    });
+
+    it('should map the rejection via parseErr', async () => {
+      const res = await fromPromise(
+        Promise.reject(new Error('x')),
+        (e) => (e as Error).message,
+      );
+      assert.equal(res.unwrapErr(), 'x');
+      const error = res.unwrapErr();
+      checkType<Equal<typeof error, string>>();
+    });
+  });
+
+  describe('fromSafePromise', () => {
+    it('should lift a Promise<Result> into an AsyncResult', async () => {
+      const asyncRes = fromSafePromise<string, number>(
+        Promise.resolve(ok(1)),
+      );
+      checkType<
+        Equal<typeof asyncRes, AsyncResult<string, number>>
+      >();
+      const res = await asyncRes.map((x) => x + 1);
+      assert.equal(res.unwrap(), 2);
     });
   });
 });

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -5,21 +5,26 @@ import {
   type AnzenAnyResult,
   type AnzenResultFailure,
   type AnzenResultSuccess,
-  Result,
+  failure,
+  fromJSON,
+  fromSyncThrowable,
+  fromThrowable,
+  promiseAll,
+  success,
+  unwrap,
+  unwrapPromiseAll,
 } from '../anzen.js';
 import { type Equal, checkType } from './utils/types.js';
 
 function getRandomRes() {
-  return Math.random() > 0.5
-    ? Result.success(1)
-    : Result.failure('a');
+  return Math.random() > 0.5 ? success(1) : failure('a');
 }
 
 describe('Result', () => {
   describe('success', () => {
     it('should return expected value', () => {
-      const res = Result.success(1);
-      assert.deepEqual(res, Result.success(12));
+      const res = success(1);
+      assert.deepEqual(res, success(12));
       assert.equal(res.isSuccess, true);
       assert.equal(res.isFailure, false);
       checkType<
@@ -30,9 +35,9 @@ describe('Result', () => {
 
   describe('failure', () => {
     it('should return expected value', () => {
-      const res = Result.failure(1);
-      assert.deepEqual(res, Result.failure(12));
-      assert.notDeepEqual(res, Result.success(1));
+      const res = failure(1);
+      assert.deepEqual(res, failure(12));
+      assert.notDeepEqual(res, success(1));
       assert.equal(res.isSuccess, false);
       assert.equal(res.isFailure, true);
       checkType<
@@ -43,9 +48,9 @@ describe('Result', () => {
 
   describe('getValue', () => {
     it('should return expected value', () => {
-      const successRes = Result.success(1);
+      const successRes = success(1);
       assert.equal(successRes.getValue(), 1);
-      const failureRes = Result.failure(1);
+      const failureRes = failure(1);
       assert.throws(() => failureRes.getValue(), {
         message: 'Cannot get the value of a failure.',
       });
@@ -54,9 +59,10 @@ describe('Result', () => {
 
   describe('getError', () => {
     it('should return expected value', () => {
-      const successRes = Result.success(
-        1,
-      ) as AnzenAnyResult<string, number>;
+      const successRes = success(1) as AnzenAnyResult<
+        string,
+        number
+      >;
       assert.throws(
         () => {
           const a = successRes.getError();
@@ -70,7 +76,7 @@ describe('Result', () => {
         },
         { message: 'Cannot get the error of a success.' },
       );
-      const failureRes = Result.failure(1);
+      const failureRes = failure(1);
       assert.equal(failureRes.getError(), 1);
     });
   });
@@ -78,19 +84,19 @@ describe('Result', () => {
   describe('chain', () => {
     it('should return expected value', () => {
       assert.equal(
-        Result.success(1)
+        success(1)
           .chain((x) => {
             checkType<Equal<typeof x, number>>();
-            return Result.success(x + 1);
+            return success(x + 1);
           })
           .getValue(),
         2,
       );
       assert.equal(
-        Result.failure(1)
+        failure(1)
           .chain((x) => {
             checkType<Equal<typeof x, number>>();
-            return Result.success(x + 1);
+            return success(x + 1);
           })
           .getError(),
         1,
@@ -101,20 +107,20 @@ describe('Result', () => {
   describe('elseChain', () => {
     it('should return expected value', () => {
       assert.equal(
-        Result.success(1)
+        success(1)
           .elseChain((x) => {
             checkType<Equal<typeof x, number>>();
-            return Result.success(x + 1);
+            return success(x + 1);
           })
           .getValue(),
         1,
       );
-      const failureRes = Result.failure(1);
+      const failureRes = failure(1);
       assert.equal(
         failureRes
           .elseChain((x) => {
             checkType<Equal<typeof x, number>>();
-            return Result.success(x + 1);
+            return success(x + 1);
           })
           .getValue(),
         2,
@@ -125,21 +131,21 @@ describe('Result', () => {
   describe('chainElseChain', () => {
     it('should return expected value', () => {
       assert.equal(
-        Result.success(1)
-          .chain(() => Result.success('a'))
+        success(1)
+          .chain(() => success('a'))
           .elseChain((x) => {
             checkType<Equal<typeof x, string>>();
-            return Result.success(2);
+            return success(2);
           })
           .getValue(),
         'a',
       );
       assert.equal(
-        Result.failure(1)
-          .chain(() => Result.success('a'))
+        failure(1)
+          .chain(() => success('a'))
           .elseChain((x) => {
             checkType<Equal<typeof x, number>>();
-            return Result.success(2);
+            return success(2);
           })
           .getValue(),
         2,
@@ -147,11 +153,11 @@ describe('Result', () => {
       const randomRes = getRandomRes()
         .chain((x) => {
           checkType<Equal<typeof x, number | string>>();
-          return Result.success('a');
+          return success('a');
         })
         .elseChain((x) => {
           checkType<Equal<typeof x, string>>();
-          return Result.failure(2);
+          return failure(2);
         });
       checkType<
         Equal<
@@ -166,7 +172,7 @@ describe('Result', () => {
   describe('map', () => {
     it('should return expected value', () => {
       assert.equal(
-        Result.success(1)
+        success(1)
           .map((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
@@ -175,7 +181,7 @@ describe('Result', () => {
         2,
       );
       assert.equal(
-        Result.failure(1)
+        failure(1)
           .map((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
@@ -189,7 +195,7 @@ describe('Result', () => {
   describe('elseMap', () => {
     it('should return expected value', () => {
       assert.equal(
-        Result.success(1)
+        success(1)
           .elseMap((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
@@ -198,7 +204,7 @@ describe('Result', () => {
         1,
       );
       assert.equal(
-        Result.failure(1)
+        failure(1)
           .elseMap((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
@@ -212,7 +218,7 @@ describe('Result', () => {
   describe('mapElseMap', () => {
     it('should return expected value', () => {
       assert.equal(
-        Result.success(1)
+        success(1)
           .map(() => 'b')
           .elseMap((x) => {
             checkType<Equal<typeof x, string>>();
@@ -222,7 +228,7 @@ describe('Result', () => {
         'b',
       );
       assert.equal(
-        Result.failure(1)
+        failure(1)
           .map(() => 'a')
           .elseMap((x) => {
             checkType<Equal<typeof x, number>>();
@@ -252,35 +258,34 @@ describe('Result', () => {
 
   describe('getOrElse', () => {
     it('should return expected value', () => {
-      const successRes = Result.success(1);
+      const successRes = success(1);
       assert.equal(successRes.getOrElse(2), 1);
-      const failureRes = Result.failure(1);
+      const failureRes = failure(1);
       assert.equal(failureRes.getOrElse(2), 2);
     });
   });
 
   describe('unwrap', () => {
     it('should return expected value', () => {
-      const success = Result.success(1).unwrap();
-      assert.equal(success[0].getValue(), 1);
-      assert.equal(success[1], 1);
+      const successPair = success(1).unwrap();
+      assert.equal(successPair[0].getValue(), 1);
+      assert.equal(successPair[1], 1);
       checkType<
         Equal<
-          typeof success,
+          typeof successPair,
           [AnzenResultSuccess<number>, number]
         >
       >();
-      const failure = Result.failure(1).unwrap();
-      assert.equal(failure[0].getError(), 1);
-      assert.equal(failure[1], undefined);
+      const failurePair = failure(1).unwrap();
+      assert.equal(failurePair[0].getError(), 1);
+      assert.equal(failurePair[1], undefined);
       checkType<
         Equal<
-          typeof failure,
+          typeof failurePair,
           [AnzenResultFailure<number>, undefined]
         >
       >();
-      const failureWithDefault =
-        Result.failure(1).unwrap(2);
+      const failureWithDefault = failure(1).unwrap(2);
       assert.equal(failureWithDefault[0].getError(), 1);
       assert.equal(failureWithDefault[1], 2);
       checkType<
@@ -294,21 +299,21 @@ describe('Result', () => {
 
   describe('unsafeUnwrap', () => {
     it('should return expected value', () => {
-      const successRes = Result.success(1);
+      const successRes = success(1);
       assert.equal(successRes.unsafeUnwrap(), 1);
-      const failureRes = Result.failure(1);
+      const failureRes = failure(1);
       assert.equal(failureRes.unsafeUnwrap(), 1);
     });
   });
 
   describe('toJSON', () => {
     it('should return expected value', () => {
-      const successRes = Result.success(1);
+      const successRes = success(1);
       assert.deepEqual(
         successRes.toJSON(),
         JSON.stringify({ value: 1, isSuccess: true }),
       );
-      const failureRes = Result.failure(1);
+      const failureRes = failure(1);
       assert.deepEqual(
         failureRes.toJSON(),
         JSON.stringify({ error: 1, isSuccess: false }),
@@ -316,15 +321,15 @@ describe('Result', () => {
     });
   });
 
-  describe('Result.fromJSON', () => {
+  describe('fromJSON', () => {
     it('should return expected value', () => {
-      const successRes = Result.fromJSON(
+      const successRes = fromJSON(
         JSON.stringify({ value: 1, isSuccess: true }),
       );
       assert.equal(successRes.isSuccess, true);
       assert.equal(successRes.isFailure, false);
       assert.equal(successRes.getValue(), 1);
-      const failureRes = Result.fromJSON(
+      const failureRes = fromJSON(
         JSON.stringify({
           error: 1,
           isSuccess: false,
@@ -337,14 +342,14 @@ describe('Result', () => {
 
     it('types the result from its generic arguments', () => {
       // No generics: both sides default to unknown.
-      const res = Result.fromJSON(
+      const res = fromJSON(
         JSON.stringify({ value: 1, isSuccess: true }),
       );
       checkType<
         Equal<typeof res, AnzenAnyResult<unknown, unknown>>
       >();
       // Error-first generics, consistent with AnzenAnyResult<E, T>.
-      const typed = Result.fromJSON<string, number>(
+      const typed = fromJSON<string, number>(
         JSON.stringify({ value: 1, isSuccess: true }),
       );
       checkType<
@@ -353,12 +358,12 @@ describe('Result', () => {
     });
   });
 
-  describe('Result.promiseAll', () => {
+  describe('promiseAll', () => {
     it('when all promises are resolved with success, should return expected value', async () => {
-      const promise1 = Promise.resolve(Result.success(1));
-      const promise2 = async () => Result.success(2);
-      const promise3 = () => Result.success('A');
-      const res = await Result.promiseAll([
+      const promise1 = Promise.resolve(success(1));
+      const promise2 = async () => success(2);
+      const promise3 = () => success('A');
+      const res = await promiseAll([
         promise1,
         promise2(),
         promise3(),
@@ -372,7 +377,7 @@ describe('Result', () => {
           AnzenResultSuccess<[number, number, string]>
         >
       >();
-      const res2 = await Result.promiseAll([
+      const res2 = await promiseAll([
         promise1,
         promise2(),
         promise3(),
@@ -390,8 +395,8 @@ describe('Result', () => {
     });
 
     it('when promises are resolved with failure, should return expected value', async () => {
-      const promise1 = Promise.resolve(Result.failure(2));
-      const res = await Result.promiseAll([promise1]);
+      const promise1 = Promise.resolve(failure(2));
+      const res = await promiseAll([promise1]);
       assert.equal(res.isSuccess, false);
       assert.equal(res.isFailure, true);
       assert.equal(res.getError(), 2);
@@ -401,9 +406,9 @@ describe('Result', () => {
     });
 
     it('all-success inputs yield a never failure branch (no narrowing)', async () => {
-      const res = await Result.promiseAll([
-        Result.success(1),
-        Promise.resolve(Result.success('a')),
+      const res = await promiseAll([
+        success(1),
+        Promise.resolve(success('a')),
       ]);
       checkType<
         Equal<
@@ -415,18 +420,17 @@ describe('Result', () => {
     });
   });
 
-  describe('Result.unwrapPromiseAll', () => {
+  describe('unwrapPromiseAll', () => {
     it('when all promises are resolved with success, should return expected value', async () => {
-      const promise1 = Promise.resolve(Result.success(1));
-      const promise2 = Promise.resolve(Result.success(2));
-      const promise3 = Promise.resolve(Result.success('A'));
-      const [res, ...results] =
-        await Result.unwrapPromiseAll([
-          [],
-          promise1,
-          promise2,
-          promise3,
-        ]);
+      const promise1 = Promise.resolve(success(1));
+      const promise2 = Promise.resolve(success(2));
+      const promise3 = Promise.resolve(success('A'));
+      const [res, ...results] = await unwrapPromiseAll([
+        [],
+        promise1,
+        promise2,
+        promise3,
+      ]);
       if (res.isSuccess) {
         results;
       }
@@ -443,9 +447,11 @@ describe('Result', () => {
     });
 
     it('when promises are resolved with failure, should return expected value', async () => {
-      const promise1 = Promise.resolve(Result.failure(2));
-      const [res, ...results] =
-        await Result.unwrapPromiseAll([[], promise1]);
+      const promise1 = Promise.resolve(failure(2));
+      const [res, ...results] = await unwrapPromiseAll([
+        [],
+        promise1,
+      ]);
       assert.equal(res.isSuccess, false);
       assert.equal(res.isFailure, true);
       assert.deepEqual(results, []);
@@ -455,17 +461,16 @@ describe('Result', () => {
     });
 
     it('when inputs may fail, res should be typed as a success-or-failure union', async () => {
-      const promise1 = Promise.resolve(Result.success(1));
-      const promise2 = async () => Result.success(2);
-      const promise3 = () => Result.success('A');
-      const [res, ...results] =
-        await Result.unwrapPromiseAll([
-          [0, 0, '', 0],
-          promise1,
-          promise2(),
-          promise3(),
-          getRandomRes(),
-        ]);
+      const promise1 = Promise.resolve(success(1));
+      const promise2 = async () => success(2);
+      const promise3 = () => success('A');
+      const [res, ...results] = await unwrapPromiseAll([
+        [0, 0, '', 0],
+        promise1,
+        promise2(),
+        promise3(),
+        getRandomRes(),
+      ]);
       checkType<
         Equal<
           typeof res,
@@ -484,16 +489,15 @@ describe('Result', () => {
     it('when any input fails, returns the provided defaults as values', async () => {
       const ok = async (): Promise<
         AnzenAnyResult<string, number>
-      > => Result.success(1);
+      > => success(1);
       const bad = async (): Promise<
         AnzenAnyResult<string, number>
-      > => Result.failure('boom');
-      const [res, ...results] =
-        await Result.unwrapPromiseAll([
-          [10, 20],
-          ok(),
-          bad(),
-        ]);
+      > => failure('boom');
+      const [res, ...results] = await unwrapPromiseAll([
+        [10, 20],
+        ok(),
+        bad(),
+      ]);
       // Assert the type before any narrowing access to `res`.
       checkType<
         Equal<
@@ -511,12 +515,12 @@ describe('Result', () => {
     });
 
     it('defaults are type-checked against the success value types', async () => {
-      const promise1 = Promise.resolve(Result.success(1));
+      const promise1 = Promise.resolve(success(1));
       // No defaults is allowed.
-      await Result.unwrapPromiseAll([[], promise1]);
+      await unwrapPromiseAll([[], promise1]);
       // A matching default is allowed.
-      await Result.unwrapPromiseAll([[0], promise1]);
-      await Result.unwrapPromiseAll([
+      await unwrapPromiseAll([[0], promise1]);
+      await unwrapPromiseAll([
         // @ts-expect-error default must match the success value type.
         ['not a number'],
         promise1,
@@ -524,12 +528,12 @@ describe('Result', () => {
     });
   });
 
-  describe('Result.unwrap', () => {
+  describe('unwrap', () => {
     it('should return expected value', async () => {
-      const successRes = Result.success(1);
-      const failureRes = Result.failure(1);
+      const successRes = success(1);
+      const failureRes = failure(1);
       const fn = async () => successRes;
-      const res = await fn().then(Result.unwrap());
+      const res = await fn().then(unwrap());
       assert.deepEqual(res, [successRes, 1]);
       checkType<
         Equal<
@@ -538,7 +542,7 @@ describe('Result', () => {
         >
       >();
       const fn2 = async () => failureRes;
-      const result2 = await fn2().then(Result.unwrap());
+      const result2 = await fn2().then(unwrap());
       assert.deepEqual(result2, [failureRes, undefined]);
       checkType<
         Equal<
@@ -546,7 +550,7 @@ describe('Result', () => {
           [AnzenResultFailure<number>, undefined]
         >
       >();
-      const result3 = await fn2().then(Result.unwrap(1));
+      const result3 = await fn2().then(unwrap(1));
       assert.deepEqual(result3, [failureRes, 1]);
       checkType<
         Equal<
@@ -559,9 +563,9 @@ describe('Result', () => {
     it('infers the success-or-failure tuple union without narrowing', async () => {
       const fn = async (): Promise<
         AnzenAnyResult<'err', number>
-      > => Result.success(1);
+      > => success(1);
       // Assert the type before any narrowing access.
-      const res = await fn().then(Result.unwrap());
+      const res = await fn().then(unwrap());
       checkType<
         Equal<
           typeof res,
@@ -570,9 +574,7 @@ describe('Result', () => {
         >
       >();
       // With a default, the failure value takes the default type.
-      const res2 = await fn().then(
-        Result.unwrap('fallback'),
-      );
+      const res2 = await fn().then(unwrap('fallback'));
       checkType<
         Equal<
           typeof res2,
@@ -584,8 +586,9 @@ describe('Result', () => {
 
     it('uses never for the impossible branch of a single-variant input', async () => {
       // A statically-success input cannot fail: error type is never.
-      const ok = await (async () =>
-        Result.success(1))().then(Result.unwrap());
+      const ok = await (async () => success(1))().then(
+        unwrap(),
+      );
       checkType<
         Equal<
           typeof ok,
@@ -594,8 +597,9 @@ describe('Result', () => {
         >
       >();
       // A statically-failure input cannot succeed: value type is never.
-      const bad = await (async () =>
-        Result.failure('e'))().then(Result.unwrap());
+      const bad = await (async () => failure('e'))().then(
+        unwrap(),
+      );
       checkType<
         Equal<
           typeof bad,
@@ -606,10 +610,10 @@ describe('Result', () => {
     });
   });
 
-  describe('Result.fromThrowable', () => {
+  describe('fromThrowable', () => {
     it('when throwable is thrown, should return expected value', () => {
       // Error-first generics let you name only the error type.
-      const res = Result.fromSyncThrowable<Error>(() => {
+      const res = fromSyncThrowable<Error>(() => {
         throw new Error('err');
       });
       checkType<
@@ -623,7 +627,7 @@ describe('Result', () => {
     });
 
     it('when throwable is not thrown, should return expected value', () => {
-      const res = Result.fromSyncThrowable(() => 1);
+      const res = fromSyncThrowable(() => 1);
       // No parseErr: value is inferred, error defaults to unknown.
       checkType<
         Equal<typeof res, AnzenAnyResult<unknown, number>>
@@ -635,7 +639,7 @@ describe('Result', () => {
 
     describe('parseError is provided', () => {
       it('when throwable is thrown, should return expected value', () => {
-        const res = Result.fromSyncThrowable(
+        const res = fromSyncThrowable(
           () => {
             throw new Error('err');
           },
@@ -658,11 +662,9 @@ describe('Result', () => {
 
     describe('async', () => {
       it('when throwable is thrown, should return expected value', async () => {
-        const res = await Result.fromThrowable<Error>(
-          async () => {
-            throw new Error('err');
-          },
-        );
+        const res = await fromThrowable<Error>(async () => {
+          throw new Error('err');
+        });
         checkType<
           Equal<typeof res, AnzenAnyResult<Error, unknown>>
         >();
@@ -675,7 +677,7 @@ describe('Result', () => {
     });
 
     it('when throwable is not thrown, should return expected value', async () => {
-      const res = await Result.fromThrowable(async () => 1);
+      const res = await fromThrowable(async () => 1);
       checkType<
         Equal<typeof res, AnzenAnyResult<unknown, number>>
       >();

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -3,65 +3,65 @@ import { describe, it } from 'node:test';
 
 import {
   type AnzenAnyResult,
-  type AnzenResultFailure,
-  type AnzenResultSuccess,
-  failure,
+  type AnzenResultErr,
+  type AnzenResultOk,
+  err,
   fromJSON,
   fromSyncThrowable,
   fromThrowable,
   isAnzenResult,
   promiseAll,
-  success,
+  ok,
   toTuple,
   unwrapPromiseAll,
 } from '../anzen.js';
 import { type Equal, checkType } from './utils/types.js';
 
 function getRandomRes() {
-  return Math.random() > 0.5 ? success(1) : failure('a');
+  return Math.random() > 0.5 ? ok(1) : err('a');
 }
 
 describe('Result', () => {
-  describe('success', () => {
+  describe('ok', () => {
     it('should return expected value', () => {
-      const res = success(1);
-      assert.deepEqual(res, success(12));
-      assert.equal(res.isSuccess, true);
-      assert.equal(res.isFailure, false);
-      checkType<
-        Equal<typeof res, AnzenResultSuccess<number>>
-      >();
+      const res = ok(1);
+      assert.deepEqual(res, ok(12));
+      assert.equal(res.isOk, true);
+      assert.equal(res.isErr, false);
+      checkType<Equal<typeof res, AnzenResultOk<number>>>();
     });
   });
 
-  describe('failure', () => {
+  describe('err', () => {
     it('should return expected value', () => {
-      const res = failure(1);
-      assert.deepEqual(res, failure(12));
-      assert.notDeepEqual(res, success(1));
-      assert.equal(res.isSuccess, false);
-      assert.equal(res.isFailure, true);
+      const res = err(1);
+      assert.deepEqual(res, err(12));
+      assert.notDeepEqual(res, ok(1));
+      assert.equal(res.isOk, false);
+      assert.equal(res.isErr, true);
       checkType<
-        Equal<typeof res, AnzenResultFailure<number>>
+        Equal<typeof res, AnzenResultErr<number>>
       >();
     });
   });
 
   describe('isAnzenResult', () => {
     it('should narrow Results and reject non-Results', () => {
-      assert.equal(isAnzenResult(success(1)), true);
-      assert.equal(isAnzenResult(failure(1)), true);
-      assert.equal(isAnzenResult(fromJSON(success(1).toJSON())), true);
+      assert.equal(isAnzenResult(ok(1)), true);
+      assert.equal(isAnzenResult(err(1)), true);
+      assert.equal(
+        isAnzenResult(fromJSON(ok(1).toJSON())),
+        true,
+      );
       assert.equal(isAnzenResult(null), false);
-      assert.equal(isAnzenResult(undefined), false);
-      assert.equal(isAnzenResult({ isSuccess: true }), false);
-      assert.equal(isAnzenResult('success'), false);
-      const value: unknown = success(1);
+      assert.equal(isAnzenResult({ isOk: true }), false);
+      assert.equal(isAnzenResult('ok'), false);
+      const value: unknown = ok(1);
       if (isAnzenResult(value)) {
         checkType<
           Equal<
             typeof value,
-            AnzenResultSuccess<unknown> | AnzenResultFailure<unknown>
+            AnzenResultOk<unknown> | AnzenResultErr<unknown>
           >
         >();
       }
@@ -70,25 +70,22 @@ describe('Result', () => {
 
   describe('unwrap', () => {
     it('should return expected value', () => {
-      const successRes = success(1);
-      assert.equal(successRes.unwrap(), 1);
-      const failureRes = failure(1);
-      assert.throws(() => failureRes.unwrap(), {
-        message: 'Cannot get the value of a failure.',
+      const okRes = ok(1);
+      assert.equal(okRes.unwrap(), 1);
+      const errRes = err(1);
+      assert.throws(() => errRes.unwrap(), {
+        message: 'Cannot get the value of an Err result.',
       });
     });
   });
 
   describe('unwrapErr', () => {
     it('should return expected value', () => {
-      const successRes = success(1) as AnzenAnyResult<
-        string,
-        number
-      >;
+      const okRes = ok(1) as AnzenAnyResult<string, number>;
       assert.throws(
         () => {
-          const a = successRes.unwrapErr();
-          const b = successRes.unwrap();
+          const a = okRes.unwrapErr();
+          const b = okRes.unwrap();
           // The throwing branch is typed `never`, so union access
           // stays clean: unwrapErr() -> E, unwrap() -> T.
           checkType<
@@ -96,29 +93,31 @@ describe('Result', () => {
             Equal<typeof b, number>
           >();
         },
-        { message: 'Cannot get the error of a success.' },
+        {
+          message: 'Cannot get the error of an Ok result.',
+        },
       );
-      const failureRes = failure(1);
-      assert.equal(failureRes.unwrapErr(), 1);
+      const errRes = err(1);
+      assert.equal(errRes.unwrapErr(), 1);
     });
   });
 
   describe('andThen', () => {
     it('should return expected value', () => {
       assert.equal(
-        success(1)
+        ok(1)
           .andThen((x) => {
             checkType<Equal<typeof x, number>>();
-            return success(x + 1);
+            return ok(x + 1);
           })
           .unwrap(),
         2,
       );
       assert.equal(
-        failure(1)
+        err(1)
           .andThen((x) => {
             checkType<Equal<typeof x, number>>();
-            return success(x + 1);
+            return ok(x + 1);
           })
           .unwrapErr(),
         1,
@@ -129,20 +128,20 @@ describe('Result', () => {
   describe('orElse', () => {
     it('should return expected value', () => {
       assert.equal(
-        success(1)
+        ok(1)
           .orElse((x) => {
             checkType<Equal<typeof x, number>>();
-            return success(x + 1);
+            return ok(x + 1);
           })
           .unwrap(),
         1,
       );
-      const failureRes = failure(1);
+      const errRes = err(1);
       assert.equal(
-        failureRes
+        errRes
           .orElse((x) => {
             checkType<Equal<typeof x, number>>();
-            return success(x + 1);
+            return ok(x + 1);
           })
           .unwrap(),
         2,
@@ -153,21 +152,21 @@ describe('Result', () => {
   describe('chainElseChain', () => {
     it('should return expected value', () => {
       assert.equal(
-        success(1)
-          .andThen(() => success('a'))
+        ok(1)
+          .andThen(() => ok('a'))
           .orElse((x) => {
             checkType<Equal<typeof x, string>>();
-            return success(2);
+            return ok(2);
           })
           .unwrap(),
         'a',
       );
       assert.equal(
-        failure(1)
-          .andThen(() => success('a'))
+        err(1)
+          .andThen(() => ok('a'))
           .orElse((x) => {
             checkType<Equal<typeof x, number>>();
-            return success(2);
+            return ok(2);
           })
           .unwrap(),
         2,
@@ -175,17 +174,16 @@ describe('Result', () => {
       const randomRes = getRandomRes()
         .andThen((x) => {
           checkType<Equal<typeof x, number | string>>();
-          return success('a');
+          return ok('a');
         })
         .orElse((x) => {
           checkType<Equal<typeof x, string>>();
-          return failure(2);
+          return err(2);
         });
       checkType<
         Equal<
           typeof randomRes,
-          | AnzenResultFailure<number>
-          | AnzenResultSuccess<string>
+          AnzenResultErr<number> | AnzenResultOk<string>
         >
       >();
     });
@@ -194,7 +192,7 @@ describe('Result', () => {
   describe('map', () => {
     it('should return expected value', () => {
       assert.equal(
-        success(1)
+        ok(1)
           .map((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
@@ -203,7 +201,7 @@ describe('Result', () => {
         2,
       );
       assert.equal(
-        failure(1)
+        err(1)
           .map((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
@@ -217,7 +215,7 @@ describe('Result', () => {
   describe('mapErr', () => {
     it('should return expected value', () => {
       assert.equal(
-        success(1)
+        ok(1)
           .mapErr((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
@@ -226,7 +224,7 @@ describe('Result', () => {
         1,
       );
       assert.equal(
-        failure(1)
+        err(1)
           .mapErr((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
@@ -240,7 +238,7 @@ describe('Result', () => {
   describe('mapMapErr', () => {
     it('should return expected value', () => {
       assert.equal(
-        success(1)
+        ok(1)
           .map(() => 'b')
           .mapErr((x) => {
             checkType<Equal<typeof x, string>>();
@@ -250,7 +248,7 @@ describe('Result', () => {
         'b',
       );
       assert.equal(
-        failure(1)
+        err(1)
           .map(() => 'a')
           .mapErr((x) => {
             checkType<Equal<typeof x, number>>();
@@ -271,8 +269,7 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof randomRes,
-          | AnzenResultSuccess<number>
-          | AnzenResultSuccess<string>
+          AnzenResultOk<number> | AnzenResultOk<string>
         >
       >();
     });
@@ -280,40 +277,40 @@ describe('Result', () => {
 
   describe('unwrapOr', () => {
     it('should return expected value', () => {
-      const successRes = success(1);
-      assert.equal(successRes.unwrapOr(2), 1);
-      const failureRes = failure(1);
-      assert.equal(failureRes.unwrapOr(2), 2);
+      const okRes = ok(1);
+      assert.equal(okRes.unwrapOr(2), 1);
+      const errRes = err(1);
+      assert.equal(errRes.unwrapOr(2), 2);
     });
   });
 
   describe('toTuple', () => {
     it('should return expected value', () => {
-      const successPair = success(1).toTuple();
-      assert.equal(successPair[0].unwrap(), 1);
-      assert.equal(successPair[1], 1);
+      const okPair = ok(1).toTuple();
+      assert.equal(okPair[0].unwrap(), 1);
+      assert.equal(okPair[1], 1);
       checkType<
         Equal<
-          typeof successPair,
-          [AnzenResultSuccess<number>, number]
+          typeof okPair,
+          [AnzenResultOk<number>, number]
         >
       >();
-      const failurePair = failure(1).toTuple();
-      assert.equal(failurePair[0].unwrapErr(), 1);
-      assert.equal(failurePair[1], undefined);
+      const errPair = err(1).toTuple();
+      assert.equal(errPair[0].unwrapErr(), 1);
+      assert.equal(errPair[1], undefined);
       checkType<
         Equal<
-          typeof failurePair,
-          [AnzenResultFailure<number>, undefined]
+          typeof errPair,
+          [AnzenResultErr<number>, undefined]
         >
       >();
-      const failureWithDefault = failure(1).toTuple(2);
-      assert.equal(failureWithDefault[0].unwrapErr(), 1);
-      assert.equal(failureWithDefault[1], 2);
+      const errWithDefault = err(1).toTuple(2);
+      assert.equal(errWithDefault[0].unwrapErr(), 1);
+      assert.equal(errWithDefault[1], 2);
       checkType<
         Equal<
-          typeof failureWithDefault,
-          [AnzenResultFailure<number>, number]
+          typeof errWithDefault,
+          [AnzenResultErr<number>, number]
         >
       >();
     });
@@ -321,58 +318,58 @@ describe('Result', () => {
 
   describe('getRaw', () => {
     it('should return expected value', () => {
-      const successRes = success(1);
-      assert.equal(successRes.getRaw(), 1);
-      const failureRes = failure(1);
-      assert.equal(failureRes.getRaw(), 1);
+      const okRes = ok(1);
+      assert.equal(okRes.getRaw(), 1);
+      const errRes = err(1);
+      assert.equal(errRes.getRaw(), 1);
     });
   });
 
   describe('toJSON', () => {
     it('should return expected value', () => {
-      const successRes = success(1);
+      const okRes = ok(1);
       assert.deepEqual(
-        successRes.toJSON(),
-        JSON.stringify({ value: 1, isSuccess: true }),
+        okRes.toJSON(),
+        JSON.stringify({ value: 1, isOk: true }),
       );
-      const failureRes = failure(1);
+      const errRes = err(1);
       assert.deepEqual(
-        failureRes.toJSON(),
-        JSON.stringify({ error: 1, isSuccess: false }),
+        errRes.toJSON(),
+        JSON.stringify({ error: 1, isOk: false }),
       );
     });
   });
 
   describe('fromJSON', () => {
     it('should return expected value', () => {
-      const successRes = fromJSON(
-        JSON.stringify({ value: 1, isSuccess: true }),
+      const okRes = fromJSON(
+        JSON.stringify({ value: 1, isOk: true }),
       );
-      assert.equal(successRes.isSuccess, true);
-      assert.equal(successRes.isFailure, false);
-      assert.equal(successRes.unwrap(), 1);
-      const failureRes = fromJSON(
+      assert.equal(okRes.isOk, true);
+      assert.equal(okRes.isErr, false);
+      assert.equal(okRes.unwrap(), 1);
+      const errRes = fromJSON(
         JSON.stringify({
           error: 1,
-          isSuccess: false,
+          isOk: false,
         }),
       );
-      assert.equal(failureRes.isSuccess, false);
-      assert.equal(failureRes.isFailure, true);
-      assert.equal(failureRes.unwrapErr(), 1);
+      assert.equal(errRes.isOk, false);
+      assert.equal(errRes.isErr, true);
+      assert.equal(errRes.unwrapErr(), 1);
     });
 
     it('types the result from its generic arguments', () => {
       // No generics: both sides default to unknown.
       const res = fromJSON(
-        JSON.stringify({ value: 1, isSuccess: true }),
+        JSON.stringify({ value: 1, isOk: true }),
       );
       checkType<
         Equal<typeof res, AnzenAnyResult<unknown, unknown>>
       >();
       // Error-first generics, consistent with AnzenAnyResult<E, T>.
       const typed = fromJSON<string, number>(
-        JSON.stringify({ value: 1, isSuccess: true }),
+        JSON.stringify({ value: 1, isOk: true }),
       );
       checkType<
         Equal<typeof typed, AnzenAnyResult<string, number>>
@@ -382,21 +379,21 @@ describe('Result', () => {
 
   describe('promiseAll', () => {
     it('when all promises are resolved with success, should return expected value', async () => {
-      const promise1 = Promise.resolve(success(1));
-      const promise2 = async () => success(2);
-      const promise3 = () => success('A');
+      const promise1 = Promise.resolve(ok(1));
+      const promise2 = async () => ok(2);
+      const promise3 = () => ok('A');
       const res = await promiseAll([
         promise1,
         promise2(),
         promise3(),
       ]);
-      assert.equal(res.isSuccess, true);
-      assert.equal(res.isFailure, false);
+      assert.equal(res.isOk, true);
+      assert.equal(res.isErr, false);
       assert.deepEqual(res.unwrap(), [1, 2, 'A']);
       checkType<
         Equal<
           typeof res,
-          AnzenResultSuccess<[number, number, string]>
+          AnzenResultOk<[number, number, string]>
         >
       >();
       const res2 = await promiseAll([
@@ -408,35 +405,33 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof res2,
-          | AnzenResultFailure<string>
-          | AnzenResultSuccess<
-              [number, number, string, number]
-            >
+          | AnzenResultErr<string>
+          | AnzenResultOk<[number, number, string, number]>
         >
       >();
     });
 
     it('when promises are resolved with failure, should return expected value', async () => {
-      const promise1 = Promise.resolve(failure(2));
+      const promise1 = Promise.resolve(err(2));
       const res = await promiseAll([promise1]);
-      assert.equal(res.isSuccess, false);
-      assert.equal(res.isFailure, true);
+      assert.equal(res.isOk, false);
+      assert.equal(res.isErr, true);
       assert.equal(res.unwrapErr(), 2);
       checkType<
-        Equal<typeof res, AnzenResultFailure<number>>
+        Equal<typeof res, AnzenResultErr<number>>
       >();
     });
 
     it('all-success inputs yield a never failure branch (no narrowing)', async () => {
       const res = await promiseAll([
-        success(1),
-        Promise.resolve(success('a')),
+        ok(1),
+        Promise.resolve(ok('a')),
       ]);
       checkType<
         Equal<
           typeof res,
-          | AnzenResultSuccess<[number, string]>
-          | AnzenResultFailure<never>
+          | AnzenResultOk<[number, string]>
+          | AnzenResultErr<never>
         >
       >();
     });
@@ -444,48 +439,48 @@ describe('Result', () => {
 
   describe('unwrapPromiseAll', () => {
     it('when all promises are resolved with success, should return expected value', async () => {
-      const promise1 = Promise.resolve(success(1));
-      const promise2 = Promise.resolve(success(2));
-      const promise3 = Promise.resolve(success('A'));
+      const promise1 = Promise.resolve(ok(1));
+      const promise2 = Promise.resolve(ok(2));
+      const promise3 = Promise.resolve(ok('A'));
       const [res, ...results] = await unwrapPromiseAll([
         [],
         promise1,
         promise2,
         promise3,
       ]);
-      if (res.isSuccess) {
+      if (res.isOk) {
         results;
       }
-      assert.equal(res.isSuccess, true);
-      assert.equal(res.isFailure, false);
+      assert.equal(res.isOk, true);
+      assert.equal(res.isErr, false);
       assert.deepEqual(results, [1, 2, 'A']);
       checkType<
         Equal<
           typeof res,
-          AnzenResultSuccess<[number, number, string]>
+          AnzenResultOk<[number, number, string]>
         >,
         Equal<typeof results, [number, number, string]>
       >();
     });
 
     it('when promises are resolved with failure, should return expected value', async () => {
-      const promise1 = Promise.resolve(failure(2));
+      const promise1 = Promise.resolve(err(2));
       const [res, ...results] = await unwrapPromiseAll([
         [],
         promise1,
       ]);
-      assert.equal(res.isSuccess, false);
-      assert.equal(res.isFailure, true);
+      assert.equal(res.isOk, false);
+      assert.equal(res.isErr, true);
       assert.deepEqual(results, []);
       checkType<
-        Equal<typeof res, AnzenResultFailure<number>>
+        Equal<typeof res, AnzenResultErr<number>>
       >();
     });
 
     it('when inputs may fail, res should be typed as a success-or-failure union', async () => {
-      const promise1 = Promise.resolve(success(1));
-      const promise2 = async () => success(2);
-      const promise3 = () => success('A');
+      const promise1 = Promise.resolve(ok(1));
+      const promise2 = async () => ok(2);
+      const promise3 = () => ok('A');
       const [res, ...results] = await unwrapPromiseAll([
         [0, 0, '', 0],
         promise1,
@@ -496,10 +491,8 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof res,
-          | AnzenResultFailure<string>
-          | AnzenResultSuccess<
-              [number, number, string, number]
-            >
+          | AnzenResultErr<string>
+          | AnzenResultOk<[number, number, string, number]>
         >,
         Equal<
           typeof results,
@@ -509,35 +502,35 @@ describe('Result', () => {
     });
 
     it('when any input fails, returns the provided defaults as values', async () => {
-      const ok = async (): Promise<
+      const good = async (): Promise<
         AnzenAnyResult<string, number>
-      > => success(1);
+      > => ok(1);
       const bad = async (): Promise<
         AnzenAnyResult<string, number>
-      > => failure('boom');
+      > => err('boom');
       const [res, ...results] = await unwrapPromiseAll([
         [10, 20],
-        ok(),
+        good(),
         bad(),
       ]);
       // Assert the type before any narrowing access to `res`.
       checkType<
         Equal<
           typeof res,
-          | AnzenResultFailure<string>
-          | AnzenResultSuccess<[number, number]>
+          | AnzenResultErr<string>
+          | AnzenResultOk<[number, number]>
         >,
         Equal<typeof results, [number, number]>
       >();
-      assert.equal(res.isFailure, true);
-      if (res.isFailure) {
+      assert.equal(res.isErr, true);
+      if (res.isErr) {
         assert.equal(res.unwrapErr(), 'boom');
       }
       assert.deepEqual(results, [10, 20]);
     });
 
     it('defaults are type-checked against the success value types', async () => {
-      const promise1 = Promise.resolve(success(1));
+      const promise1 = Promise.resolve(ok(1));
       // No defaults is allowed.
       await unwrapPromiseAll([[], promise1]);
       // A matching default is allowed.
@@ -552,32 +545,29 @@ describe('Result', () => {
 
   describe('toTuple', () => {
     it('should return expected value', async () => {
-      const successRes = success(1);
-      const failureRes = failure(1);
-      const fn = async () => successRes;
+      const okRes = ok(1);
+      const errRes = err(1);
+      const fn = async () => okRes;
       const res = await fn().then(toTuple());
-      assert.deepEqual(res, [successRes, 1]);
+      assert.deepEqual(res, [okRes, 1]);
       checkType<
-        Equal<
-          typeof res,
-          [AnzenResultSuccess<number>, number]
-        >
+        Equal<typeof res, [AnzenResultOk<number>, number]>
       >();
-      const fn2 = async () => failureRes;
+      const fn2 = async () => errRes;
       const result2 = await fn2().then(toTuple());
-      assert.deepEqual(result2, [failureRes, undefined]);
+      assert.deepEqual(result2, [errRes, undefined]);
       checkType<
         Equal<
           typeof result2,
-          [AnzenResultFailure<number>, undefined]
+          [AnzenResultErr<number>, undefined]
         >
       >();
       const result3 = await fn2().then(toTuple(1));
-      assert.deepEqual(result3, [failureRes, 1]);
+      assert.deepEqual(result3, [errRes, 1]);
       checkType<
         Equal<
           typeof result3,
-          [AnzenResultFailure<number>, number]
+          [AnzenResultErr<number>, number]
         >
       >();
     });
@@ -585,14 +575,14 @@ describe('Result', () => {
     it('infers the success-or-failure tuple union without narrowing', async () => {
       const fn = async (): Promise<
         AnzenAnyResult<'err', number>
-      > => success(1);
+      > => ok(1);
       // Assert the type before any narrowing access.
       const res = await fn().then(toTuple());
       checkType<
         Equal<
           typeof res,
-          | [AnzenResultFailure<'err'>, undefined]
-          | [AnzenResultSuccess<number>, number]
+          | [AnzenResultErr<'err'>, undefined]
+          | [AnzenResultOk<number>, number]
         >
       >();
       // With a default, the failure value takes the default type.
@@ -600,33 +590,33 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof res2,
-          | [AnzenResultFailure<'err'>, string]
-          | [AnzenResultSuccess<number>, number]
+          | [AnzenResultErr<'err'>, string]
+          | [AnzenResultOk<number>, number]
         >
       >();
     });
 
     it('uses never for the impossible branch of a single-variant input', async () => {
       // A statically-success input cannot fail: error type is never.
-      const ok = await (async () => success(1))().then(
+      const good = await (async () => ok(1))().then(
         toTuple(),
       );
       checkType<
         Equal<
-          typeof ok,
-          | [AnzenResultFailure<never>, undefined]
-          | [AnzenResultSuccess<number>, number]
+          typeof good,
+          | [AnzenResultErr<never>, undefined]
+          | [AnzenResultOk<number>, number]
         >
       >();
       // A statically-failure input cannot succeed: value type is never.
-      const bad = await (async () => failure('e'))().then(
+      const bad = await (async () => err('e'))().then(
         toTuple(),
       );
       checkType<
         Equal<
           typeof bad,
-          | [AnzenResultFailure<string>, undefined]
-          | [AnzenResultSuccess<never>, never]
+          | [AnzenResultErr<string>, undefined]
+          | [AnzenResultOk<never>, never]
         >
       >();
     });
@@ -641,9 +631,9 @@ describe('Result', () => {
       checkType<
         Equal<typeof res, AnzenAnyResult<Error, unknown>>
       >();
-      assert.equal(res.isSuccess, false);
-      assert.equal(res.isFailure, true);
-      if (res.isFailure) {
+      assert.equal(res.isOk, false);
+      assert.equal(res.isErr, true);
+      if (res.isErr) {
         assert.equal(res.unwrapErr().message, 'err');
       }
     });
@@ -654,8 +644,8 @@ describe('Result', () => {
       checkType<
         Equal<typeof res, AnzenAnyResult<unknown, number>>
       >();
-      assert.equal(res.isSuccess, true);
-      assert.equal(res.isFailure, false);
+      assert.equal(res.isOk, true);
+      assert.equal(res.isErr, false);
       assert.equal(res.unwrap(), 1);
     });
 
@@ -674,9 +664,9 @@ describe('Result', () => {
         checkType<
           Equal<typeof res, AnzenAnyResult<string, never>>
         >();
-        assert.equal(res.isSuccess, false);
-        assert.equal(res.isFailure, true);
-        if (res.isFailure) {
+        assert.equal(res.isOk, false);
+        assert.equal(res.isErr, true);
+        if (res.isErr) {
           assert.equal(res.unwrapErr(), 'err');
         }
       });
@@ -690,9 +680,9 @@ describe('Result', () => {
         checkType<
           Equal<typeof res, AnzenAnyResult<Error, unknown>>
         >();
-        assert.equal(res.isSuccess, false);
-        assert.equal(res.isFailure, true);
-        if (res.isFailure) {
+        assert.equal(res.isOk, false);
+        assert.equal(res.isErr, true);
+        if (res.isErr) {
           assert.equal(res.unwrapErr().message, 'err');
         }
       });
@@ -703,8 +693,8 @@ describe('Result', () => {
       checkType<
         Equal<typeof res, AnzenAnyResult<unknown, number>>
       >();
-      assert.equal(res.isSuccess, true);
-      assert.equal(res.isFailure, false);
+      assert.equal(res.isOk, true);
+      assert.equal(res.isErr, false);
       assert.equal(res.unwrap(), 1);
     });
   });

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -11,7 +11,7 @@ import {
   fromThrowable,
   promiseAll,
   success,
-  unwrap,
+  toTuple,
   unwrapPromiseAll,
 } from '../anzen.js';
 import { type Equal, checkType } from './utils/types.js';
@@ -46,18 +46,18 @@ describe('Result', () => {
     });
   });
 
-  describe('getValue', () => {
+  describe('unwrap', () => {
     it('should return expected value', () => {
       const successRes = success(1);
-      assert.equal(successRes.getValue(), 1);
+      assert.equal(successRes.unwrap(), 1);
       const failureRes = failure(1);
-      assert.throws(() => failureRes.getValue(), {
+      assert.throws(() => failureRes.unwrap(), {
         message: 'Cannot get the value of a failure.',
       });
     });
   });
 
-  describe('getError', () => {
+  describe('unwrapErr', () => {
     it('should return expected value', () => {
       const successRes = success(1) as AnzenAnyResult<
         string,
@@ -65,10 +65,10 @@ describe('Result', () => {
       >;
       assert.throws(
         () => {
-          const a = successRes.getError();
-          const b = successRes.getValue();
+          const a = successRes.unwrapErr();
+          const b = successRes.unwrap();
           // The throwing branch is typed `never`, so union access
-          // stays clean: getError() -> E, getValue() -> T.
+          // stays clean: unwrapErr() -> E, unwrap() -> T.
           checkType<
             Equal<typeof a, string>,
             Equal<typeof b, number>
@@ -77,52 +77,52 @@ describe('Result', () => {
         { message: 'Cannot get the error of a success.' },
       );
       const failureRes = failure(1);
-      assert.equal(failureRes.getError(), 1);
+      assert.equal(failureRes.unwrapErr(), 1);
     });
   });
 
-  describe('chain', () => {
+  describe('andThen', () => {
     it('should return expected value', () => {
       assert.equal(
         success(1)
-          .chain((x) => {
+          .andThen((x) => {
             checkType<Equal<typeof x, number>>();
             return success(x + 1);
           })
-          .getValue(),
+          .unwrap(),
         2,
       );
       assert.equal(
         failure(1)
-          .chain((x) => {
+          .andThen((x) => {
             checkType<Equal<typeof x, number>>();
             return success(x + 1);
           })
-          .getError(),
+          .unwrapErr(),
         1,
       );
     });
   });
 
-  describe('elseChain', () => {
+  describe('orElse', () => {
     it('should return expected value', () => {
       assert.equal(
         success(1)
-          .elseChain((x) => {
+          .orElse((x) => {
             checkType<Equal<typeof x, number>>();
             return success(x + 1);
           })
-          .getValue(),
+          .unwrap(),
         1,
       );
       const failureRes = failure(1);
       assert.equal(
         failureRes
-          .elseChain((x) => {
+          .orElse((x) => {
             checkType<Equal<typeof x, number>>();
             return success(x + 1);
           })
-          .getValue(),
+          .unwrap(),
         2,
       );
     });
@@ -132,30 +132,30 @@ describe('Result', () => {
     it('should return expected value', () => {
       assert.equal(
         success(1)
-          .chain(() => success('a'))
-          .elseChain((x) => {
+          .andThen(() => success('a'))
+          .orElse((x) => {
             checkType<Equal<typeof x, string>>();
             return success(2);
           })
-          .getValue(),
+          .unwrap(),
         'a',
       );
       assert.equal(
         failure(1)
-          .chain(() => success('a'))
-          .elseChain((x) => {
+          .andThen(() => success('a'))
+          .orElse((x) => {
             checkType<Equal<typeof x, number>>();
             return success(2);
           })
-          .getValue(),
+          .unwrap(),
         2,
       );
       const randomRes = getRandomRes()
-        .chain((x) => {
+        .andThen((x) => {
           checkType<Equal<typeof x, number | string>>();
           return success('a');
         })
-        .elseChain((x) => {
+        .orElse((x) => {
           checkType<Equal<typeof x, string>>();
           return failure(2);
         });
@@ -177,7 +177,7 @@ describe('Result', () => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
           })
-          .getValue(),
+          .unwrap(),
         2,
       );
       assert.equal(
@@ -186,55 +186,55 @@ describe('Result', () => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
           })
-          .getError(),
+          .unwrapErr(),
         1,
       );
     });
   });
 
-  describe('elseMap', () => {
+  describe('mapErr', () => {
     it('should return expected value', () => {
       assert.equal(
         success(1)
-          .elseMap((x) => {
+          .mapErr((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
           })
-          .getValue(),
+          .unwrap(),
         1,
       );
       assert.equal(
         failure(1)
-          .elseMap((x) => {
+          .mapErr((x) => {
             checkType<Equal<typeof x, number>>();
             return x + 1;
           })
-          .getValue(),
+          .unwrap(),
         2,
       );
     });
   });
 
-  describe('mapElseMap', () => {
+  describe('mapMapErr', () => {
     it('should return expected value', () => {
       assert.equal(
         success(1)
           .map(() => 'b')
-          .elseMap((x) => {
+          .mapErr((x) => {
             checkType<Equal<typeof x, string>>();
             return 2;
           })
-          .getValue(),
+          .unwrap(),
         'b',
       );
       assert.equal(
         failure(1)
           .map(() => 'a')
-          .elseMap((x) => {
+          .mapErr((x) => {
             checkType<Equal<typeof x, number>>();
             return 2;
           })
-          .getValue(),
+          .unwrap(),
         2,
       );
       const randomRes = getRandomRes()
@@ -242,7 +242,7 @@ describe('Result', () => {
           checkType<Equal<typeof x, number | string>>();
           return 'a';
         })
-        .elseMap((x) => {
+        .mapErr((x) => {
           checkType<Equal<typeof x, string>>();
           return 2;
         });
@@ -256,19 +256,19 @@ describe('Result', () => {
     });
   });
 
-  describe('getOrElse', () => {
+  describe('unwrapOr', () => {
     it('should return expected value', () => {
       const successRes = success(1);
-      assert.equal(successRes.getOrElse(2), 1);
+      assert.equal(successRes.unwrapOr(2), 1);
       const failureRes = failure(1);
-      assert.equal(failureRes.getOrElse(2), 2);
+      assert.equal(failureRes.unwrapOr(2), 2);
     });
   });
 
-  describe('unwrap', () => {
+  describe('toTuple', () => {
     it('should return expected value', () => {
-      const successPair = success(1).unwrap();
-      assert.equal(successPair[0].getValue(), 1);
+      const successPair = success(1).toTuple();
+      assert.equal(successPair[0].unwrap(), 1);
       assert.equal(successPair[1], 1);
       checkType<
         Equal<
@@ -276,8 +276,8 @@ describe('Result', () => {
           [AnzenResultSuccess<number>, number]
         >
       >();
-      const failurePair = failure(1).unwrap();
-      assert.equal(failurePair[0].getError(), 1);
+      const failurePair = failure(1).toTuple();
+      assert.equal(failurePair[0].unwrapErr(), 1);
       assert.equal(failurePair[1], undefined);
       checkType<
         Equal<
@@ -285,8 +285,8 @@ describe('Result', () => {
           [AnzenResultFailure<number>, undefined]
         >
       >();
-      const failureWithDefault = failure(1).unwrap(2);
-      assert.equal(failureWithDefault[0].getError(), 1);
+      const failureWithDefault = failure(1).toTuple(2);
+      assert.equal(failureWithDefault[0].unwrapErr(), 1);
       assert.equal(failureWithDefault[1], 2);
       checkType<
         Equal<
@@ -297,12 +297,12 @@ describe('Result', () => {
     });
   });
 
-  describe('unsafeUnwrap', () => {
+  describe('getRaw', () => {
     it('should return expected value', () => {
       const successRes = success(1);
-      assert.equal(successRes.unsafeUnwrap(), 1);
+      assert.equal(successRes.getRaw(), 1);
       const failureRes = failure(1);
-      assert.equal(failureRes.unsafeUnwrap(), 1);
+      assert.equal(failureRes.getRaw(), 1);
     });
   });
 
@@ -328,7 +328,7 @@ describe('Result', () => {
       );
       assert.equal(successRes.isSuccess, true);
       assert.equal(successRes.isFailure, false);
-      assert.equal(successRes.getValue(), 1);
+      assert.equal(successRes.unwrap(), 1);
       const failureRes = fromJSON(
         JSON.stringify({
           error: 1,
@@ -337,7 +337,7 @@ describe('Result', () => {
       );
       assert.equal(failureRes.isSuccess, false);
       assert.equal(failureRes.isFailure, true);
-      assert.equal(failureRes.getError(), 1);
+      assert.equal(failureRes.unwrapErr(), 1);
     });
 
     it('types the result from its generic arguments', () => {
@@ -370,7 +370,7 @@ describe('Result', () => {
       ]);
       assert.equal(res.isSuccess, true);
       assert.equal(res.isFailure, false);
-      assert.deepEqual(res.getValue(), [1, 2, 'A']);
+      assert.deepEqual(res.unwrap(), [1, 2, 'A']);
       checkType<
         Equal<
           typeof res,
@@ -399,7 +399,7 @@ describe('Result', () => {
       const res = await promiseAll([promise1]);
       assert.equal(res.isSuccess, false);
       assert.equal(res.isFailure, true);
-      assert.equal(res.getError(), 2);
+      assert.equal(res.unwrapErr(), 2);
       checkType<
         Equal<typeof res, AnzenResultFailure<number>>
       >();
@@ -509,7 +509,7 @@ describe('Result', () => {
       >();
       assert.equal(res.isFailure, true);
       if (res.isFailure) {
-        assert.equal(res.getError(), 'boom');
+        assert.equal(res.unwrapErr(), 'boom');
       }
       assert.deepEqual(results, [10, 20]);
     });
@@ -528,12 +528,12 @@ describe('Result', () => {
     });
   });
 
-  describe('unwrap', () => {
+  describe('toTuple', () => {
     it('should return expected value', async () => {
       const successRes = success(1);
       const failureRes = failure(1);
       const fn = async () => successRes;
-      const res = await fn().then(unwrap());
+      const res = await fn().then(toTuple());
       assert.deepEqual(res, [successRes, 1]);
       checkType<
         Equal<
@@ -542,7 +542,7 @@ describe('Result', () => {
         >
       >();
       const fn2 = async () => failureRes;
-      const result2 = await fn2().then(unwrap());
+      const result2 = await fn2().then(toTuple());
       assert.deepEqual(result2, [failureRes, undefined]);
       checkType<
         Equal<
@@ -550,7 +550,7 @@ describe('Result', () => {
           [AnzenResultFailure<number>, undefined]
         >
       >();
-      const result3 = await fn2().then(unwrap(1));
+      const result3 = await fn2().then(toTuple(1));
       assert.deepEqual(result3, [failureRes, 1]);
       checkType<
         Equal<
@@ -565,7 +565,7 @@ describe('Result', () => {
         AnzenAnyResult<'err', number>
       > => success(1);
       // Assert the type before any narrowing access.
-      const res = await fn().then(unwrap());
+      const res = await fn().then(toTuple());
       checkType<
         Equal<
           typeof res,
@@ -574,7 +574,7 @@ describe('Result', () => {
         >
       >();
       // With a default, the failure value takes the default type.
-      const res2 = await fn().then(unwrap('fallback'));
+      const res2 = await fn().then(toTuple('fallback'));
       checkType<
         Equal<
           typeof res2,
@@ -587,7 +587,7 @@ describe('Result', () => {
     it('uses never for the impossible branch of a single-variant input', async () => {
       // A statically-success input cannot fail: error type is never.
       const ok = await (async () => success(1))().then(
-        unwrap(),
+        toTuple(),
       );
       checkType<
         Equal<
@@ -598,7 +598,7 @@ describe('Result', () => {
       >();
       // A statically-failure input cannot succeed: value type is never.
       const bad = await (async () => failure('e'))().then(
-        unwrap(),
+        toTuple(),
       );
       checkType<
         Equal<
@@ -622,7 +622,7 @@ describe('Result', () => {
       assert.equal(res.isSuccess, false);
       assert.equal(res.isFailure, true);
       if (res.isFailure) {
-        assert.equal(res.getError().message, 'err');
+        assert.equal(res.unwrapErr().message, 'err');
       }
     });
 
@@ -634,7 +634,7 @@ describe('Result', () => {
       >();
       assert.equal(res.isSuccess, true);
       assert.equal(res.isFailure, false);
-      assert.equal(res.getValue(), 1);
+      assert.equal(res.unwrap(), 1);
     });
 
     describe('parseError is provided', () => {
@@ -655,7 +655,7 @@ describe('Result', () => {
         assert.equal(res.isSuccess, false);
         assert.equal(res.isFailure, true);
         if (res.isFailure) {
-          assert.equal(res.getError(), 'err');
+          assert.equal(res.unwrapErr(), 'err');
         }
       });
     });
@@ -671,7 +671,7 @@ describe('Result', () => {
         assert.equal(res.isSuccess, false);
         assert.equal(res.isFailure, true);
         if (res.isFailure) {
-          assert.equal(res.getError().message, 'err');
+          assert.equal(res.unwrapErr().message, 'err');
         }
       });
     });
@@ -683,7 +683,7 @@ describe('Result', () => {
       >();
       assert.equal(res.isSuccess, true);
       assert.equal(res.isFailure, false);
-      assert.equal(res.getValue(), 1);
+      assert.equal(res.unwrap(), 1);
     });
   });
 });

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -2,17 +2,17 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
-  type AnzenAnyResult,
+  type AnzenResult,
   type AnzenResultErr,
   type AnzenResultOk,
-  AsyncResult,
+  ResultAsync,
   err,
   errAsync,
   fromJSON,
   fromPromise,
   fromSafePromise,
-  fromSyncThrowable,
   fromThrowable,
+  fromAsyncThrowable,
   isAnzenResult,
   okAsync,
   promiseAll,
@@ -86,7 +86,7 @@ describe('Result', () => {
 
   describe('unwrapErr', () => {
     it('should return expected value', () => {
-      const okRes = ok(1) as AnzenAnyResult<string, number>;
+      const okRes = ok(1) as AnzenResult<string, number>;
       assert.throws(
         () => {
           const a = okRes.unwrapErr();
@@ -321,15 +321,6 @@ describe('Result', () => {
     });
   });
 
-  describe('getRaw', () => {
-    it('should return expected value', () => {
-      const okRes = ok(1);
-      assert.equal(okRes.getRaw(), 1);
-      const errRes = err(1);
-      assert.equal(errRes.getRaw(), 1);
-    });
-  });
-
   describe('toJSON', () => {
     it('should return expected value', () => {
       const okRes = ok(1);
@@ -370,14 +361,14 @@ describe('Result', () => {
         JSON.stringify({ value: 1, isOk: true }),
       );
       checkType<
-        Equal<typeof res, AnzenAnyResult<unknown, unknown>>
+        Equal<typeof res, AnzenResult<unknown, unknown>>
       >();
-      // Error-first generics, consistent with AnzenAnyResult<E, T>.
+      // Error-first generics, consistent with AnzenResult<E, T>.
       const typed = fromJSON<string, number>(
         JSON.stringify({ value: 1, isOk: true }),
       );
       checkType<
-        Equal<typeof typed, AnzenAnyResult<string, number>>
+        Equal<typeof typed, AnzenResult<string, number>>
       >();
     });
   });
@@ -407,9 +398,8 @@ describe('Result', () => {
     });
 
     it('when promises are resolved with failure, should return expected value', async () => {
-      const promise1: Promise<
-        AnzenAnyResult<number, number>
-      > = Promise.resolve(err(2));
+      const promise1: Promise<AnzenResult<number, number>> =
+        Promise.resolve(err(2));
       const res = await promiseAll([promise1]);
       assert.equal(res.isOk, false);
       assert.equal(res.isErr, true);
@@ -419,7 +409,7 @@ describe('Result', () => {
     it('types a raw (non-Result) rejection as unknown (B2)', async () => {
       const raw = Promise.reject(
         new Error('raw'),
-      ) as Promise<AnzenAnyResult<never, number>>;
+      ) as Promise<AnzenResult<never, number>>;
       const res = await promiseAll([raw]);
       assert.equal(res.isErr, true);
       if (res.isErr) {
@@ -470,9 +460,8 @@ describe('Result', () => {
     });
 
     it('when an input fails, returns the provided defaults as values', async () => {
-      const failing: Promise<
-        AnzenAnyResult<string, number>
-      > = Promise.resolve(err('boom'));
+      const failing: Promise<AnzenResult<string, number>> =
+        Promise.resolve(err('boom'));
       const [res, ...results] = await unwrapPromiseAll([
         [0],
         failing,
@@ -571,7 +560,7 @@ describe('Result', () => {
 
     it('infers the success-or-failure tuple union without narrowing', async () => {
       const fn = async (): Promise<
-        AnzenAnyResult<'err', number>
+        AnzenResult<'err', number>
       > => ok(1);
       // Assert the type before any narrowing access.
       const res = await fn().then(toTuple());
@@ -619,14 +608,14 @@ describe('Result', () => {
     });
   });
 
-  describe('fromThrowable', () => {
+  describe('fromAsyncThrowable', () => {
     it('when throwable is thrown, should return expected value', () => {
       // Error-first generics let you name only the error type.
-      const res = fromSyncThrowable<Error>(() => {
+      const res = fromThrowable<Error>(() => {
         throw new Error('err');
       });
       checkType<
-        Equal<typeof res, AnzenAnyResult<Error, unknown>>
+        Equal<typeof res, AnzenResult<Error, unknown>>
       >();
       assert.equal(res.isOk, false);
       assert.equal(res.isErr, true);
@@ -636,10 +625,10 @@ describe('Result', () => {
     });
 
     it('when throwable is not thrown, should return expected value', () => {
-      const res = fromSyncThrowable(() => 1);
+      const res = fromThrowable(() => 1);
       // No parseErr: value is inferred, error defaults to unknown.
       checkType<
-        Equal<typeof res, AnzenAnyResult<unknown, number>>
+        Equal<typeof res, AnzenResult<unknown, number>>
       >();
       assert.equal(res.isOk, true);
       assert.equal(res.isErr, false);
@@ -648,7 +637,7 @@ describe('Result', () => {
 
     describe('parseError is provided', () => {
       it('when throwable is thrown, should return expected value', () => {
-        const res = fromSyncThrowable(
+        const res = fromThrowable(
           () => {
             throw new Error('err');
           },
@@ -659,7 +648,7 @@ describe('Result', () => {
         );
         // Error type is inferred from parseErr's return type.
         checkType<
-          Equal<typeof res, AnzenAnyResult<string, never>>
+          Equal<typeof res, AnzenResult<string, never>>
         >();
         assert.equal(res.isOk, false);
         assert.equal(res.isErr, true);
@@ -671,11 +660,13 @@ describe('Result', () => {
 
     describe('async', () => {
       it('when throwable is thrown, should return expected value', async () => {
-        const res = await fromThrowable<Error>(async () => {
-          throw new Error('err');
-        });
+        const res = await fromAsyncThrowable<Error>(
+          async () => {
+            throw new Error('err');
+          },
+        );
         checkType<
-          Equal<typeof res, AnzenAnyResult<Error, unknown>>
+          Equal<typeof res, AnzenResult<Error, unknown>>
         >();
         assert.equal(res.isOk, false);
         assert.equal(res.isErr, true);
@@ -686,9 +677,9 @@ describe('Result', () => {
     });
 
     it('when throwable is not thrown, should return expected value', async () => {
-      const res = await fromThrowable(async () => 1);
+      const res = await fromAsyncThrowable(async () => 1);
       checkType<
-        Equal<typeof res, AnzenAnyResult<unknown, number>>
+        Equal<typeof res, AnzenResult<unknown, number>>
       >();
       assert.equal(res.isOk, true);
       assert.equal(res.isErr, false);
@@ -697,7 +688,7 @@ describe('Result', () => {
   });
 });
 
-describe('AsyncResult', () => {
+describe('ResultAsync', () => {
   describe('okAsync / errAsync', () => {
     it('should build awaitable Results', async () => {
       const okRes = await okAsync(1);
@@ -712,7 +703,7 @@ describe('AsyncResult', () => {
     it('should be awaitable to the underlying Result', async () => {
       const res = await okAsync(1);
       checkType<
-        Equal<typeof res, AnzenAnyResult<never, number>>
+        Equal<typeof res, AnzenResult<never, number>>
       >();
       assert.equal(res.isOk, true);
     });
@@ -745,7 +736,7 @@ describe('AsyncResult', () => {
   });
 
   describe('andThen', () => {
-    it('should sequence Result / AsyncResult / Promise returns', async () => {
+    it('should sequence Result / ResultAsync / Promise returns', async () => {
       const viaResult = await okAsync(1).andThen((x) =>
         ok(x + 1),
       );
@@ -769,7 +760,7 @@ describe('AsyncResult', () => {
         x > 0 ? ok(x) : err('neg'),
       );
       checkType<
-        Equal<typeof res, AnzenAnyResult<string, number>>
+        Equal<typeof res, AnzenResult<string, number>>
       >();
     });
   });
@@ -832,12 +823,12 @@ describe('AsyncResult', () => {
   });
 
   describe('fromSafePromise', () => {
-    it('should lift a Promise<Result> into an AsyncResult', async () => {
+    it('should lift a Promise<Result> into an ResultAsync', async () => {
       const asyncRes = fromSafePromise<string, number>(
         Promise.resolve(ok(1)),
       );
       checkType<
-        Equal<typeof asyncRes, AsyncResult<string, number>>
+        Equal<typeof asyncRes, ResultAsync<string, number>>
       >();
       const res = await asyncRes.map((x) => x + 1);
       assert.equal(res.unwrap(), 2);

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -394,40 +394,43 @@ describe('Result', () => {
       ]);
       assert.equal(res.isOk, true);
       assert.equal(res.isErr, false);
-      assert.deepEqual(res.unwrap(), [1, 2, 'A']);
+      // All inputs are statically Ok, so there is no failure branch.
       checkType<
         Equal<
           typeof res,
           AnzenResultOk<[number, number, string]>
         >
       >();
-      const res2 = await promiseAll([
-        promise1,
-        promise2(),
-        promise3(),
-        getRandomRes(),
-      ]);
-      checkType<
-        Equal<
-          typeof res2,
-          | AnzenResultErr<string>
-          | AnzenResultOk<[number, number, string, number]>
-        >
-      >();
+      if (res.isOk) {
+        assert.deepEqual(res.unwrap(), [1, 2, 'A']);
+      }
     });
 
     it('when promises are resolved with failure, should return expected value', async () => {
-      const promise1 = Promise.resolve(err(2));
+      const promise1: Promise<
+        AnzenAnyResult<number, number>
+      > = Promise.resolve(err(2));
       const res = await promiseAll([promise1]);
       assert.equal(res.isOk, false);
       assert.equal(res.isErr, true);
       assert.equal(res.unwrapErr(), 2);
-      checkType<
-        Equal<typeof res, AnzenResultErr<number>>
-      >();
     });
 
-    it('all-success inputs yield a never failure branch (no narrowing)', async () => {
+    it('types a raw (non-Result) rejection as unknown (B2)', async () => {
+      const raw = Promise.reject(
+        new Error('raw'),
+      ) as Promise<AnzenAnyResult<never, number>>;
+      const res = await promiseAll([raw]);
+      assert.equal(res.isErr, true);
+      if (res.isErr) {
+        const error = res.unwrapErr();
+        // The caught value is not one of the wrapped Result failures,
+        // so it is honestly typed `unknown`, not the declared error type.
+        checkType<Equal<typeof error, unknown>>();
+      }
+    });
+
+    it('the failure branch is always typed unknown', async () => {
       const res = await promiseAll([
         ok(1),
         Promise.resolve(ok('a')),
@@ -436,7 +439,7 @@ describe('Result', () => {
         Equal<
           typeof res,
           | AnzenResultOk<[number, string]>
-          | AnzenResultErr<never>
+          | AnzenResultErr<unknown>
         >
       >();
     });
@@ -448,17 +451,15 @@ describe('Result', () => {
       const promise2 = Promise.resolve(ok(2));
       const promise3 = Promise.resolve(ok('A'));
       const [res, ...results] = await unwrapPromiseAll([
-        [],
+        [0, 0, ''],
         promise1,
         promise2,
         promise3,
       ]);
-      if (res.isOk) {
-        results;
-      }
       assert.equal(res.isOk, true);
       assert.equal(res.isErr, false);
       assert.deepEqual(results, [1, 2, 'A']);
+      // All inputs are statically Ok, so there is no failure branch.
       checkType<
         Equal<
           typeof res,
@@ -468,18 +469,27 @@ describe('Result', () => {
       >();
     });
 
-    it('when promises are resolved with failure, should return expected value', async () => {
-      const promise1 = Promise.resolve(err(2));
+    it('when an input fails, returns the provided defaults as values', async () => {
+      const failing: Promise<
+        AnzenAnyResult<string, number>
+      > = Promise.resolve(err('boom'));
       const [res, ...results] = await unwrapPromiseAll([
-        [],
-        promise1,
+        [0],
+        failing,
       ]);
-      assert.equal(res.isOk, false);
-      assert.equal(res.isErr, true);
-      assert.deepEqual(results, []);
+      // Assert the type before any narrowing access to `res`.
       checkType<
-        Equal<typeof res, AnzenResultErr<number>>
+        Equal<
+          typeof res,
+          AnzenResultErr<unknown> | AnzenResultOk<[number]>
+        >,
+        Equal<typeof results, [number]>
       >();
+      assert.equal(res.isErr, true);
+      if (res.isErr) {
+        assert.equal(res.unwrapErr(), 'boom');
+      }
+      assert.deepEqual(results, [0]);
     });
 
     it('when inputs may fail, res should be typed as a success-or-failure union', async () => {
@@ -496,7 +506,7 @@ describe('Result', () => {
       checkType<
         Equal<
           typeof res,
-          | AnzenResultErr<string>
+          | AnzenResultErr<unknown>
           | AnzenResultOk<[number, number, string, number]>
         >,
         Equal<
@@ -506,40 +516,22 @@ describe('Result', () => {
       >();
     });
 
-    it('when any input fails, returns the provided defaults as values', async () => {
-      const good = async (): Promise<
-        AnzenAnyResult<string, number>
-      > => ok(1);
-      const bad = async (): Promise<
-        AnzenAnyResult<string, number>
-      > => err('boom');
-      const [res, ...results] = await unwrapPromiseAll([
-        [10, 20],
-        good(),
-        bad(),
-      ]);
-      // Assert the type before any narrowing access to `res`.
-      checkType<
-        Equal<
-          typeof res,
-          | AnzenResultErr<string>
-          | AnzenResultOk<[number, number]>
-        >,
-        Equal<typeof results, [number, number]>
-      >();
-      assert.equal(res.isErr, true);
-      if (res.isErr) {
-        assert.equal(res.unwrapErr(), 'boom');
-      }
-      assert.deepEqual(results, [10, 20]);
-    });
-
-    it('defaults are type-checked against the success value types', async () => {
+    it('requires a full-length defaults tuple (B1)', async () => {
       const promise1 = Promise.resolve(ok(1));
-      // No defaults is allowed.
-      await unwrapPromiseAll([[], promise1]);
-      // A matching default is allowed.
-      await unwrapPromiseAll([[0], promise1]);
+      const promise2 = Promise.resolve(ok(2));
+      // A full, correctly-typed defaults tuple is allowed.
+      await unwrapPromiseAll([[0, 0], promise1, promise2]);
+      await unwrapPromiseAll([
+        // @ts-expect-error short defaults are rejected: need 2, got 1.
+        [0],
+        promise1,
+        promise2,
+      ]);
+      await unwrapPromiseAll([
+        // @ts-expect-error empty defaults are rejected when results exist.
+        [],
+        promise1,
+      ]);
       await unwrapPromiseAll([
         // @ts-expect-error default must match the success value type.
         ['not a number'],

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -9,6 +9,7 @@ import {
   fromJSON,
   fromSyncThrowable,
   fromThrowable,
+  isAnzenResult,
   promiseAll,
   success,
   toTuple,
@@ -43,6 +44,27 @@ describe('Result', () => {
       checkType<
         Equal<typeof res, AnzenResultFailure<number>>
       >();
+    });
+  });
+
+  describe('isAnzenResult', () => {
+    it('should narrow Results and reject non-Results', () => {
+      assert.equal(isAnzenResult(success(1)), true);
+      assert.equal(isAnzenResult(failure(1)), true);
+      assert.equal(isAnzenResult(fromJSON(success(1).toJSON())), true);
+      assert.equal(isAnzenResult(null), false);
+      assert.equal(isAnzenResult(undefined), false);
+      assert.equal(isAnzenResult({ isSuccess: true }), false);
+      assert.equal(isAnzenResult('success'), false);
+      const value: unknown = success(1);
+      if (isAnzenResult(value)) {
+        checkType<
+          Equal<
+            typeof value,
+            AnzenResultSuccess<unknown> | AnzenResultFailure<unknown>
+          >
+        >();
+      }
     });
   });
 

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -5,19 +5,14 @@ import {
   type AnzenResult,
   type AnzenResultErr,
   type AnzenResultOk,
-  ResultAsync,
   err,
-  errAsync,
   fromJSON,
-  fromPromise,
-  fromSafePromise,
   fromThrowable,
   fromAsyncThrowable,
-  wrapAsyncThrowable,
   isAnzenResult,
-  okAsync,
   promiseAll,
   ok,
+  safeTry,
   toTuple,
   unwrapPromiseAll,
 } from '../anzen.js';
@@ -610,87 +605,48 @@ describe('Result', () => {
   });
 
   describe('fromThrowable', () => {
-    it('when throwable is thrown, should return expected value', () => {
-      // Error-first generics let you name only the error type.
-      const res = fromThrowable<Error>(() => {
-        throw new Error('err');
-      });
+    it('returns a function that wraps throws as Err', () => {
+      const safe = fromThrowable(
+        (id: number) => {
+          if (id < 0) throw new Error('bad id');
+          return id * 2;
+        },
+        (e) => (e instanceof Error ? e.message : String(e)),
+      );
       checkType<
-        Equal<typeof res, AnzenResult<Error, unknown>>
+        Equal<
+          typeof safe,
+          (id: number) => AnzenResult<string, number>
+        >
       >();
-      assert.equal(res.isOk, false);
-      assert.equal(res.isErr, true);
-      if (res.isErr) {
-        assert.equal(res.unwrapErr().message, 'err');
+      assert.equal(safe(2).unwrap(), 4);
+      const errRes = safe(-1);
+      assert.equal(errRes.isErr, true);
+      if (errRes.isErr) {
+        assert.equal(errRes.unwrapErr(), 'bad id');
       }
     });
 
-    it('when throwable is not thrown, should return expected value', () => {
-      const res = fromThrowable(() => 1);
-      // No parseErr: value is inferred, error defaults to unknown.
+    it('error defaults to unknown when parseErr is omitted', () => {
+      const safe = fromThrowable((x: number) => x + 1);
       checkType<
-        Equal<typeof res, AnzenResult<unknown, number>>
+        Equal<
+          typeof safe,
+          (x: number) => AnzenResult<unknown, number>
+        >
       >();
-      assert.equal(res.isOk, true);
-      assert.equal(res.isErr, false);
-      assert.equal(res.unwrap(), 1);
+      assert.equal(safe(1).unwrap(), 2);
     });
 
-    describe('parseError is provided', () => {
-      it('when throwable is thrown, should return expected value', () => {
-        const res = fromThrowable(
-          () => {
-            throw new Error('err');
-          },
-          (err) =>
-            err instanceof Error
-              ? err.message
-              : String(err),
-        );
-        // Error type is inferred from parseErr's return type.
-        checkType<
-          Equal<typeof res, AnzenResult<string, never>>
-        >();
-        assert.equal(res.isOk, false);
-        assert.equal(res.isErr, true);
-        if (res.isErr) {
-          assert.equal(res.unwrapErr(), 'err');
-        }
-      });
+    it('works with zero-argument functions', () => {
+      const safe = fromThrowable(() => 42);
+      assert.equal(safe().unwrap(), 42);
     });
   });
 
   describe('fromAsyncThrowable', () => {
-    it('when throwable is thrown, should return expected value', async () => {
-      const res = await fromAsyncThrowable<Error>(
-        async () => {
-          throw new Error('err');
-        },
-      );
-      checkType<
-        Equal<typeof res, AnzenResult<Error, unknown>>
-      >();
-      assert.equal(res.isOk, false);
-      assert.equal(res.isErr, true);
-      if (res.isErr) {
-        assert.equal(res.unwrapErr().message, 'err');
-      }
-    });
-
-    it('when throwable is not thrown, should return expected value', async () => {
-      const res = await fromAsyncThrowable(async () => 1);
-      checkType<
-        Equal<typeof res, AnzenResult<unknown, number>>
-      >();
-      assert.equal(res.isOk, true);
-      assert.equal(res.isErr, false);
-      assert.equal(res.unwrap(), 1);
-    });
-  });
-
-  describe('wrapAsyncThrowable', () => {
-    it('adapts an async throwing fn into a reusable AnzenResultFn', async () => {
-      const safe = wrapAsyncThrowable(
+    it('returns a function that wraps rejections as Err', async () => {
+      const safe = fromAsyncThrowable(
         async (id: number) => {
           if (id < 0) throw new Error('bad id');
           return id * 2;
@@ -705,8 +661,7 @@ describe('Result', () => {
           ) => Promise<AnzenResult<string, number>>
         >
       >();
-      const okRes = await safe(2);
-      assert.equal(okRes.unwrap(), 4);
+      assert.equal((await safe(2)).unwrap(), 4);
       const errRes = await safe(-1);
       assert.equal(errRes.isErr, true);
       if (errRes.isErr) {
@@ -714,9 +669,23 @@ describe('Result', () => {
       }
     });
 
+    it('error defaults to unknown when parseErr is omitted', async () => {
+      const safe = fromAsyncThrowable(
+        async (x: number) => x + 1,
+      );
+      checkType<
+        Equal<
+          typeof safe,
+          (
+            x: number,
+          ) => Promise<AnzenResult<unknown, number>>
+        >
+      >();
+      assert.equal((await safe(1)).unwrap(), 2);
+    });
+
     it('captures a synchronous throw on invocation', async () => {
-      // The thunk defers the call, so a sync throw is caught too.
-      const safe = wrapAsyncThrowable(
+      const safe = fromAsyncThrowable(
         (): Promise<number> => {
           throw new Error('sync boom');
         },
@@ -727,150 +696,81 @@ describe('Result', () => {
   });
 });
 
-describe('ResultAsync', () => {
-  describe('okAsync / errAsync', () => {
-    it('should build awaitable Results', async () => {
-      const okRes = await okAsync(1);
-      assert.equal(okRes.unwrap(), 1);
-      const errRes = await errAsync('boom');
-      assert.equal(errRes.unwrapErr(), 'boom');
-      checkType<Equal<typeof okAsync, typeof okAsync>>();
-    });
-  });
-
-  describe('then', () => {
-    it('should be awaitable to the underlying Result', async () => {
-      const res = await okAsync(1);
+describe('safeTry', () => {
+  describe('sync', () => {
+    it('unwraps Ok values and returns the final Result', () => {
+      const res = safeTry<string, number>(function* () {
+        const a = yield* ok<number>(1);
+        const b = yield* ok<number>(2);
+        return ok(a + b);
+      });
       checkType<
-        Equal<typeof res, AnzenResult<never, number>>
+        Equal<typeof res, AnzenResult<string, number>>
       >();
       assert.equal(res.isOk, true);
+      assert.equal(res.unwrap(), 3);
+    });
+
+    it('short-circuits on the first Err', () => {
+      let reached = false;
+      const res = safeTry<string, number>(function* () {
+        const a = yield* ok<number>(1);
+        yield* err<string>('boom');
+        reached = true;
+        return ok(a);
+      });
+      assert.equal(res.isErr, true);
+      assert.equal(reached, false);
+      if (res.isErr) {
+        assert.equal(res.unwrapErr(), 'boom');
+      }
+    });
+
+    it('unions the error types of every yielded Result', () => {
+      const res = safeTry(function* () {
+        const a = yield* ok(1) as AnzenResult<'a', number>;
+        const b = yield* ok(2) as AnzenResult<'b', number>;
+        return ok(a + b);
+      });
+      checkType<
+        Equal<typeof res, AnzenResult<'a' | 'b', number>>
+      >();
     });
   });
 
-  describe('map', () => {
-    it('should transform the Ok value with sync or async fn', async () => {
-      const res = await okAsync(1)
-        .map((x) => x + 1)
-        .map(async (x) => x * 10);
-      assert.equal(res.unwrap(), 20);
-      const passthrough = await errAsync<string>(
-        'boom',
-      ).map((x: number) => x + 1);
-      assert.equal(passthrough.unwrapErr(), 'boom');
-    });
-  });
-
-  describe('mapErr', () => {
-    it('should transform the Err value with sync or async fn', async () => {
-      const res = await errAsync('boom').mapErr(
-        async (e) => `${e}!`,
-      );
-      assert.equal(res.unwrapErr(), 'boom!');
-      const passthrough = await okAsync(1).mapErr(
-        (e: string) => `${e}!`,
-      );
-      assert.equal(passthrough.unwrap(), 1);
-    });
-  });
-
-  describe('andThen', () => {
-    it('should sequence Result / ResultAsync / Promise returns', async () => {
-      const viaResult = await okAsync(1).andThen((x) =>
-        ok(x + 1),
-      );
-      assert.equal(viaResult.unwrap(), 2);
-      const viaAsync = await okAsync(1).andThen((x) =>
-        okAsync(x + 2),
-      );
-      assert.equal(viaAsync.unwrap(), 3);
-      const viaPromise = await okAsync(1).andThen((x) =>
-        Promise.resolve(ok(x + 3)),
-      );
-      assert.equal(viaPromise.unwrap(), 4);
-      const short = await errAsync<string>('boom').andThen(
-        (x: number) => ok(x + 1),
-      );
-      assert.equal(short.unwrapErr(), 'boom');
-    });
-
-    it('should union the error type', async () => {
-      const res = await okAsync<number>(1).andThen((x) =>
-        x > 0 ? ok(x) : err('neg'),
+  describe('async', () => {
+    it('unwraps Ok values across awaited steps', async () => {
+      const find = async () => ok<number>(10);
+      const res = await safeTry<string, number>(
+        async function* () {
+          const a = yield* await find();
+          return ok(a * 2);
+        },
       );
       checkType<
         Equal<typeof res, AnzenResult<string, number>>
       >();
+      assert.equal(res.unwrap(), 20);
     });
-  });
 
-  describe('orElse', () => {
-    it('should recover from an Err', async () => {
-      const recovered = await errAsync('boom').orElse(() =>
-        ok('foo'),
-      );
-      assert.equal(recovered.unwrap(), 'foo');
-      const passthrough = await okAsync(1).orElse(() =>
-        ok(2),
-      );
-      assert.equal(passthrough.unwrap(), 1);
-    });
-  });
-
-  describe('unwrap / unwrapErr / unwrapOr', () => {
-    it('should resolve the awaited terminals', async () => {
-      assert.equal(await okAsync(1).unwrap(), 1);
-      assert.equal(
-        await errAsync('boom').unwrapErr(),
-        'boom',
-      );
-      assert.equal(await errAsync('boom').unwrapOr(2), 2);
-      assert.equal(await okAsync(1).unwrapOr(2), 1);
-      await assert.rejects(
-        () => errAsync('boom').unwrap(),
-        {
-          message: 'Cannot get the value of an Err result.',
+    it('short-circuits on the first Err', async () => {
+      let reached = false;
+      const charge = async () => err<string>('declined');
+      const res = await safeTry<string, number>(
+        async function* () {
+          const a = yield* await Promise.resolve(
+            ok<number>(1),
+          );
+          yield* await charge();
+          reached = true;
+          return ok(a);
         },
       );
-    });
-  });
-
-  describe('fromPromise', () => {
-    it('should wrap a resolved promise as Ok', async () => {
-      const res = await fromPromise(Promise.resolve(1));
-      assert.equal(res.unwrap(), 1);
-    });
-
-    it('should wrap a rejection as Err, typed unknown by default', async () => {
-      const res = await fromPromise(
-        Promise.reject(new Error('x')),
-      );
       assert.equal(res.isErr, true);
-      const error = res.unwrapErr();
-      checkType<Equal<typeof error, unknown>>();
-    });
-
-    it('should map the rejection via parseErr', async () => {
-      const res = await fromPromise(
-        Promise.reject(new Error('x')),
-        (e) => (e as Error).message,
-      );
-      assert.equal(res.unwrapErr(), 'x');
-      const error = res.unwrapErr();
-      checkType<Equal<typeof error, string>>();
-    });
-  });
-
-  describe('fromSafePromise', () => {
-    it('should lift a Promise<Result> into an ResultAsync', async () => {
-      const asyncRes = fromSafePromise<string, number>(
-        Promise.resolve(ok(1)),
-      );
-      checkType<
-        Equal<typeof asyncRes, ResultAsync<string, number>>
-      >();
-      const res = await asyncRes.map((x) => x + 1);
-      assert.equal(res.unwrap(), 2);
+      assert.equal(reached, false);
+      if (res.isErr) {
+        assert.equal(res.unwrapErr(), 'declined');
+      }
     });
   });
 });

--- a/packages/anzen/src/__tests__/anzen_test.ts
+++ b/packages/anzen/src/__tests__/anzen_test.ts
@@ -13,6 +13,7 @@ import {
   fromSafePromise,
   fromThrowable,
   fromAsyncThrowable,
+  wrapAsyncThrowable,
   isAnzenResult,
   okAsync,
   promiseAll,
@@ -608,7 +609,7 @@ describe('Result', () => {
     });
   });
 
-  describe('fromAsyncThrowable', () => {
+  describe('fromThrowable', () => {
     it('when throwable is thrown, should return expected value', () => {
       // Error-first generics let you name only the error type.
       const res = fromThrowable<Error>(() => {
@@ -657,23 +658,23 @@ describe('Result', () => {
         }
       });
     });
+  });
 
-    describe('async', () => {
-      it('when throwable is thrown, should return expected value', async () => {
-        const res = await fromAsyncThrowable<Error>(
-          async () => {
-            throw new Error('err');
-          },
-        );
-        checkType<
-          Equal<typeof res, AnzenResult<Error, unknown>>
-        >();
-        assert.equal(res.isOk, false);
-        assert.equal(res.isErr, true);
-        if (res.isErr) {
-          assert.equal(res.unwrapErr().message, 'err');
-        }
-      });
+  describe('fromAsyncThrowable', () => {
+    it('when throwable is thrown, should return expected value', async () => {
+      const res = await fromAsyncThrowable<Error>(
+        async () => {
+          throw new Error('err');
+        },
+      );
+      checkType<
+        Equal<typeof res, AnzenResult<Error, unknown>>
+      >();
+      assert.equal(res.isOk, false);
+      assert.equal(res.isErr, true);
+      if (res.isErr) {
+        assert.equal(res.unwrapErr().message, 'err');
+      }
     });
 
     it('when throwable is not thrown, should return expected value', async () => {
@@ -684,6 +685,44 @@ describe('Result', () => {
       assert.equal(res.isOk, true);
       assert.equal(res.isErr, false);
       assert.equal(res.unwrap(), 1);
+    });
+  });
+
+  describe('wrapAsyncThrowable', () => {
+    it('adapts an async throwing fn into a reusable AnzenResultFn', async () => {
+      const safe = wrapAsyncThrowable(
+        async (id: number) => {
+          if (id < 0) throw new Error('bad id');
+          return id * 2;
+        },
+        (e) => (e instanceof Error ? e.message : String(e)),
+      );
+      checkType<
+        Equal<
+          typeof safe,
+          (
+            id: number,
+          ) => Promise<AnzenResult<string, number>>
+        >
+      >();
+      const okRes = await safe(2);
+      assert.equal(okRes.unwrap(), 4);
+      const errRes = await safe(-1);
+      assert.equal(errRes.isErr, true);
+      if (errRes.isErr) {
+        assert.equal(errRes.unwrapErr(), 'bad id');
+      }
+    });
+
+    it('captures a synchronous throw on invocation', async () => {
+      // The thunk defers the call, so a sync throw is caught too.
+      const safe = wrapAsyncThrowable(
+        (): Promise<number> => {
+          throw new Error('sync boom');
+        },
+      );
+      const res = await safe();
+      assert.equal(res.isErr, true);
     });
   });
 });

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -1,6 +1,6 @@
 export type AnzenResultOk<T> = ResultOk<T>;
 export type AnzenResultErr<E> = ResultErr<E>;
-export type AnzenAnyResult<E, T> =
+export type AnzenResult<E, T> =
   | AnzenResultErr<E>
   | AnzenResultOk<T>;
 type ExtractOk<T extends readonly unknown[]> = {
@@ -12,7 +12,7 @@ type ExtractOk<T extends readonly unknown[]> = {
 };
 export type AnzenResultFn<E, T> = (
   ...args: any[]
-) => AnzenAnyResult<E, T> | Promise<AnzenAnyResult<E, T>>;
+) => AnzenResult<E, T> | Promise<AnzenResult<E, T>>;
 
 // Registry-global brand stamped on every Result. `Symbol.for` keeps it
 // stable across realms/bundles (and duplicated module copies), so
@@ -44,7 +44,7 @@ export class ResultOk<T> {
     );
   }
 
-  andThen<V extends AnzenAnyResult<unknown, unknown>>(
+  andThen<V extends AnzenResult<unknown, unknown>>(
     fn: (val: T) => V,
   ): V {
     return fn(this.#value);
@@ -64,10 +64,6 @@ export class ResultOk<T> {
 
   toTuple(): [this, T] {
     return [this, this.#value];
-  }
-
-  getRaw(): T {
-    return this.#value;
   }
 
   toJSON(): string {
@@ -106,7 +102,7 @@ export class ResultErr<E> {
     return this;
   }
 
-  orElse<V extends AnzenAnyResult<unknown, unknown>>(
+  orElse<V extends AnzenResult<unknown, unknown>>(
     fn: (err: E) => V,
   ): V {
     return fn(this.#error);
@@ -124,10 +120,6 @@ export class ResultErr<E> {
     return [this, defaultVal as V];
   }
 
-  getRaw(): E {
-    return this.#error;
-  }
-
   toJSON(): string {
     return JSON.stringify({
       error: this.#error,
@@ -137,9 +129,7 @@ export class ResultErr<E> {
 }
 
 async function handleResult<E, T>(
-  whenRes:
-    | Promise<AnzenAnyResult<E, T>>
-    | AnzenAnyResult<E, T>,
+  whenRes: Promise<AnzenResult<E, T>> | AnzenResult<E, T>,
 ) {
   const res = await whenRes;
   return res.isOk
@@ -159,7 +149,7 @@ export function err<E>(error: E): AnzenResultErr<E> {
 // `instanceof`, when more than one copy of the package is loaded.
 export function isAnzenResult(
   value: unknown,
-): value is AnzenAnyResult<unknown, unknown> {
+): value is AnzenResult<unknown, unknown> {
   return (
     typeof value === 'object' &&
     value !== null &&
@@ -169,8 +159,8 @@ export function isAnzenResult(
 
 export async function promiseAll<
   const T extends (
-    | AnzenAnyResult<unknown, unknown>
-    | Promise<AnzenAnyResult<unknown, unknown>>
+    | AnzenResult<unknown, unknown>
+    | Promise<AnzenResult<unknown, unknown>>
   )[],
 >(
   whenRes: T,
@@ -191,8 +181,8 @@ export async function promiseAll<
 
 export async function unwrapPromiseAll<
   const T extends (
-    | AnzenAnyResult<unknown, unknown>
-    | Promise<AnzenAnyResult<unknown, unknown>>
+    | AnzenResult<unknown, unknown>
+    | Promise<AnzenResult<unknown, unknown>>
   )[],
 >(
   // A full-length defaults tuple is required: on failure these are spread
@@ -228,24 +218,24 @@ export function toTuple<
   D = undefined,
 >(defaultVal?: D) {
   return (
-    res: AnzenAnyResult<E, T>,
+    res: AnzenResult<E, T>,
   ): [AnzenResultErr<E>, D] | [AnzenResultOk<T>, T] =>
     res.isOk ? [res, res.unwrap()] : [res, defaultVal as D];
 }
 
 export function fromJSON<E = unknown, T = unknown>(
   json: string,
-): AnzenAnyResult<E, T> {
+): AnzenResult<E, T> {
   const obj = JSON.parse(json);
   return obj.isOk
     ? new ResultOk<T>(obj.value)
     : new ResultErr<E>(obj.error);
 }
 
-export function fromSyncThrowable<E = unknown, T = unknown>(
+export function fromThrowable<E = unknown, T = unknown>(
   fn: () => T,
   parseErr?: (error: unknown) => E,
-): AnzenAnyResult<E, T> {
+): AnzenResult<E, T> {
   try {
     return ok(fn());
   } catch (error) {
@@ -253,13 +243,13 @@ export function fromSyncThrowable<E = unknown, T = unknown>(
   }
 }
 
-export async function fromThrowable<
+export async function fromAsyncThrowable<
   E = unknown,
   T = unknown,
 >(
   fn: () => Promise<T>,
   parseErr?: (error: unknown) => E,
-): Promise<AnzenAnyResult<E, T>> {
+): Promise<AnzenResult<E, T>> {
   try {
     return ok(await fn());
   } catch (error) {
@@ -269,24 +259,22 @@ export async function fromThrowable<
 
 // A thenable that carries the Result combinators over an async boundary,
 // so I/O-heavy code can keep chaining instead of awaiting and re-wrapping
-// at every step. `await`-ing an AsyncResult yields the underlying Result.
-export class AsyncResult<E, T> implements PromiseLike<
-  AnzenAnyResult<E, T>
+// at every step. `await`-ing an ResultAsync yields the underlying Result.
+export class ResultAsync<E, T> implements PromiseLike<
+  AnzenResult<E, T>
 > {
-  #promise: Promise<AnzenAnyResult<E, T>>;
+  #promise: Promise<AnzenResult<E, T>>;
 
-  constructor(promise: Promise<AnzenAnyResult<E, T>>) {
+  constructor(promise: Promise<AnzenResult<E, T>>) {
     this.#promise = promise;
   }
 
   // The thenable surface is intentional: it lets callers `await` an
-  // AsyncResult to get the underlying Result (the core ergonomic).
+  // ResultAsync to get the underlying Result (the core ergonomic).
   // eslint-disable-next-line unicorn/no-thenable
-  then<R1 = AnzenAnyResult<E, T>, R2 = never>(
+  then<R1 = AnzenResult<E, T>, R2 = never>(
     onFulfilled?:
-      | ((
-          value: AnzenAnyResult<E, T>,
-        ) => R1 | PromiseLike<R1>)
+      | ((value: AnzenResult<E, T>) => R1 | PromiseLike<R1>)
       | null,
     onRejected?:
       | ((reason: unknown) => R2 | PromiseLike<R2>)
@@ -297,8 +285,8 @@ export class AsyncResult<E, T> implements PromiseLike<
 
   map<U>(
     fn: (val: T) => U | Promise<U>,
-  ): AsyncResult<E, U> {
-    return new AsyncResult(
+  ): ResultAsync<E, U> {
+    return new ResultAsync(
       this.#promise.then(async (res) =>
         res.isOk ? ok(await fn(res.unwrap())) : res,
       ),
@@ -307,8 +295,8 @@ export class AsyncResult<E, T> implements PromiseLike<
 
   mapErr<U>(
     fn: (error: E) => U | Promise<U>,
-  ): AsyncResult<U, T> {
-    return new AsyncResult(
+  ): ResultAsync<U, T> {
+    return new ResultAsync(
       this.#promise.then(async (res) =>
         res.isErr ? err(await fn(res.unwrapErr())) : res,
       ),
@@ -319,16 +307,16 @@ export class AsyncResult<E, T> implements PromiseLike<
     fn: (
       val: T,
     ) =>
-      | AnzenAnyResult<F, U>
-      | AsyncResult<F, U>
-      | Promise<AnzenAnyResult<F, U>>,
-  ): AsyncResult<E | F, U> {
-    return new AsyncResult<E | F, U>(
+      | AnzenResult<F, U>
+      | ResultAsync<F, U>
+      | Promise<AnzenResult<F, U>>,
+  ): ResultAsync<E | F, U> {
+    return new ResultAsync<E | F, U>(
       this.#promise.then((res) =>
         res.isOk
           ? fn(res.unwrap())
           : (res as AnzenResultErr<E>),
-      ) as Promise<AnzenAnyResult<E | F, U>>,
+      ) as Promise<AnzenResult<E | F, U>>,
     );
   }
 
@@ -336,16 +324,16 @@ export class AsyncResult<E, T> implements PromiseLike<
     fn: (
       error: E,
     ) =>
-      | AnzenAnyResult<F, U>
-      | AsyncResult<F, U>
-      | Promise<AnzenAnyResult<F, U>>,
-  ): AsyncResult<F, T | U> {
-    return new AsyncResult<F, T | U>(
+      | AnzenResult<F, U>
+      | ResultAsync<F, U>
+      | Promise<AnzenResult<F, U>>,
+  ): ResultAsync<F, T | U> {
+    return new ResultAsync<F, T | U>(
       this.#promise.then((res) =>
         res.isErr
           ? fn(res.unwrapErr())
           : (res as AnzenResultOk<T>),
-      ) as Promise<AnzenAnyResult<F, T | U>>,
+      ) as Promise<AnzenResult<F, T | U>>,
     );
   }
 
@@ -362,25 +350,25 @@ export class AsyncResult<E, T> implements PromiseLike<
   }
 }
 
-export function okAsync<T>(val: T): AsyncResult<never, T> {
-  return new AsyncResult(Promise.resolve(ok(val)));
+export function okAsync<T>(val: T): ResultAsync<never, T> {
+  return new ResultAsync(Promise.resolve(ok(val)));
 }
 
 export function errAsync<E>(
   error: E,
-): AsyncResult<E, never> {
-  return new AsyncResult(Promise.resolve(err(error)));
+): ResultAsync<E, never> {
+  return new ResultAsync(Promise.resolve(err(error)));
 }
 
-// Lifts a Promise that may reject into an AsyncResult: a resolved value
+// Lifts a Promise that may reject into an ResultAsync: a resolved value
 // becomes Ok, a rejection becomes Err. Without `parseErr` the error type
 // is `unknown` — pass `parseErr` to obtain a typed error (matching
 // neverthrow's `fromPromise(promise, errorFn)` contract).
 export function fromPromise<T, E = unknown>(
   promise: Promise<T>,
   parseErr?: (error: unknown) => E,
-): AsyncResult<E, T> {
-  return new AsyncResult(
+): ResultAsync<E, T> {
+  return new ResultAsync(
     promise.then(
       (val) => ok<T>(val),
       (error) =>
@@ -390,9 +378,9 @@ export function fromPromise<T, E = unknown>(
 }
 
 // Lifts a Promise that is already known not to reject (it resolves to a
-// Result) into an AsyncResult.
+// Result) into an ResultAsync.
 export function fromSafePromise<E, T>(
-  promise: Promise<AnzenAnyResult<E, T>>,
-): AsyncResult<E, T> {
-  return new AsyncResult(promise);
+  promise: Promise<AnzenResult<E, T>>,
+): ResultAsync<E, T> {
+  return new ResultAsync(promise);
 }

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -29,25 +29,25 @@ export class ResultSuccess<T> {
     this.#value = value;
   }
 
-  getValue(): T {
+  unwrap(): T {
     return this.#value;
   }
 
-  getOrElse<V>(_: V): T {
+  unwrapOr<V>(_: V): T {
     return this.#value;
   }
 
-  getError(): never {
+  unwrapErr(): never {
     throw new Error('Cannot get the error of a success.');
   }
 
-  chain<V extends AnzenAnyResult<unknown, unknown>>(
+  andThen<V extends AnzenAnyResult<unknown, unknown>>(
     fn: (val: T) => V,
   ): V {
     return fn(this.#value);
   }
 
-  elseChain(_: (val: T) => unknown): this {
+  orElse(_: (val: T) => unknown): this {
     return this;
   }
 
@@ -55,15 +55,15 @@ export class ResultSuccess<T> {
     return new ResultSuccess(fn(this.#value));
   }
 
-  elseMap(_: (val: T) => unknown): this {
+  mapErr(_: (val: T) => unknown): this {
     return this;
   }
 
-  unwrap(): [this, T] {
+  toTuple(): [this, T] {
     return [this, this.#value];
   }
 
-  unsafeUnwrap(): T {
+  getRaw(): T {
     return this.#value;
   }
 
@@ -84,23 +84,23 @@ export class ResultFailure<E> {
     this.#error = err;
   }
 
-  getValue(): never {
+  unwrap(): never {
     throw new Error('Cannot get the value of a failure.');
   }
 
-  getOrElse<T>(defaultVal: T): T {
+  unwrapOr<T>(defaultVal: T): T {
     return defaultVal;
   }
 
-  getError(): E {
+  unwrapErr(): E {
     return this.#error;
   }
 
-  chain(_: (err: E) => unknown): this {
+  andThen(_: (err: E) => unknown): this {
     return this;
   }
 
-  elseChain<V extends AnzenAnyResult<unknown, unknown>>(
+  orElse<V extends AnzenAnyResult<unknown, unknown>>(
     fn: (err: E) => V,
   ): V {
     return fn(this.#error);
@@ -110,15 +110,15 @@ export class ResultFailure<E> {
     return this;
   }
 
-  elseMap<V>(fn: (err: E) => V): AnzenResultSuccess<V> {
+  mapErr<V>(fn: (err: E) => V): AnzenResultSuccess<V> {
     return new ResultSuccess(fn(this.#error));
   }
 
-  unwrap<V = undefined>(defaultVal?: V): [this, V] {
+  toTuple<V = undefined>(defaultVal?: V): [this, V] {
     return [this, defaultVal as V];
   }
 
-  unsafeUnwrap(): E {
+  getRaw(): E {
     return this.#error;
   }
 
@@ -137,8 +137,8 @@ async function handleResult<E, T>(
 ) {
   const res = await whenRes;
   return res.isSuccess
-    ? res.getValue()
-    : Promise.reject(res.getError());
+    ? res.unwrap()
+    : Promise.reject(res.unwrapErr());
 }
 
 export function success<T>(val: T): AnzenResultSuccess<T> {
@@ -207,16 +207,18 @@ export async function unwrapPromiseAll<
   }
 }
 
-export function unwrap<T = never, E = never, D = undefined>(
-  defaultVal?: D,
-) {
+export function toTuple<
+  T = never,
+  E = never,
+  D = undefined,
+>(defaultVal?: D) {
   return (
     res: AnzenAnyResult<E, T>,
   ):
     | [AnzenResultFailure<E>, D]
     | [AnzenResultSuccess<T>, T] =>
     res.isSuccess
-      ? [res, res.getValue()]
+      ? [res, res.unwrap()]
       : [res, defaultVal as D];
 }
 

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -141,112 +141,137 @@ async function handleResult<E, T>(
     : Promise.reject(res.getError());
 }
 
-export class Result {
-  static success = <T>(val: T): AnzenResultSuccess<T> =>
-    new ResultSuccess(val);
+export function success<T>(
+  val: T,
+): AnzenResultSuccess<T> {
+  return new ResultSuccess(val);
+}
 
-  static failure = <E>(err: E): AnzenResultFailure<E> =>
-    new ResultFailure(err);
+export function failure<E>(
+  err: E,
+): AnzenResultFailure<E> {
+  return new ResultFailure(err);
+}
 
-  static async promiseAll<
-    const T extends (
-      | AnzenAnyResult<unknown, unknown>
-      | Promise<AnzenAnyResult<unknown, unknown>>
-    )[],
-  >(
-    whenRes: T,
-  ): Promise<
-    | AnzenResultSuccess<ExtractSuccess<T>>
-    | AnzenResultFailure<ExtractFailure<T>>
-  > {
-    try {
-      const vals = await Promise.all(
-        whenRes.map((r) => handleResult(r)),
-      );
-      return Result.success(vals) as AnzenResultSuccess<
-        ExtractSuccess<T>
-      >;
-    } catch (err) {
-      return Result.failure(err) as AnzenResultFailure<
-        ExtractFailure<T>
-      >;
-    }
-  }
-
-  static async unwrapPromiseAll<
-    const T extends (
-      | AnzenAnyResult<unknown, unknown>
-      | Promise<AnzenAnyResult<unknown, unknown>>
-    )[],
-  >(
-    args: [Partial<ExtractSuccess<T>>, ...T],
-  ): Promise<
-    [
-      (
-        | AnzenResultSuccess<ExtractSuccess<T>>
-        | AnzenResultFailure<ExtractFailure<T>>
-      ),
-      ...ExtractSuccess<T>,
-    ]
-  > {
-    const [defaultsVals, ...whenRes] = args;
-    try {
-      const vals = await Promise.all(
-        whenRes.map((r) => handleResult(r)),
-      );
-      return [Result.success(vals), ...vals] as [
-        AnzenResultSuccess<ExtractSuccess<T>>,
-        ...ExtractSuccess<T>,
-      ];
-    } catch (err) {
-      return [Result.failure(err), ...defaultsVals] as [
-        AnzenResultFailure<ExtractFailure<T>>,
-        ...ExtractSuccess<T>,
-      ];
-    }
-  }
-
-  static unwrap<T = never, E = never, D = undefined>(
-    defaultVal?: D,
-  ) {
-    return (
-      res: AnzenAnyResult<E, T>,
-    ):
-      | [AnzenResultFailure<E>, D]
-      | [AnzenResultSuccess<T>, T] =>
-      res.isSuccess
-        ? [res, res.getValue()]
-        : [res, defaultVal as D];
-  }
-
-  static fromJSON<E = unknown, T = unknown>(
-    json: string,
-  ): AnzenAnyResult<E, T> {
-    const obj = JSON.parse(json);
-    return obj.isSuccess
-      ? new ResultSuccess<T>(obj.value)
-      : new ResultFailure<E>(obj.error);
-  }
-
-  static fromSyncThrowable<E = unknown, T = unknown>(
-    fn: () => T,
-    parseErr?: (err: unknown) => E,
-  ): AnzenAnyResult<E, T> {
-    try {
-      return Result.success(fn());
-    } catch (err) {
-      return Result.failure(parseErr?.(err) ?? (err as E));
-    }
-  }
-
-  static async fromThrowable<E = unknown, T = unknown>(
-    fn: () => Promise<T>,
-    parseErr?: (err: unknown) => E,
-  ): Promise<AnzenAnyResult<E, T>> {
-    try {
-      return Result.success(await fn());
-    } catch (err) {
-      return Result.failure(parseErr?.(err) ?? (err as E));
-    }
+export async function promiseAll<
+  const T extends (
+    | AnzenAnyResult<unknown, unknown>
+    | Promise<AnzenAnyResult<unknown, unknown>>
+  )[],
+>(
+  whenRes: T,
+): Promise<
+  | AnzenResultSuccess<ExtractSuccess<T>>
+  | AnzenResultFailure<ExtractFailure<T>>
+> {
+  try {
+    const vals = await Promise.all(
+      whenRes.map((r) => handleResult(r)),
+    );
+    return success(vals) as AnzenResultSuccess<
+      ExtractSuccess<T>
+    >;
+  } catch (err) {
+    return failure(err) as AnzenResultFailure<
+      ExtractFailure<T>
+    >;
   }
 }
+
+export async function unwrapPromiseAll<
+  const T extends (
+    | AnzenAnyResult<unknown, unknown>
+    | Promise<AnzenAnyResult<unknown, unknown>>
+  )[],
+>(
+  args: [Partial<ExtractSuccess<T>>, ...T],
+): Promise<
+  [
+    (
+      | AnzenResultSuccess<ExtractSuccess<T>>
+      | AnzenResultFailure<ExtractFailure<T>>
+    ),
+    ...ExtractSuccess<T>,
+  ]
+> {
+  const [defaultsVals, ...whenRes] = args;
+  try {
+    const vals = await Promise.all(
+      whenRes.map((r) => handleResult(r)),
+    );
+    return [success(vals), ...vals] as [
+      AnzenResultSuccess<ExtractSuccess<T>>,
+      ...ExtractSuccess<T>,
+    ];
+  } catch (err) {
+    return [failure(err), ...defaultsVals] as [
+      AnzenResultFailure<ExtractFailure<T>>,
+      ...ExtractSuccess<T>,
+    ];
+  }
+}
+
+export function unwrap<T = never, E = never, D = undefined>(
+  defaultVal?: D,
+) {
+  return (
+    res: AnzenAnyResult<E, T>,
+  ):
+    | [AnzenResultFailure<E>, D]
+    | [AnzenResultSuccess<T>, T] =>
+    res.isSuccess
+      ? [res, res.getValue()]
+      : [res, defaultVal as D];
+}
+
+export function fromJSON<E = unknown, T = unknown>(
+  json: string,
+): AnzenAnyResult<E, T> {
+  const obj = JSON.parse(json);
+  return obj.isSuccess
+    ? new ResultSuccess<T>(obj.value)
+    : new ResultFailure<E>(obj.error);
+}
+
+export function fromSyncThrowable<
+  E = unknown,
+  T = unknown,
+>(
+  fn: () => T,
+  parseErr?: (err: unknown) => E,
+): AnzenAnyResult<E, T> {
+  try {
+    return success(fn());
+  } catch (err) {
+    return failure(parseErr?.(err) ?? (err as E));
+  }
+}
+
+export async function fromThrowable<
+  E = unknown,
+  T = unknown,
+>(
+  fn: () => Promise<T>,
+  parseErr?: (err: unknown) => E,
+): Promise<AnzenAnyResult<E, T>> {
+  try {
+    return success(await fn());
+  } catch (err) {
+    return failure(parseErr?.(err) ?? (err as E));
+  }
+}
+
+// Back-compat aggregating namespace. Importing `Result` retains every
+// combinator (a single binding bundlers cannot split), so for per-function
+// tree-shaking import the named functions directly, e.g.
+// `import { success } from '@daisugi/anzen'`.
+export const Result = {
+  success,
+  failure,
+  promiseAll,
+  unwrapPromiseAll,
+  unwrap,
+  fromJSON,
+  fromSyncThrowable,
+  fromThrowable,
+};

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -3,7 +3,7 @@ export type AnzenResultErr<E> = ResultErr<E>;
 export type AnzenResult<E, T> =
   | AnzenResultErr<E>
   | AnzenResultOk<T>;
-export type AnzenResultAsync<E, T> = ResultAsync<E, T>;
+
 type ExtractOk<T extends readonly unknown[]> = {
   [K in keyof T]: Awaited<T[K]> extends infer R
     ? R extends AnzenResultOk<infer U>
@@ -79,6 +79,13 @@ export class ResultOk<T> {
     return [this, this.#value];
   }
 
+  // Generator hook for `safeTry`: an Ok yields nothing and returns its
+  // value, so `yield* okResult` evaluates to the unwrapped value.
+  // eslint-disable-next-line require-yield
+  *[Symbol.iterator](): Generator<never, T> {
+    return this.#value;
+  }
+
   toJSON(): string {
     return JSON.stringify({
       value: this.#value,
@@ -143,6 +150,19 @@ export class ResultErr<E> {
     return [this, defaultVal as V];
   }
 
+  // Generator hook for `safeTry`: an Err yields itself, short-circuiting the
+  // enclosing generator. The throw is unreachable (the yield never resumes)
+  // and only satisfies the `never` return type.
+  *[Symbol.iterator](): Generator<
+    AnzenResultErr<E>,
+    never
+  > {
+    yield this;
+    throw new Error(
+      'safeTry generator resumed after an Err.',
+    );
+  }
+
   toJSON(): string {
     return JSON.stringify({
       error: this.#error,
@@ -169,6 +189,42 @@ export function isAnzenResult(
     value !== null &&
     (value as Record<symbol, unknown>)[anzenBrand] === true
   );
+}
+
+// Rust's `?`-operator for Results, via generators. Inside `body`, `yield*`
+// on a Result unwraps an Ok to its value or aborts the whole body to that
+// Err. A sync generator returns a Result; an async one (`async function*`
+// with `yield* await ...`) returns a Promise of one.
+export function safeTry<E, T>(
+  body: () => Generator<
+    AnzenResultErr<E>,
+    AnzenResult<E, T>
+  >,
+): AnzenResult<E, T>;
+export function safeTry<E, T>(
+  body: () => AsyncGenerator<
+    AnzenResultErr<E>,
+    AnzenResult<E, T>
+  >,
+): Promise<AnzenResult<E, T>>;
+export function safeTry<E, T>(
+  body:
+    | (() => Generator<
+        AnzenResultErr<E>,
+        AnzenResult<E, T>
+      >)
+    | (() => AsyncGenerator<
+        AnzenResultErr<E>,
+        AnzenResult<E, T>
+      >),
+): AnzenResult<E, T> | Promise<AnzenResult<E, T>> {
+  // The first step either yields an Err (short-circuit) or returns the
+  // final Result; both surface in `.value`, so the generator is never
+  // advanced again.
+  const next = body().next();
+  return next instanceof Promise
+    ? next.then((res) => res.value)
+    : next.value;
 }
 
 export async function promiseAll<
@@ -258,176 +314,41 @@ export function fromJSON<E = unknown, T = unknown>(
     : new ResultErr<E>(obj.error);
 }
 
-export function fromThrowable<E = unknown, T = unknown>(
-  fn: () => T,
-  parseErr?: (error: unknown) => E,
-): AnzenResult<E, T> {
-  try {
-    return ok(fn());
-  } catch (error) {
-    return err(parseErr?.(error) ?? (error as E));
-  }
-}
-
-export async function fromAsyncThrowable<
+export function fromThrowable<
   E = unknown,
   T = unknown,
+  A extends readonly unknown[] = [],
 >(
-  fn: () => Promise<T>,
+  fn: (...args: A) => T,
   parseErr?: (error: unknown) => E,
-): Promise<AnzenResult<E, T>> {
-  try {
-    return ok(await fn());
-  } catch (error) {
-    return err(parseErr?.(error) ?? (error as E));
-  }
+): (...args: A) => AnzenResult<E, T> {
+  return (...args) => {
+    try {
+      return ok(fn(...args));
+    } catch (error) {
+      return err(parseErr?.(error) ?? (error as E));
+    }
+  };
 }
 
-// Lazy counterpart of `fromAsyncThrowable`: adapts a throwing/rejecting async
-// function into a reusable Result-returning function, preserving its parameters.
-// Each call defers into the thunk, so a synchronous throw on invocation is caught.
-export function wrapAsyncThrowable<
-  A extends readonly unknown[],
-  T,
+export function fromAsyncThrowable<
   E = unknown,
+  T = unknown,
+  A extends readonly unknown[] = [],
 >(
   fn: (...args: A) => Promise<T>,
   parseErr?: (error: unknown) => E,
 ): (...args: A) => Promise<AnzenResult<E, T>> {
-  return (...args) =>
-    fromAsyncThrowable(() => fn(...args), parseErr);
-}
-
-// A thenable that carries the Result combinators over an async boundary,
-// so I/O-heavy code can keep chaining instead of awaiting and re-wrapping
-// at every step. `await`-ing an ResultAsync yields the underlying Result.
-export class ResultAsync<E, T> implements PromiseLike<
-  AnzenResult<E, T>
-> {
-  #promise: Promise<AnzenResult<E, T>>;
-
-  constructor(promise: Promise<AnzenResult<E, T>>) {
-    this.#promise = promise;
-  }
-
-  // The thenable surface is intentional: it lets callers `await` an
-  // ResultAsync to get the underlying Result (the core ergonomic).
-  // eslint-disable-next-line unicorn/no-thenable
-  then<R1 = AnzenResult<E, T>, R2 = never>(
-    onFulfilled?:
-      | ((value: AnzenResult<E, T>) => R1 | PromiseLike<R1>)
-      | null,
-    onRejected?:
-      | ((reason: unknown) => R2 | PromiseLike<R2>)
-      | null,
-  ): Promise<R1 | R2> {
-    return this.#promise.then(onFulfilled, onRejected);
-  }
-
-  map<U>(
-    fn: (val: T) => U | Promise<U>,
-  ): ResultAsync<E, U> {
-    return new ResultAsync<E, U>(
-      this.#promise.then((res) => {
-        if (res.isErr) return res;
-        // Only adopt a microtask when the transform is actually async.
-        const out = fn(res.unwrap());
-        return out instanceof Promise
-          ? out.then(ok)
-          : ok(out);
-      }),
-    );
-  }
-
-  mapErr<U>(
-    fn: (error: E) => U | Promise<U>,
-  ): ResultAsync<U, T> {
-    return new ResultAsync<U, T>(
-      this.#promise.then((res) => {
-        if (res.isOk) return res;
-        const out = fn(res.unwrapErr());
-        return out instanceof Promise
-          ? out.then(err)
-          : err(out);
-      }),
-    );
-  }
-
-  andThen<U, F>(
-    fn: (
-      val: T,
-    ) =>
-      | AnzenResult<F, U>
-      | ResultAsync<F, U>
-      | Promise<AnzenResult<F, U>>,
-  ): ResultAsync<E | F, U> {
-    return new ResultAsync<E | F, U>(
-      this.#promise.then((res) => {
-        if (res.isErr) return res;
-        return fn(res.unwrap());
-      }),
-    );
-  }
-
-  orElse<U, F>(
-    fn: (
-      error: E,
-    ) =>
-      | AnzenResult<F, U>
-      | ResultAsync<F, U>
-      | Promise<AnzenResult<F, U>>,
-  ): ResultAsync<F, T | U> {
-    return new ResultAsync<F, T | U>(
-      this.#promise.then((res) => {
-        if (res.isOk) return res;
-        return fn(res.unwrapErr());
-      }),
-    );
-  }
-
-  async unwrap(): Promise<T> {
-    return (await this.#promise).unwrap();
-  }
-
-  async unwrapErr(): Promise<E> {
-    return (await this.#promise).unwrapErr();
-  }
-
-  async unwrapOr<V>(defaultVal: V): Promise<T | V> {
-    return (await this.#promise).unwrapOr(defaultVal);
-  }
-}
-
-export function okAsync<T>(val: T): ResultAsync<never, T> {
-  return new ResultAsync(Promise.resolve(ok(val)));
-}
-
-export function errAsync<E>(
-  error: E,
-): ResultAsync<E, never> {
-  return new ResultAsync(Promise.resolve(err(error)));
-}
-
-// Lifts a Promise that may reject into an ResultAsync: resolved becomes Ok,
-// rejection becomes Err. Without `parseErr` the error type is `unknown`; pass
-// it for a typed error (neverthrow's `fromPromise(promise, errorFn)` contract).
-export function fromPromise<T, E = unknown>(
-  promise: Promise<T>,
-  parseErr?: (error: unknown) => E,
-): ResultAsync<E, T> {
-  return new ResultAsync(
-    promise.then(
-      (val) => ok<T>(val),
-      (error) =>
-        err<E>(parseErr ? parseErr(error) : (error as E)),
-    ),
-  );
-}
-
-// Lifts a Promise that is already known not to reject (it resolves to a
-// Result) into an ResultAsync.
-export function fromSafePromise<E, T>(
-  promise: Promise<AnzenResult<E, T>>,
-): ResultAsync<E, T> {
-  return new ResultAsync(promise);
+  return (...args) => {
+    try {
+      return fn(...args).then(
+        (val) => ok(val),
+        (error) => err(parseErr?.(error) ?? (error as E)),
+      );
+    } catch (error) {
+      return Promise.resolve(
+        err(parseErr?.(error) ?? (error as E)),
+      );
+    }
+  };
 }

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -1,17 +1,17 @@
-export type AnzenResultSuccess<T> = ResultSuccess<T>;
-export type AnzenResultFailure<E> = ResultFailure<E>;
+export type AnzenResultOk<T> = ResultOk<T>;
+export type AnzenResultErr<E> = ResultErr<E>;
 export type AnzenAnyResult<E, T> =
-  | AnzenResultFailure<E>
-  | AnzenResultSuccess<T>;
-type ExtractFailure<T extends readonly unknown[]> =
+  | AnzenResultErr<E>
+  | AnzenResultOk<T>;
+type ExtractErr<T extends readonly unknown[]> =
   Awaited<T[number]> extends infer R
-    ? R extends AnzenResultFailure<infer U>
+    ? R extends AnzenResultErr<infer U>
       ? U
       : never
     : never;
-type ExtractSuccess<T extends readonly unknown[]> = {
+type ExtractOk<T extends readonly unknown[]> = {
   [K in keyof T]: Awaited<T[K]> extends infer R
-    ? R extends AnzenResultSuccess<infer U>
+    ? R extends AnzenResultOk<infer U>
       ? U
       : never
     : never;
@@ -26,9 +26,9 @@ export type AnzenResultFn<E, T> = (
 // the package are loaded, their classes are no longer reference-equal.
 const anzenBrand = Symbol.for('@daisugi/anzen');
 
-export class ResultSuccess<T> {
-  readonly isSuccess = true;
-  readonly isFailure = false;
+export class ResultOk<T> {
+  readonly isOk = true;
+  readonly isErr = false;
   readonly [anzenBrand] = true;
   #value: T;
 
@@ -45,7 +45,9 @@ export class ResultSuccess<T> {
   }
 
   unwrapErr(): never {
-    throw new Error('Cannot get the error of a success.');
+    throw new Error(
+      'Cannot get the error of an Ok result.',
+    );
   }
 
   andThen<V extends AnzenAnyResult<unknown, unknown>>(
@@ -58,8 +60,8 @@ export class ResultSuccess<T> {
     return this;
   }
 
-  map<V>(fn: (val: T) => V): AnzenResultSuccess<V> {
-    return new ResultSuccess(fn(this.#value));
+  map<V>(fn: (val: T) => V): AnzenResultOk<V> {
+    return new ResultOk(fn(this.#value));
   }
 
   mapErr(_: (val: T) => unknown): this {
@@ -77,23 +79,25 @@ export class ResultSuccess<T> {
   toJSON(): string {
     return JSON.stringify({
       value: this.#value,
-      isSuccess: this.isSuccess,
+      isOk: this.isOk,
     });
   }
 }
 
-export class ResultFailure<E> {
-  readonly isSuccess = false;
-  readonly isFailure = true;
+export class ResultErr<E> {
+  readonly isOk = false;
+  readonly isErr = true;
   readonly [anzenBrand] = true;
   #error: E;
 
-  constructor(err: E) {
-    this.#error = err;
+  constructor(error: E) {
+    this.#error = error;
   }
 
   unwrap(): never {
-    throw new Error('Cannot get the value of a failure.');
+    throw new Error(
+      'Cannot get the value of an Err result.',
+    );
   }
 
   unwrapOr<T>(defaultVal: T): T {
@@ -118,8 +122,8 @@ export class ResultFailure<E> {
     return this;
   }
 
-  mapErr<V>(fn: (err: E) => V): AnzenResultSuccess<V> {
-    return new ResultSuccess(fn(this.#error));
+  mapErr<V>(fn: (err: E) => V): AnzenResultOk<V> {
+    return new ResultOk(fn(this.#error));
   }
 
   toTuple<V = undefined>(defaultVal?: V): [this, V] {
@@ -133,7 +137,7 @@ export class ResultFailure<E> {
   toJSON(): string {
     return JSON.stringify({
       error: this.#error,
-      isSuccess: this.isSuccess,
+      isOk: this.isOk,
     });
   }
 }
@@ -144,17 +148,17 @@ async function handleResult<E, T>(
     | AnzenAnyResult<E, T>,
 ) {
   const res = await whenRes;
-  return res.isSuccess
+  return res.isOk
     ? res.unwrap()
     : Promise.reject(res.unwrapErr());
 }
 
-export function success<T>(val: T): AnzenResultSuccess<T> {
-  return new ResultSuccess(val);
+export function ok<T>(val: T): AnzenResultOk<T> {
+  return new ResultOk(val);
 }
 
-export function failure<E>(err: E): AnzenResultFailure<E> {
-  return new ResultFailure(err);
+export function err<E>(error: E): AnzenResultErr<E> {
+  return new ResultErr(error);
 }
 
 // Brand-based type guard. Reliable across realms/bundles, unlike
@@ -177,20 +181,16 @@ export async function promiseAll<
 >(
   whenRes: T,
 ): Promise<
-  | AnzenResultSuccess<ExtractSuccess<T>>
-  | AnzenResultFailure<ExtractFailure<T>>
+  | AnzenResultOk<ExtractOk<T>>
+  | AnzenResultErr<ExtractErr<T>>
 > {
   try {
     const vals = await Promise.all(
       whenRes.map((r) => handleResult(r)),
     );
-    return success(vals) as AnzenResultSuccess<
-      ExtractSuccess<T>
-    >;
-  } catch (err) {
-    return failure(err) as AnzenResultFailure<
-      ExtractFailure<T>
-    >;
+    return ok(vals) as AnzenResultOk<ExtractOk<T>>;
+  } catch (error) {
+    return err(error) as AnzenResultErr<ExtractErr<T>>;
   }
 }
 
@@ -200,14 +200,14 @@ export async function unwrapPromiseAll<
     | Promise<AnzenAnyResult<unknown, unknown>>
   )[],
 >(
-  args: [Partial<ExtractSuccess<T>>, ...T],
+  args: [Partial<ExtractOk<T>>, ...T],
 ): Promise<
   [
     (
-      | AnzenResultSuccess<ExtractSuccess<T>>
-      | AnzenResultFailure<ExtractFailure<T>>
+      | AnzenResultOk<ExtractOk<T>>
+      | AnzenResultErr<ExtractErr<T>>
     ),
-    ...ExtractSuccess<T>,
+    ...ExtractOk<T>,
   ]
 > {
   const [defaultsVals, ...whenRes] = args;
@@ -215,14 +215,14 @@ export async function unwrapPromiseAll<
     const vals = await Promise.all(
       whenRes.map((r) => handleResult(r)),
     );
-    return [success(vals), ...vals] as [
-      AnzenResultSuccess<ExtractSuccess<T>>,
-      ...ExtractSuccess<T>,
+    return [ok(vals), ...vals] as [
+      AnzenResultOk<ExtractOk<T>>,
+      ...ExtractOk<T>,
     ];
-  } catch (err) {
-    return [failure(err), ...defaultsVals] as [
-      AnzenResultFailure<ExtractFailure<T>>,
-      ...ExtractSuccess<T>,
+  } catch (error) {
+    return [err(error), ...defaultsVals] as [
+      AnzenResultErr<ExtractErr<T>>,
+      ...ExtractOk<T>,
     ];
   }
 }
@@ -234,31 +234,27 @@ export function toTuple<
 >(defaultVal?: D) {
   return (
     res: AnzenAnyResult<E, T>,
-  ):
-    | [AnzenResultFailure<E>, D]
-    | [AnzenResultSuccess<T>, T] =>
-    res.isSuccess
-      ? [res, res.unwrap()]
-      : [res, defaultVal as D];
+  ): [AnzenResultErr<E>, D] | [AnzenResultOk<T>, T] =>
+    res.isOk ? [res, res.unwrap()] : [res, defaultVal as D];
 }
 
 export function fromJSON<E = unknown, T = unknown>(
   json: string,
 ): AnzenAnyResult<E, T> {
   const obj = JSON.parse(json);
-  return obj.isSuccess
-    ? new ResultSuccess<T>(obj.value)
-    : new ResultFailure<E>(obj.error);
+  return obj.isOk
+    ? new ResultOk<T>(obj.value)
+    : new ResultErr<E>(obj.error);
 }
 
 export function fromSyncThrowable<E = unknown, T = unknown>(
   fn: () => T,
-  parseErr?: (err: unknown) => E,
+  parseErr?: (error: unknown) => E,
 ): AnzenAnyResult<E, T> {
   try {
-    return success(fn());
-  } catch (err) {
-    return failure(parseErr?.(err) ?? (err as E));
+    return ok(fn());
+  } catch (error) {
+    return err(parseErr?.(error) ?? (error as E));
   }
 }
 
@@ -267,11 +263,11 @@ export async function fromThrowable<
   T = unknown,
 >(
   fn: () => Promise<T>,
-  parseErr?: (err: unknown) => E,
+  parseErr?: (error: unknown) => E,
 ): Promise<AnzenAnyResult<E, T>> {
   try {
-    return success(await fn());
-  } catch (err) {
-    return failure(parseErr?.(err) ?? (err as E));
+    return ok(await fn());
+  } catch (error) {
+    return err(parseErr?.(error) ?? (error as E));
   }
 }

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -21,10 +21,25 @@ export type AnzenResultFn<E, T> = (
 const anzenBrand = Symbol.for('@daisugi/anzen');
 
 export class ResultOk<T> {
-  readonly isOk = true;
-  readonly isErr = false;
-  readonly [anzenBrand] = true;
+  declare readonly isOk: true;
+  declare readonly isErr: false;
   #value: T;
+
+  // Constant discriminants and brand live on the prototype (set once
+  // here), so each allocation writes only #value. A static block keeps
+  // this part of the class definition — safe under `sideEffects: false`,
+  // unlike a top-level `prototype` assignment. Cast through Record: the
+  // discriminants are declared `readonly` and the brand is a symbol.
+  static {
+    const proto = this.prototype as unknown as {
+      isOk: boolean;
+      isErr: boolean;
+      [key: symbol]: unknown;
+    };
+    proto.isOk = true;
+    proto.isErr = false;
+    proto[anzenBrand] = true;
+  }
 
   constructor(value: T) {
     this.#value = value;
@@ -75,10 +90,20 @@ export class ResultOk<T> {
 }
 
 export class ResultErr<E> {
-  readonly isOk = false;
-  readonly isErr = true;
-  readonly [anzenBrand] = true;
+  declare readonly isOk: false;
+  declare readonly isErr: true;
   #error: E;
+
+  static {
+    const proto = this.prototype as unknown as {
+      isOk: boolean;
+      isErr: boolean;
+      [key: symbol]: unknown;
+    };
+    proto.isOk = false;
+    proto.isErr = true;
+    proto[anzenBrand] = true;
+  }
 
   constructor(error: E) {
     this.#error = error;
@@ -128,15 +153,6 @@ export class ResultErr<E> {
   }
 }
 
-async function handleResult<E, T>(
-  whenRes: Promise<AnzenResult<E, T>> | AnzenResult<E, T>,
-) {
-  const res = await whenRes;
-  return res.isOk
-    ? res.unwrap()
-    : Promise.reject(res.unwrapErr());
-}
-
 export function ok<T>(val: T): AnzenResultOk<T> {
   return new ResultOk(val);
 }
@@ -168,13 +184,17 @@ export async function promiseAll<
   AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>
 > {
   try {
-    const vals = await Promise.all(
-      whenRes.map((r) => handleResult(r)),
-    );
+    // Settle everything once; scan in array order for the first Err.
+    const results = await Promise.all(whenRes);
+    const vals: unknown[] = [];
+    for (const res of results) {
+      if (res.isErr) return err(res.unwrapErr());
+      vals.push(res.unwrap());
+    }
     return ok(vals) as AnzenResultOk<ExtractOk<T>>;
   } catch (error) {
-    // A wrapped Err rejects with its own error, but a raw promise can
-    // reject with anything, so the failure type is honestly `unknown`.
+    // A raw promise can reject with anything, so the failure type is
+    // honestly `unknown`.
     return err(error);
   }
 }
@@ -197,9 +217,17 @@ export async function unwrapPromiseAll<
 > {
   const [defaultsVals, ...whenRes] = args;
   try {
-    const vals = await Promise.all(
-      whenRes.map((r) => handleResult(r)),
-    );
+    const results = await Promise.all(whenRes);
+    const vals: unknown[] = [];
+    for (const res of results) {
+      if (res.isErr) {
+        return [err(res.unwrapErr()), ...defaultsVals] as [
+          AnzenResultErr<unknown>,
+          ...ExtractOk<T>,
+        ];
+      }
+      vals.push(res.unwrap());
+    }
     return [ok(vals), ...vals] as [
       AnzenResultOk<ExtractOk<T>>,
       ...ExtractOk<T>,
@@ -302,20 +330,29 @@ export class ResultAsync<E, T> implements PromiseLike<
   map<U>(
     fn: (val: T) => U | Promise<U>,
   ): ResultAsync<E, U> {
-    return new ResultAsync(
-      this.#promise.then(async (res) =>
-        res.isOk ? ok(await fn(res.unwrap())) : res,
-      ),
+    return new ResultAsync<E, U>(
+      this.#promise.then((res) => {
+        if (res.isErr) return res;
+        // Only adopt a microtask when the transform is actually async.
+        const out = fn(res.unwrap());
+        return out instanceof Promise
+          ? out.then(ok)
+          : ok(out);
+      }),
     );
   }
 
   mapErr<U>(
     fn: (error: E) => U | Promise<U>,
   ): ResultAsync<U, T> {
-    return new ResultAsync(
-      this.#promise.then(async (res) =>
-        res.isErr ? err(await fn(res.unwrapErr())) : res,
-      ),
+    return new ResultAsync<U, T>(
+      this.#promise.then((res) => {
+        if (res.isOk) return res;
+        const out = fn(res.unwrapErr());
+        return out instanceof Promise
+          ? out.then(err)
+          : err(out);
+      }),
     );
   }
 

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -20,9 +20,16 @@ export type AnzenResultFn<E, T> = (
   ...args: any[]
 ) => AnzenAnyResult<E, T> | Promise<AnzenAnyResult<E, T>>;
 
+// Registry-global brand stamped on every Result. `Symbol.for` keeps it
+// stable across realms/bundles (and duplicated module copies), so
+// `isAnzenResult` works where `instanceof` can't — e.g. when two copies of
+// the package are loaded, their classes are no longer reference-equal.
+const anzenBrand = Symbol.for('@daisugi/anzen');
+
 export class ResultSuccess<T> {
   readonly isSuccess = true;
   readonly isFailure = false;
+  readonly [anzenBrand] = true;
   #value: T;
 
   constructor(value: T) {
@@ -78,6 +85,7 @@ export class ResultSuccess<T> {
 export class ResultFailure<E> {
   readonly isSuccess = false;
   readonly isFailure = true;
+  readonly [anzenBrand] = true;
   #error: E;
 
   constructor(err: E) {
@@ -147,6 +155,18 @@ export function success<T>(val: T): AnzenResultSuccess<T> {
 
 export function failure<E>(err: E): AnzenResultFailure<E> {
   return new ResultFailure(err);
+}
+
+// Brand-based type guard. Reliable across realms/bundles, unlike
+// `instanceof`, when more than one copy of the package is loaded.
+export function isAnzenResult(
+  value: unknown,
+): value is AnzenAnyResult<unknown, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<symbol, unknown>)[anzenBrand] === true
+  );
 }
 
 export async function promiseAll<

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -141,15 +141,11 @@ async function handleResult<E, T>(
     : Promise.reject(res.getError());
 }
 
-export function success<T>(
-  val: T,
-): AnzenResultSuccess<T> {
+export function success<T>(val: T): AnzenResultSuccess<T> {
   return new ResultSuccess(val);
 }
 
-export function failure<E>(
-  err: E,
-): AnzenResultFailure<E> {
+export function failure<E>(err: E): AnzenResultFailure<E> {
   return new ResultFailure(err);
 }
 
@@ -233,10 +229,7 @@ export function fromJSON<E = unknown, T = unknown>(
     : new ResultFailure<E>(obj.error);
 }
 
-export function fromSyncThrowable<
-  E = unknown,
-  T = unknown,
->(
+export function fromSyncThrowable<E = unknown, T = unknown>(
   fn: () => T,
   parseErr?: (err: unknown) => E,
 ): AnzenAnyResult<E, T> {
@@ -260,18 +253,3 @@ export async function fromThrowable<
     return failure(parseErr?.(err) ?? (err as E));
   }
 }
-
-// Back-compat aggregating namespace. Importing `Result` retains every
-// combinator (a single binding bundlers cannot split), so for per-function
-// tree-shaking import the named functions directly, e.g.
-// `import { success } from '@daisugi/anzen'`.
-export const Result = {
-  success,
-  failure,
-  promiseAll,
-  unwrapPromiseAll,
-  unwrap,
-  fromJSON,
-  fromSyncThrowable,
-  fromThrowable,
-};

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -3,12 +3,6 @@ export type AnzenResultErr<E> = ResultErr<E>;
 export type AnzenAnyResult<E, T> =
   | AnzenResultErr<E>
   | AnzenResultOk<T>;
-type ExtractErr<T extends readonly unknown[]> =
-  Awaited<T[number]> extends infer R
-    ? R extends AnzenResultErr<infer U>
-      ? U
-      : never
-    : never;
 type ExtractOk<T extends readonly unknown[]> = {
   [K in keyof T]: Awaited<T[K]> extends infer R
     ? R extends AnzenResultOk<infer U>
@@ -181,8 +175,7 @@ export async function promiseAll<
 >(
   whenRes: T,
 ): Promise<
-  | AnzenResultOk<ExtractOk<T>>
-  | AnzenResultErr<ExtractErr<T>>
+  AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>
 > {
   try {
     const vals = await Promise.all(
@@ -190,7 +183,9 @@ export async function promiseAll<
     );
     return ok(vals) as AnzenResultOk<ExtractOk<T>>;
   } catch (error) {
-    return err(error) as AnzenResultErr<ExtractErr<T>>;
+    // A wrapped Err rejects with its own error, but a raw promise can
+    // reject with anything, so the failure type is honestly `unknown`.
+    return err(error);
   }
 }
 
@@ -200,13 +195,13 @@ export async function unwrapPromiseAll<
     | Promise<AnzenAnyResult<unknown, unknown>>
   )[],
 >(
-  args: [Partial<ExtractOk<T>>, ...T],
+  // A full-length defaults tuple is required: on failure these are spread
+  // into the value positions, so a partial set would leave `undefined`
+  // holes that the return type claims are present values.
+  args: [ExtractOk<T>, ...T],
 ): Promise<
   [
-    (
-      | AnzenResultOk<ExtractOk<T>>
-      | AnzenResultErr<ExtractErr<T>>
-    ),
+    AnzenResultOk<ExtractOk<T>> | AnzenResultErr<unknown>,
     ...ExtractOk<T>,
   ]
 > {
@@ -221,7 +216,7 @@ export async function unwrapPromiseAll<
     ];
   } catch (error) {
     return [err(error), ...defaultsVals] as [
-      AnzenResultErr<ExtractErr<T>>,
+      AnzenResultErr<unknown>,
       ...ExtractOk<T>,
     ];
   }

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -257,6 +257,22 @@ export async function fromAsyncThrowable<
   }
 }
 
+// Lazy counterpart of `fromAsyncThrowable`: adapts an async function that
+// may throw or reject into a reusable Result-returning function (an
+// `AnzenResultFn`), preserving its parameters. Each call defers into the
+// thunk, so a synchronous throw on invocation is captured too.
+export function wrapAsyncThrowable<
+  A extends readonly unknown[],
+  T,
+  E = unknown,
+>(
+  fn: (...args: A) => Promise<T>,
+  parseErr?: (error: unknown) => E,
+): (...args: A) => Promise<AnzenResult<E, T>> {
+  return (...args) =>
+    fromAsyncThrowable(() => fn(...args), parseErr);
+}
+
 // A thenable that carries the Result combinators over an async boundary,
 // so I/O-heavy code can keep chaining instead of awaiting and re-wrapping
 // at every step. `await`-ing an ResultAsync yields the underlying Result.

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -328,11 +328,10 @@ export class ResultAsync<E, T> implements PromiseLike<
       | Promise<AnzenResult<F, U>>,
   ): ResultAsync<E | F, U> {
     return new ResultAsync<E | F, U>(
-      this.#promise.then((res) =>
-        res.isOk
-          ? fn(res.unwrap())
-          : (res as AnzenResultErr<E>),
-      ) as Promise<AnzenResult<E | F, U>>,
+      this.#promise.then((res) => {
+        if (res.isErr) return res;
+        return fn(res.unwrap());
+      }),
     );
   }
 
@@ -345,11 +344,10 @@ export class ResultAsync<E, T> implements PromiseLike<
       | Promise<AnzenResult<F, U>>,
   ): ResultAsync<F, T | U> {
     return new ResultAsync<F, T | U>(
-      this.#promise.then((res) =>
-        res.isErr
-          ? fn(res.unwrapErr())
-          : (res as AnzenResultOk<T>),
-      ) as Promise<AnzenResult<F, T | U>>,
+      this.#promise.then((res) => {
+        if (res.isOk) return res;
+        return fn(res.unwrapErr());
+      }),
     );
   }
 

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -271,3 +271,133 @@ export async function fromThrowable<
     return err(parseErr?.(error) ?? (error as E));
   }
 }
+
+// A thenable that carries the Result combinators over an async boundary,
+// so I/O-heavy code can keep chaining instead of awaiting and re-wrapping
+// at every step. `await`-ing an AsyncResult yields the underlying Result.
+export class AsyncResult<E, T> implements PromiseLike<
+  AnzenAnyResult<E, T>
+> {
+  #promise: Promise<AnzenAnyResult<E, T>>;
+
+  constructor(promise: Promise<AnzenAnyResult<E, T>>) {
+    this.#promise = promise;
+  }
+
+  // The thenable surface is intentional: it lets callers `await` an
+  // AsyncResult to get the underlying Result (the core ergonomic).
+  // eslint-disable-next-line unicorn/no-thenable
+  then<R1 = AnzenAnyResult<E, T>, R2 = never>(
+    onFulfilled?:
+      | ((
+          value: AnzenAnyResult<E, T>,
+        ) => R1 | PromiseLike<R1>)
+      | null,
+    onRejected?:
+      | ((reason: unknown) => R2 | PromiseLike<R2>)
+      | null,
+  ): Promise<R1 | R2> {
+    return this.#promise.then(onFulfilled, onRejected);
+  }
+
+  map<U>(
+    fn: (val: T) => U | Promise<U>,
+  ): AsyncResult<E, U> {
+    return new AsyncResult(
+      this.#promise.then(async (res) =>
+        res.isOk ? ok(await fn(res.unwrap())) : res,
+      ),
+    );
+  }
+
+  mapErr<U>(
+    fn: (error: E) => U | Promise<U>,
+  ): AsyncResult<U, T> {
+    return new AsyncResult(
+      this.#promise.then(async (res) =>
+        res.isErr ? err(await fn(res.unwrapErr())) : res,
+      ),
+    );
+  }
+
+  andThen<U, F>(
+    fn: (
+      val: T,
+    ) =>
+      | AnzenAnyResult<F, U>
+      | AsyncResult<F, U>
+      | Promise<AnzenAnyResult<F, U>>,
+  ): AsyncResult<E | F, U> {
+    return new AsyncResult<E | F, U>(
+      this.#promise.then((res) =>
+        res.isOk
+          ? fn(res.unwrap())
+          : (res as AnzenResultErr<E>),
+      ) as Promise<AnzenAnyResult<E | F, U>>,
+    );
+  }
+
+  orElse<U, F>(
+    fn: (
+      error: E,
+    ) =>
+      | AnzenAnyResult<F, U>
+      | AsyncResult<F, U>
+      | Promise<AnzenAnyResult<F, U>>,
+  ): AsyncResult<F, T | U> {
+    return new AsyncResult<F, T | U>(
+      this.#promise.then((res) =>
+        res.isErr
+          ? fn(res.unwrapErr())
+          : (res as AnzenResultOk<T>),
+      ) as Promise<AnzenAnyResult<F, T | U>>,
+    );
+  }
+
+  async unwrap(): Promise<T> {
+    return (await this.#promise).unwrap();
+  }
+
+  async unwrapErr(): Promise<E> {
+    return (await this.#promise).unwrapErr();
+  }
+
+  async unwrapOr<V>(defaultVal: V): Promise<T | V> {
+    return (await this.#promise).unwrapOr(defaultVal);
+  }
+}
+
+export function okAsync<T>(val: T): AsyncResult<never, T> {
+  return new AsyncResult(Promise.resolve(ok(val)));
+}
+
+export function errAsync<E>(
+  error: E,
+): AsyncResult<E, never> {
+  return new AsyncResult(Promise.resolve(err(error)));
+}
+
+// Lifts a Promise that may reject into an AsyncResult: a resolved value
+// becomes Ok, a rejection becomes Err. Without `parseErr` the error type
+// is `unknown` — pass `parseErr` to obtain a typed error (matching
+// neverthrow's `fromPromise(promise, errorFn)` contract).
+export function fromPromise<T, E = unknown>(
+  promise: Promise<T>,
+  parseErr?: (error: unknown) => E,
+): AsyncResult<E, T> {
+  return new AsyncResult(
+    promise.then(
+      (val) => ok<T>(val),
+      (error) =>
+        err<E>(parseErr ? parseErr(error) : (error as E)),
+    ),
+  );
+}
+
+// Lifts a Promise that is already known not to reject (it resolves to a
+// Result) into an AsyncResult.
+export function fromSafePromise<E, T>(
+  promise: Promise<AnzenAnyResult<E, T>>,
+): AsyncResult<E, T> {
+  return new AsyncResult(promise);
+}

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -3,6 +3,7 @@ export type AnzenResultErr<E> = ResultErr<E>;
 export type AnzenResult<E, T> =
   | AnzenResultErr<E>
   | AnzenResultOk<T>;
+export type AnzenResultAsync<E, T> = ResultAsync<E, T>;
 type ExtractOk<T extends readonly unknown[]> = {
   [K in keyof T]: Awaited<T[K]> extends infer R
     ? R extends AnzenResultOk<infer U>

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -146,7 +146,7 @@ export class ResultErr<E> {
     return new ResultOk(fn(this.#error));
   }
 
-  toTuple<V = undefined>(defaultVal?: V): [this, V] {
+  toTuple<V = never>(defaultVal?: V): [this, V] {
     return [this, defaultVal as V];
   }
 
@@ -253,7 +253,7 @@ export async function promiseAll<
   }
 }
 
-export async function unwrapPromiseAll<
+export async function promiseAllTuple<
   const T extends (
     | AnzenResult<unknown, unknown>
     | Promise<AnzenResult<unknown, unknown>>
@@ -294,11 +294,9 @@ export async function unwrapPromiseAll<
   }
 }
 
-export function toTuple<
-  T = never,
-  E = never,
-  D = undefined,
->(defaultVal?: D) {
+export function toTuple<T = never, E = never, D = never>(
+  defaultVal?: D,
+) {
   return (
     res: AnzenResult<E, T>,
   ): [AnzenResultErr<E>, D] | [AnzenResultOk<T>, T] =>

--- a/packages/anzen/src/anzen.ts
+++ b/packages/anzen/src/anzen.ts
@@ -15,9 +15,8 @@ export type AnzenResultFn<E, T> = (
 ) => AnzenResult<E, T> | Promise<AnzenResult<E, T>>;
 
 // Registry-global brand stamped on every Result. `Symbol.for` keeps it
-// stable across realms/bundles (and duplicated module copies), so
-// `isAnzenResult` works where `instanceof` can't — e.g. when two copies of
-// the package are loaded, their classes are no longer reference-equal.
+// stable across realms/bundles, so `isAnzenResult` works where `instanceof`
+// can't when duplicate package copies make classes non reference-equal.
 const anzenBrand = Symbol.for('@daisugi/anzen');
 
 export class ResultOk<T> {
@@ -25,11 +24,9 @@ export class ResultOk<T> {
   declare readonly isErr: false;
   #value: T;
 
-  // Constant discriminants and brand live on the prototype (set once
-  // here), so each allocation writes only #value. A static block keeps
-  // this part of the class definition — safe under `sideEffects: false`,
-  // unlike a top-level `prototype` assignment. Cast through Record: the
-  // discriminants are declared `readonly` and the brand is a symbol.
+  // Constant discriminants and brand live on the prototype, so each allocation
+  // writes only #value. A static block keeps this safe under `sideEffects: false`
+  // (unlike a top-level `prototype` assignment); the Record cast bypasses readonly.
   static {
     const proto = this.prototype as unknown as {
       isOk: boolean;
@@ -188,7 +185,7 @@ export async function promiseAll<
     const results = await Promise.all(whenRes);
     const vals: unknown[] = [];
     for (const res of results) {
-      if (res.isErr) return err(res.unwrapErr());
+      if (res.isErr) return res;
       vals.push(res.unwrap());
     }
     return ok(vals) as AnzenResultOk<ExtractOk<T>>;
@@ -221,7 +218,7 @@ export async function unwrapPromiseAll<
     const vals: unknown[] = [];
     for (const res of results) {
       if (res.isErr) {
-        return [err(res.unwrapErr()), ...defaultsVals] as [
+        return [res, ...defaultsVals] as [
           AnzenResultErr<unknown>,
           ...ExtractOk<T>,
         ];
@@ -285,10 +282,9 @@ export async function fromAsyncThrowable<
   }
 }
 
-// Lazy counterpart of `fromAsyncThrowable`: adapts an async function that
-// may throw or reject into a reusable Result-returning function (an
-// `AnzenResultFn`), preserving its parameters. Each call defers into the
-// thunk, so a synchronous throw on invocation is captured too.
+// Lazy counterpart of `fromAsyncThrowable`: adapts a throwing/rejecting async
+// function into a reusable Result-returning function, preserving its parameters.
+// Each call defers into the thunk, so a synchronous throw on invocation is caught.
 export function wrapAsyncThrowable<
   A extends readonly unknown[],
   T,
@@ -411,10 +407,9 @@ export function errAsync<E>(
   return new ResultAsync(Promise.resolve(err(error)));
 }
 
-// Lifts a Promise that may reject into an ResultAsync: a resolved value
-// becomes Ok, a rejection becomes Err. Without `parseErr` the error type
-// is `unknown` — pass `parseErr` to obtain a typed error (matching
-// neverthrow's `fromPromise(promise, errorFn)` contract).
+// Lifts a Promise that may reject into an ResultAsync: resolved becomes Ok,
+// rejection becomes Err. Without `parseErr` the error type is `unknown`; pass
+// it for a typed error (neverthrow's `fromPromise(promise, errorFn)` contract).
 export function fromPromise<T, E = unknown>(
   promise: Promise<T>,
   parseErr?: (error: unknown) => E,

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -17,9 +17,9 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 📦 Uses only trusted dependencies
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
-- 🤝 Used in production by millions of users
+- 🤝 Used in production
 - 🌳 Tree-shakeable
-- 🌐 Universal — runs in the browser and on the server (Node.js)
+- 🌐 Universal - runs in the browser and on the server (Node.js)
 - 🔀 Supports both ES Modules and CommonJS
 
 ---
@@ -167,20 +167,22 @@ console.log(err.meta);      // { userId: 42 }
 
 ### `errFnRes`
 
-Same as `errFn` but wraps the error in an [@daisugi/anzen](../anzen) `Result.failure`:
+Same as `errFn` but wraps the error in an [@daisugi/anzen](../anzen) failure `Result`:
 
 ```ts
 errFnRes.<Name>(message: string, opts?: AyamariOpts): AnzenResultFailure<AyamariErr>
 ```
 
 ```ts
+import { success } from '@daisugi/anzen';
+
 const { errFnRes } = new Ayamari();
 
 function findUser(id: number) {
   if (id < 0) {
     return errFnRes.InvalidArgument('id must be positive');
   }
-  return Result.success({ id, name: 'Alice' });
+  return success({ id, name: 'Alice' });
 }
 
 const result = findUser(-1);

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -17,8 +17,9 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 📦 Uses only trusted dependencies
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
-- 🤝 Used in production
+- 🤝 Used in production by millions of users
 - 🌳 Tree-shakeable
+- 🌐 Universal — runs in the browser and on the server (Node.js)
 - 🔀 Supports both ES Modules and CommonJS
 
 ---

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -188,7 +188,7 @@ function findUser(id: number) {
 const result = findUser(-1);
 
 if (result.isFailure) {
-  console.log(result.getError().code); // "InvalidArgument"
+  console.log(result.unwrapErr().code); // "InvalidArgument"
 }
 ```
 

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -170,11 +170,11 @@ console.log(err.meta);      // { userId: 42 }
 Same as `errFn` but wraps the error in an [@daisugi/anzen](../anzen) failure `Result`:
 
 ```ts
-errFnRes.<Name>(message: string, opts?: AyamariOpts): AnzenResultFailure<AyamariErr>
+errFnRes.<Name>(message: string, opts?: AyamariOpts): AnzenResultErr<AyamariErr>
 ```
 
 ```ts
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
 const { errFnRes } = new Ayamari();
 
@@ -182,12 +182,12 @@ function findUser(id: number) {
   if (id < 0) {
     return errFnRes.InvalidArgument('id must be positive');
   }
-  return success({ id, name: 'Alice' });
+  return ok({ id, name: 'Alice' });
 }
 
 const result = findUser(-1);
 
-if (result.isFailure) {
+if (result.isErr) {
   console.log(result.unwrapErr().code); // "InvalidArgument"
 }
 ```
@@ -248,7 +248,7 @@ Re-create an error of the same code as the cause, adding a new message and conte
 
 ```ts
 propagateErr(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AyamariErr
-propagateErrRes(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AnzenResultFailure<AyamariErr>
+propagateErrRes(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AnzenResultErr<AyamariErr>
 ```
 
 ```ts

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -27,18 +27,18 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 ## 🚀 Usage
 
 ```js
-import { Ayamari, prettifyStack } from '@daisugi/ayamari';
+import { Ayamari, formatStack } from '@daisugi/ayamari';
 
-const { errFn } = new Ayamari();
+const { errs } = new Ayamari();
 
 try {
   eval('{');
 } catch (err) {
-  const appErr = errFn.UnexpectedError('Something went wrong.', {
+  const appErr = errs.UnexpectedError('Something went wrong.', {
     cause: err,
   });
 
-  console.error(prettifyStack(appErr, { color: true }));
+  console.error(formatStack(appErr, { color: true }));
 }
 ```
 
@@ -54,12 +54,12 @@ try {
   - [🔍 Overview](#-overview)
   - [📚 API](#-api)
     - [`new Ayamari(opts?)`](#new-ayamariopts)
-    - [`errFn`](#errfn)
-    - [`errFnRes`](#errfnres)
+    - [`errs`](#errs)
+    - [`errsResult`](#errsresult)
     - [`errCode`](#errcode)
     - [`level`](#level)
-    - [`propagateErr` / `propagateErrRes`](#propagateerr--propagateerrres)
-    - [`prettifyStack`](#prettifystack)
+    - [`wrapErr` / `wrapErrResult`](#wrapErr--wrapErrResult)
+    - [`formatStack`](#formatstack)
     - [`isAyamariErr`](#isayamarierr)
     - [`findCauseByCode`](#findcausebycode)
     - [Custom error codes](#custom-error-codes)
@@ -121,12 +121,12 @@ const ayamari = new Ayamari({
 
 ---
 
-### `errFn`
+### `errs`
 
 A map of error-creator functions, one per error code. Each function has the signature:
 
 ```ts
-errFn.<Name>(message: string, opts?: AyamariOpts): AyamariErr
+errs.<Name>(message: string, opts?: AyamariErrOpts): AyamariErr
 ```
 
 | Option        | Type                  | Default          | Description                                                            |
@@ -151,9 +151,9 @@ Every created error is a lightweight object (`AyamariErr`) — its prototype is 
 > `stack` is a lazily derived accessor (`"<name>: <message>"`, built only when read) inherited from a shared prototype; enabling `injectStack` stores a real captured trace as an own property instead. Because the default form is inherited rather than an own property, it is not emitted by `JSON.stringify(err)` unless `injectStack` is set — read `err.stack` directly (loggers do).
 
 ```ts
-const { errFn } = new Ayamari();
+const { errs } = new Ayamari();
 
-const err = errFn.NotFound('User not found.', {
+const err = errs.NotFound('User not found.', {
   meta: { userId: 42 },
 });
 
@@ -165,22 +165,22 @@ console.log(err.meta);      // { userId: 42 }
 
 ---
 
-### `errFnRes`
+### `errsResult`
 
-Same as `errFn` but wraps the error in an [@daisugi/anzen](../anzen) failure `Result`:
+Same as `errs` but wraps the error in an [@daisugi/anzen](../anzen) failure `Result`:
 
 ```ts
-errFnRes.<Name>(message: string, opts?: AyamariOpts): AnzenResultErr<AyamariErr>
+errsResult.<Name>(message: string, opts?: AyamariErrOpts): AnzenResultErr<AyamariErr>
 ```
 
 ```ts
 import { ok } from '@daisugi/anzen';
 
-const { errFnRes } = new Ayamari();
+const { errsResult } = new Ayamari();
 
 function findUser(id: number) {
   if (id < 0) {
-    return errFnRes.InvalidArgument('id must be positive');
+    return errsResult.InvalidArgument('id must be positive');
   }
   return ok({ id, name: 'Alice' });
 }
@@ -231,35 +231,35 @@ Pino-style numeric severity levels. Higher means more severe, so monitoring can 
 Every error carries a `levelValue`, defaulting to `error` (50). Override per error with `opts.levelValue`:
 
 ```ts
-const { errFn } = new Ayamari();
+const { errs } = new Ayamari();
 
-errFn.NotFound('missing').levelValue;                          // 50 (error, the default)
-errFn.NotFound('missing', { levelValue: level.debug }) // 20 (overridden)
+errs.NotFound('missing').levelValue;                          // 50 (error, the default)
+errs.NotFound('missing', { levelValue: level.debug }) // 20 (overridden)
   .levelValue;
 ```
 
-`propagateErr` carries the cause's `levelValue` through to the wrapper.
+`wrapErr` carries the cause's `levelValue` through to the wrapper.
 
 ---
 
-### `propagateErr` / `propagateErrRes`
+### `wrapErr` / `wrapErrResult`
 
 Re-create an error of the same code as the cause, adding a new message and context. Useful for wrapping errors at layer boundaries without losing the original code.
 
 ```ts
-propagateErr(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AyamariErr
-propagateErrRes(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AnzenResultErr<AyamariErr>
+wrapErr(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AyamariErr
+wrapErrResult(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AnzenResultErr<AyamariErr>
 ```
 
 ```ts
-const { errFn, propagateErr } = new Ayamari();
+const { errs, wrapErr } = new Ayamari();
 
 function readConfig(path: string) {
   try {
     // ...
   } catch (err) {
-    const inner = errFn.UnexpectedError('Failed to read file.', { cause: err });
-    return propagateErr('Config loading failed.', { cause: inner });
+    const inner = errs.UnexpectedError('Failed to read file.', { cause: err });
+    return wrapErr('Config loading failed.', { cause: inner });
   }
 }
 ```
@@ -268,12 +268,12 @@ The propagated error has the same code as `cause` so callers can pattern-match o
 
 ---
 
-### `prettifyStack`
+### `formatStack`
 
 Standalone function that formats an error (and its cause chain) as a human-readable string. Import it only where you print errors; modules that just create errors won't bundle the prettifier.
 
 ```ts
-prettifyStack(
+formatStack(
   err: AyamariErr | Error,
   opts?: PrettyStackOpts,
 ): string
@@ -301,15 +301,15 @@ Features of the formatted output:
 - Causes are separated by a `└── caused by 🚨:` connector.
 
 ```ts
-const { errFn } = new Ayamari({ injectStack: true });
+const { errs } = new Ayamari({ injectStack: true });
 
 const cause = new Error('DB connection refused');
-const err = errFn.UnexpectedError('Request failed', {
+const err = errs.UnexpectedError('Request failed', {
   cause,
   meta: { url: '/api/users' },
 });
 
-console.error(prettifyStack(err, { color: true }));
+console.error(formatStack(err, { color: true }));
 ```
 
 Example output:
@@ -329,7 +329,7 @@ Example output:
 To filter frames by file path (e.g. keep only your own source):
 
 ```ts
-prettifyStack(err, {
+formatStack(err, {
   frameFilter: (frame) => frame.file.startsWith('/home/me/project/src'),
 });
 ```
@@ -378,7 +378,7 @@ It returns the matched error (use `!== null` for the boolean case, or read the m
 
 ### Custom error codes
 
-Pass a `customErrCode` map to extend the built-in set. The instance's `errFn`, `errFnRes`, and `errCode` are all updated automatically.
+Pass a `customErrCode` map to extend the built-in set. The instance's `errs`, `errsResult`, and `errCode` are all updated automatically.
 
 ```ts
 const customErrCode = {
@@ -386,12 +386,12 @@ const customErrCode = {
   RateLimitExceeded: 'RateLimitExceeded',
 } as const;
 
-const { errFn, errCode } = new Ayamari({ customErrCode });
+const { errs, errCode } = new Ayamari({ customErrCode });
 
-const err = errFn.PaymentDeclined('Card was declined.');
+const err = errs.PaymentDeclined('Card was declined.');
 console.log(err.code); // "PaymentDeclined"
 
-// TypeScript: errFn and errCode are fully typed with your custom codes.
+// TypeScript: errs and errCode are fully typed with your custom codes.
 ```
 
 [:top: Back to top](#-table-of-contents)

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -275,10 +275,10 @@ Standalone function that formats an error (and its cause chain) as a human-reada
 ```ts
 formatStack(
   err: AyamariErr | Error,
-  opts?: PrettyStackOpts,
+  opts?: FormatStackOpts,
 ): string
 
-interface PrettyStackOpts {
+interface FormatStackOpts {
   color?: boolean;           // default: false
   sensitiveKeys?: readonly string[];
   frameFilter?: FrameFilter;

--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -111,7 +111,7 @@ Creates an Ayamari instance.
 | Option          | Type      | Default | Description                                                                                            |
 | --------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | `injectStack`   | `boolean` | `false` | Capture a real V8 stack trace on each error (has a performance cost).                                  |
-| `customErrCode` | `object`  | —       | Additional error codes to merge with the built-in set (see [Custom error codes](#custom-error-codes)). |
+| `customErrCode` | `object`  | -       | Additional error codes to merge with the built-in set (see [Custom error codes](#custom-error-codes)). |
 
 ```ts
 const ayamari = new Ayamari({
@@ -131,12 +131,12 @@ errs.<Name>(message: string, opts?: AyamariErrOpts): AyamariErr
 
 | Option        | Type                  | Default          | Description                                                            |
 | ------------- | --------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `cause`       | `AyamariErr \| Error` | —                | The underlying error that caused this one.                             |
+| `cause`       | `AyamariErr \| Error` | -                | The underlying error that caused this one.                             |
 | `meta`        | `unknown`             | `null`           | Arbitrary extra data attached to the error (surfaced in pretty-print). |
 | `injectStack` | `boolean`             | instance default | Override stack injection per call.                                     |
 | `levelValue`  | `number`              | `error`          | Override the error's severity (see [`level`](#level)).                 |
 
-Every created error is a lightweight object (`AyamariErr`) — its prototype is `Error.prototype`, so `err instanceof Error` is `true`, but no native `Error` is constructed (no stack-capture cost unless `injectStack` is enabled). It has these fields:
+Every created error is a lightweight object (`AyamariErr`) - its prototype is `Error.prototype`, so `err instanceof Error` is `true`, but no native `Error` is constructed (no stack-capture cost unless `injectStack` is enabled). It has these fields:
 
 | Field        | Type                          | Description                                                               |
 | ------------ | ----------------------------- | ------------------------------------------------------------------------- |
@@ -144,11 +144,11 @@ Every created error is a lightweight object (`AyamariErr`) — its prototype is 
 | `message`    | `string`                      | The message you passed.                                                   |
 | `code`       | `string`                      | String error code (equal to the error name), e.g. `"Fail"`.               |
 | `levelValue` | `number`                      | Numeric severity (see [`level`](#level)); defaults to `error`.            |
-| `stack`      | `string`                      | `"<name>: <message>"` — or a real stack trace when `injectStack` is true. |
+| `stack`      | `string`                      | `"<name>: <message>"` - or a real stack trace when `injectStack` is true. |
 | `cause`      | `AyamariErr \| Error \| null` | Chained cause.                                                            |
 | `meta`       | `unknown`                     | Extra context data.                                                       |
 
-> `stack` is a lazily derived accessor (`"<name>: <message>"`, built only when read) inherited from a shared prototype; enabling `injectStack` stores a real captured trace as an own property instead. Because the default form is inherited rather than an own property, it is not emitted by `JSON.stringify(err)` unless `injectStack` is set — read `err.stack` directly (loggers do).
+> `stack` is a lazily derived accessor (`"<name>: <message>"`, built only when read) inherited from a shared prototype; enabling `injectStack` stores a real captured trace as an own property instead. Because the default form is inherited rather than an own property, it is not emitted by `JSON.stringify(err)` unless `injectStack` is set - read `err.stack` directly (loggers do).
 
 ```ts
 const { errs } = new Ayamari();
@@ -353,7 +353,7 @@ try {
 }
 ```
 
-It checks an internal brand (a registry-global `Symbol`), not the shape of the object — so it never mistakes a native error that happens to carry a `code` (e.g. Node's `ENOENT`) for an Ayamari one, and it works across bundles/realms where `instanceof` would not.
+It checks an internal brand (a registry-global `Symbol`), not the shape of the object - so it never mistakes a native error that happens to carry a `code` (e.g. Node's `ENOENT`) for an Ayamari one, and it works across bundles/realms where `instanceof` would not.
 
 ---
 
@@ -378,7 +378,7 @@ It returns the matched error (use `!== null` for the boolean case, or read the m
 
 ### Custom error codes
 
-Pass a `customErrCode` map to extend the built-in set. The instance's `errs`, `errsResult`, and `errCode` are all updated automatically.
+Pass a `customErrCode` map to extend the built-in set. The instance's `errs`, `errsResult`, and `codes` are all updated automatically.
 
 ```ts
 const customErrCode = {
@@ -386,12 +386,12 @@ const customErrCode = {
   RateLimitExceeded: 'RateLimitExceeded',
 } as const;
 
-const { errs, errCode } = new Ayamari({ customErrCode });
+const { errs, codes } = new Ayamari({ customErrCode });
 
 const err = errs.PaymentDeclined('Card was declined.');
 console.log(err.code); // "PaymentDeclined"
 
-// TypeScript: errs and errCode are fully typed with your custom codes.
+// TypeScript: errs and codes are fully typed with your custom codes.
 ```
 
 [:top: Back to top](#-table-of-contents)

--- a/packages/ayamari/src/__tests__/ayamari_test.ts
+++ b/packages/ayamari/src/__tests__/ayamari_test.ts
@@ -132,7 +132,7 @@ describe('Ayamari', () => {
       const cause = errFn.NotFound('missing');
       const res = propagateErrRes('wrapped', { cause });
       assert.equal(res.isSuccess, false);
-      assert.equal(res.getError().code, 'NotFound');
+      assert.equal(res.unwrapErr().code, 'NotFound');
     });
 
     it("should carry the cause's levelValue", () => {

--- a/packages/ayamari/src/__tests__/ayamari_test.ts
+++ b/packages/ayamari/src/__tests__/ayamari_test.ts
@@ -6,13 +6,13 @@ import {
   findCauseByCode,
   isAyamariErr,
   level,
-  prettifyStack,
+  formatStack,
 } from '../ayamari.js';
 
 describe('Ayamari', () => {
   it('should work', () => {
-    const { errFn } = new Ayamari();
-    const err = errFn.Fail('err');
+    const { errs } = new Ayamari();
+    const err = errs.Fail('err');
     assert.equal(err.code, 'Fail');
     assert.equal(err.name, 'Fail');
     assert.equal(err.message, 'err');
@@ -21,17 +21,17 @@ describe('Ayamari', () => {
   });
 
   it('should be an instance of Error', () => {
-    const { errFn } = new Ayamari();
-    const err = errFn.Fail('err');
+    const { errs } = new Ayamari();
+    const err = errs.Fail('err');
     assert.ok(err instanceof Error);
   });
 
   it('should work with global options', () => {
-    const { errFn } = new Ayamari({
+    const { errs } = new Ayamari({
       injectStack: true,
     });
     const nativeErr = new Error('native err');
-    const err = errFn.Fail('err', {
+    const err = errs.Fail('err', {
       cause: nativeErr,
     });
     assert.equal(err.code, 'Fail');
@@ -42,8 +42,8 @@ describe('Ayamari', () => {
   });
 
   it('should work with options', () => {
-    const { errFn } = new Ayamari();
-    const err = errFn.Fail('err', {
+    const { errs } = new Ayamari();
+    const err = errs.Fail('err', {
       injectStack: true,
     });
     assert.equal(err.code, 'Fail');
@@ -53,36 +53,36 @@ describe('Ayamari', () => {
     assert.equal(err.cause, null);
   });
 
-  it('should could customize errFn', () => {
+  it('should could customize errs', () => {
     const customErrCode = {
       FooErr: 'FooErr',
     };
-    const { errFn } = new Ayamari({
+    const { errs } = new Ayamari({
       customErrCode,
     });
-    assert.equal(errFn.FooErr('err').code, 'FooErr');
+    assert.equal(errs.FooErr('err').code, 'FooErr');
   });
 
   describe('levelValue', () => {
     it('should default to error for every code', () => {
-      const { errFn } = new Ayamari();
+      const { errs } = new Ayamari();
       assert.equal(
-        errFn.UnexpectedError('boom').levelValue,
+        errs.UnexpectedError('boom').levelValue,
         level.error,
       );
       assert.equal(
-        errFn.NotFound('missing').levelValue,
+        errs.NotFound('missing').levelValue,
         level.error,
       );
       assert.equal(
-        errFn.StopPropagation('halt').levelValue,
+        errs.StopPropagation('halt').levelValue,
         level.error,
       );
     });
 
     it('should let opts.levelValue override the default', () => {
-      const { errFn } = new Ayamari();
-      const err = errFn.NotFound('missing', {
+      const { errs } = new Ayamari();
+      const err = errs.NotFound('missing', {
         levelValue: level.debug,
       });
       assert.equal(err.levelValue, level.debug);
@@ -91,8 +91,8 @@ describe('Ayamari', () => {
 
   describe('isAyamariErr', () => {
     it('should be true for an Ayamari error', () => {
-      const { errFn } = new Ayamari();
-      assert.equal(isAyamariErr(errFn.Fail('boom')), true);
+      const { errs } = new Ayamari();
+      assert.equal(isAyamariErr(errs.Fail('boom')), true);
     });
 
     it('should be false for native errors and non-errors', () => {
@@ -107,11 +107,11 @@ describe('Ayamari', () => {
     });
   });
 
-  describe('propagateErr', () => {
+  describe('wrapErr', () => {
     it('should reuse the code of an AyamariErr cause', () => {
-      const { errFn, propagateErr } = new Ayamari();
-      const cause = errFn.NotFound('missing');
-      const err = propagateErr('wrapped', { cause });
+      const { errs, wrapErr } = new Ayamari();
+      const cause = errs.NotFound('missing');
+      const err = wrapErr('wrapped', { cause });
       assert.equal(err.code, 'NotFound');
       assert.equal(err.name, 'NotFound');
       assert.equal(err.message, 'wrapped');
@@ -119,105 +119,105 @@ describe('Ayamari', () => {
     });
 
     it('should fall back to UnexpectedError for a native Error cause', () => {
-      const { propagateErr } = new Ayamari();
+      const { wrapErr } = new Ayamari();
       const cause = new Error('native');
-      const err = propagateErr('wrapped', { cause });
+      const err = wrapErr('wrapped', { cause });
       assert.equal(err.code, 'UnexpectedError');
       assert.equal(err.name, 'UnexpectedError');
       assert.equal(err.cause, cause);
     });
 
-    it('propagateErrRes should wrap the error in a failure Result', () => {
-      const { errFn, propagateErrRes } = new Ayamari();
-      const cause = errFn.NotFound('missing');
-      const res = propagateErrRes('wrapped', { cause });
+    it('wrapErrResult should wrap the error in a failure Result', () => {
+      const { errs, wrapErrResult } = new Ayamari();
+      const cause = errs.NotFound('missing');
+      const res = wrapErrResult('wrapped', { cause });
       assert.equal(res.isOk, false);
       assert.equal(res.unwrapErr().code, 'NotFound');
     });
 
     it("should carry the cause's levelValue", () => {
-      const { errFn, propagateErr } = new Ayamari();
-      const cause = errFn.NotFound('missing', {
+      const { errs, wrapErr } = new Ayamari();
+      const cause = errs.NotFound('missing', {
         levelValue: level.fatal,
       });
-      const err = propagateErr('wrapped', { cause });
+      const err = wrapErr('wrapped', { cause });
       assert.equal(err.levelValue, level.fatal);
     });
   });
 
   describe('findCauseByCode', () => {
     it('should find a matching error deep in the cause chain', () => {
-      const { errFn } = new Ayamari();
-      const root = errFn.NotFound('missing');
-      const middle = errFn.Fail('mid', { cause: root });
-      const top = errFn.Timeout('top', { cause: middle });
+      const { errs } = new Ayamari();
+      const root = errs.NotFound('missing');
+      const middle = errs.Fail('mid', { cause: root });
+      const top = errs.Timeout('top', { cause: middle });
       assert.equal(findCauseByCode(top, 'NotFound'), root);
     });
 
     it('should match the error itself', () => {
-      const { errFn } = new Ayamari();
-      const err = errFn.NotFound('missing');
+      const { errs } = new Ayamari();
+      const err = errs.NotFound('missing');
       assert.equal(findCauseByCode(err, 'NotFound'), err);
     });
 
     it('should match a native error in the chain by its code', () => {
-      const { errFn } = new Ayamari();
+      const { errs } = new Ayamari();
       const native = Object.assign(new Error('fs'), {
         code: 'ENOENT',
       });
-      const err = errFn.Fail('wrapped', { cause: native });
+      const err = errs.Fail('wrapped', { cause: native });
       assert.equal(findCauseByCode(err, 'ENOENT'), native);
     });
 
     it('should return null when no cause matches', () => {
-      const { errFn } = new Ayamari();
-      const err = errFn.Fail('boom');
+      const { errs } = new Ayamari();
+      const err = errs.Fail('boom');
       assert.equal(findCauseByCode(err, 'NotFound'), null);
       assert.equal(findCauseByCode(null, 'NotFound'), null);
     });
 
     it('should not hang on a cyclic cause chain', () => {
-      const { errFn } = new Ayamari();
-      const a = errFn.Fail('a');
-      const b = errFn.Fail('b', { cause: a });
+      const { errs } = new Ayamari();
+      const a = errs.Fail('a');
+      const b = errs.Fail('b', { cause: a });
       a.cause = b;
       assert.equal(findCauseByCode(b, 'NotFound'), null);
     });
   });
 
   it('should print pretty stack', () => {
-    const { errFn } = new Ayamari({
+    const { errs } = new Ayamari({
       injectStack: true,
     });
     const nativeErr = new Error('native err');
-    const err = errFn.Fail('err', {
+    const err = errs.Fail('err', {
       cause: nativeErr,
     });
     assert.match(
-      prettifyStack(err, { color: false }),
+      formatStack(err, { color: false }),
       /Fail: err/u,
     );
   });
 
   describe('when injectStack is false', () => {
     it('should print pretty stack', () => {
-      const { errFn } = new Ayamari();
+      const { errs } = new Ayamari();
       const nativeErr = new Error('native err: example');
-      const err = errFn.Fail('err', {
+      const err = errs.Fail('err', {
         cause: nativeErr,
       });
       assert.match(
-        prettifyStack(err, { color: false }),
+        formatStack(err, { color: false }),
         /Fail: err/u,
       );
     });
 
     describe('when cause is null', () => {
       it('should print pretty stack', () => {
-        const { errFn } = new Ayamari();
-        const err = errFn.Fail('err');
+        const { errs } = new Ayamari();
+        const err = errs.Fail('err');
         assert.match(
-          prettifyStack(err, { color: false }),
+          formatStack(err, { color: false }),
           /Fail: err/u,
         );
       });

--- a/packages/ayamari/src/__tests__/ayamari_test.ts
+++ b/packages/ayamari/src/__tests__/ayamari_test.ts
@@ -131,7 +131,7 @@ describe('Ayamari', () => {
       const { errFn, propagateErrRes } = new Ayamari();
       const cause = errFn.NotFound('missing');
       const res = propagateErrRes('wrapped', { cause });
-      assert.equal(res.isSuccess, false);
+      assert.equal(res.isOk, false);
       assert.equal(res.unwrapErr().code, 'NotFound');
     });
 

--- a/packages/ayamari/src/__tests__/format_stack_test.ts
+++ b/packages/ayamari/src/__tests__/format_stack_test.ts
@@ -2,18 +2,18 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { Ayamari, type AyamariErr } from '../ayamari.js';
-import { PrettyStack } from '../pretty_stack.js';
+import { FormatStack } from '../format_stack.js';
 
 const { errs } = new Ayamari();
 
-describe('PrettyStack.print', () => {
+describe('FormatStack.print', () => {
   describe('given an AyamariErr without stack frames', () => {
     it('returns only the header line', () => {
       const error = errs.UnexpectedError(
         'something went wrong',
       );
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.equal(
         result,
@@ -30,7 +30,7 @@ describe('PrettyStack.print', () => {
         '    at userFn (/project/src/foo.ts:10:5)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /userFn/u);
     });
@@ -43,7 +43,7 @@ describe('PrettyStack.print', () => {
         '    at node:internal/process/task_queues:140:7',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.doesNotMatch(result, /node:internal/u);
     });
@@ -57,7 +57,7 @@ describe('PrettyStack.print', () => {
         '    at /project/src/anon.ts:3:1',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(
         result,
@@ -72,7 +72,7 @@ describe('PrettyStack.print', () => {
         '    at noCol (/project/src/x.ts:7)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(
         result,
@@ -89,7 +89,7 @@ describe('PrettyStack.print', () => {
         '    at Array.map (<anonymous>)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /callback/u);
       assert.match(
@@ -111,7 +111,7 @@ describe('PrettyStack.print', () => {
       }
       assert.ok(error);
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /<anonymous>/u);
     });
@@ -126,7 +126,7 @@ describe('PrettyStack.print', () => {
         '    at drop (/project/src/drop.ts:2:2)',
       ].join('\n');
 
-      const result = PrettyStack.print(error, {
+      const result = FormatStack.print(error, {
         color: false,
         frameFilter: (frame) =>
           !frame.file.includes('drop.ts'),
@@ -143,7 +143,7 @@ describe('PrettyStack.print', () => {
         '    at internal (node:internal/foo:1:1)',
       ].join('\n');
 
-      const result = PrettyStack.print(error, {
+      const result = FormatStack.print(error, {
         color: false,
         frameFilter: () => true,
       });
@@ -158,7 +158,7 @@ describe('PrettyStack.print', () => {
         '    at internal (node:internal/foo:1:1)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.doesNotMatch(result, /node:internal/u);
     });
@@ -171,7 +171,7 @@ describe('PrettyStack.print', () => {
         cause,
       });
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.ok(
         result.indexOf('query failed') <
@@ -190,7 +190,7 @@ describe('PrettyStack.print', () => {
         cause: middle,
       });
 
-      const result = PrettyStack.print(top);
+      const result = FormatStack.print(top);
 
       const topIdx = result.indexOf('service down');
       const middleIdx = result.indexOf('query failed');
@@ -214,7 +214,7 @@ describe('PrettyStack.print', () => {
       top.stack =
         'Timeout: service down\n    at topFn (/project/src/top.ts:20:8)';
 
-      const result = PrettyStack.print(top);
+      const result = FormatStack.print(top);
 
       assert.match(result, /topFn/u);
       assert.match(result, /middleFn/u);
@@ -243,7 +243,7 @@ describe('PrettyStack.print', () => {
         '    at topFn (/project/src/top.ts:20:8)',
       ].join('\n');
 
-      const result = PrettyStack.print(top);
+      const result = FormatStack.print(top);
 
       assert.equal(result.split('sharedFn').length - 1, 1);
     });
@@ -256,7 +256,7 @@ describe('PrettyStack.print', () => {
         cause,
       });
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /└── caused by/u);
       assert.match(
@@ -275,7 +275,7 @@ describe('PrettyStack.print', () => {
         cause: middle,
       });
 
-      const result = PrettyStack.print(top);
+      const result = FormatStack.print(top);
 
       const connectors =
         result.split('└── caused by').length - 1;
@@ -285,7 +285,7 @@ describe('PrettyStack.print', () => {
     it('renders a single error without any connector', () => {
       const error = errs.UnexpectedError('lonely');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.doesNotMatch(result, /caused by/u);
     });
@@ -296,7 +296,7 @@ describe('PrettyStack.print', () => {
         cause,
       });
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /UnexpectedError: wrapped/u);
       assert.match(result, /└── caused by/u);
@@ -319,7 +319,7 @@ describe('PrettyStack.print', () => {
         '    at otherFn (/project/src/other.ts:10:5)',
       ].join('\n');
 
-      const result = PrettyStack.print(top);
+      const result = FormatStack.print(top);
 
       const occurrences =
         result.split('sharedFn').length - 1;
@@ -333,7 +333,7 @@ describe('PrettyStack.print', () => {
       const error = errs.UnexpectedError('path test');
       error.stack = `UnexpectedError: path test\n    at myFn (${cwd}/src/foo.ts:10:5)`;
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.ok(!result.includes(cwd));
       assert.match(result, /~/u);
@@ -344,7 +344,7 @@ describe('PrettyStack.print', () => {
       const error = errs.UnexpectedError('path test');
       error.stack = `UnexpectedError: path test\n    at myFn (${cwd}/src/foo.ts:10:5) ${cwd}/other.ts`;
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.ok(!result.includes(cwd));
     });
@@ -364,7 +364,7 @@ describe('PrettyStack.print', () => {
         },
       );
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /native failure/u);
       assert.match(result, /nativeFn/u);
@@ -383,7 +383,7 @@ describe('PrettyStack.print', () => {
         '    at plainFn (/project/src/plain.ts:7:1)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /Error: plain failure/u);
       assert.match(result, /plainFn/u);
@@ -395,7 +395,7 @@ describe('PrettyStack.print', () => {
       };
       error.code = 'EPLAIN';
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /code: EPLAIN/u);
     });
@@ -416,7 +416,7 @@ describe('PrettyStack.print', () => {
         },
       );
 
-      const result = PrettyStack.print(wrapped);
+      const result = FormatStack.print(wrapped);
 
       assert.match(result, /code: ERR_INVALID_URL/u);
       assert.match(result, /input: not-a-url/u);
@@ -428,7 +428,7 @@ describe('PrettyStack.print', () => {
         cause: error,
       });
 
-      const result = PrettyStack.print(wrapped);
+      const result = FormatStack.print(wrapped);
 
       assert.doesNotMatch(result, /\bname:/u);
       assert.doesNotMatch(result, /\bstack:/u);
@@ -445,7 +445,7 @@ describe('PrettyStack.print', () => {
         cause: error,
       });
 
-      const result = PrettyStack.print(wrapped);
+      const result = FormatStack.print(wrapped);
 
       assert.doesNotMatch(result, /nullProp/u);
     });
@@ -462,7 +462,7 @@ describe('PrettyStack.print', () => {
         cause: error,
       });
 
-      const result = PrettyStack.print(wrapped);
+      const result = FormatStack.print(wrapped);
 
       assert.match(result, /context: \{.*url.*503.*\}/u);
     });
@@ -472,7 +472,7 @@ describe('PrettyStack.print', () => {
         meta: { userId: 42 },
       });
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /meta: \{.*userId.*42.*\}/u);
     });
@@ -490,7 +490,7 @@ describe('PrettyStack.print', () => {
         cause,
       });
 
-      const result = PrettyStack.print(wrapped);
+      const result = FormatStack.print(wrapped);
 
       assert.match(result, /circularProp:/u);
       assert.match(result, /\[Circular\]/u);
@@ -513,7 +513,7 @@ describe('PrettyStack.print', () => {
         },
       );
 
-      const result = PrettyStack.print(wrapped);
+      const result = FormatStack.print(wrapped);
 
       assert.match(result, /details:/u);
       assert.match(result, /\[Circular\]/u);
@@ -540,7 +540,7 @@ describe('PrettyStack.print', () => {
         },
       );
 
-      const result = PrettyStack.print(wrapped, {
+      const result = FormatStack.print(wrapped, {
         color: false,
         sensitiveKeys: ['config', 'request', 'response'],
       });
@@ -576,7 +576,7 @@ describe('PrettyStack.print', () => {
         },
       );
 
-      const result = PrettyStack.print(wrapped, {
+      const result = FormatStack.print(wrapped, {
         color: false,
         sensitiveKeys: ['config', 'request', 'response'],
       });
@@ -602,7 +602,7 @@ describe('PrettyStack.print', () => {
         cause,
       });
 
-      const result = PrettyStack.print(wrapped, {
+      const result = FormatStack.print(wrapped, {
         color: false,
         sensitiveKeys: ['config', 'request', 'response'],
       });
@@ -625,7 +625,7 @@ describe('PrettyStack.print', () => {
         '    at renderRoot (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom-server.js:6000:5)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(
         result,
@@ -643,7 +643,7 @@ describe('PrettyStack.print', () => {
         '    at fn2 (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom.js:20:3)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /\[fastify@5\.0\.0\]/u);
       assert.match(result, /\[react-dom@19\.2\.3\]/u);
@@ -658,7 +658,7 @@ describe('PrettyStack.print', () => {
         '    at anotherUserFn (/project/src/component.ts:20:3)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /userFn/u);
       assert.match(result, /anotherUserFn/u);
@@ -682,7 +682,7 @@ describe('PrettyStack.print', () => {
         '    at renderElement (/project/node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/cjs/react-dom-server.js:5497:23)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(
         result,
@@ -697,7 +697,7 @@ describe('PrettyStack.print', () => {
         '    at fn1 (/project/node_modules/fastify/lib/server.js:10:5)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /\[fastify\]/u);
     });
@@ -709,7 +709,7 @@ describe('PrettyStack.print', () => {
         '    at fn1 (/project/node_modules/.pnpm/@fastify+static@8.0.0/node_modules/@fastify/static/index.js:10:5)',
       ].join('\n');
 
-      const result = PrettyStack.print(error);
+      const result = FormatStack.print(error);
 
       assert.match(result, /\[@fastify\/static@8\.0\.0\]/u);
     });

--- a/packages/ayamari/src/__tests__/pretty_stack_test.ts
+++ b/packages/ayamari/src/__tests__/pretty_stack_test.ts
@@ -4,12 +4,12 @@ import { describe, it } from 'node:test';
 import { Ayamari, type AyamariErr } from '../ayamari.js';
 import { PrettyStack } from '../pretty_stack.js';
 
-const { errFn } = new Ayamari();
+const { errs } = new Ayamari();
 
 describe('PrettyStack.print', () => {
   describe('given an AyamariErr without stack frames', () => {
     it('returns only the header line', () => {
-      const error = errFn.UnexpectedError(
+      const error = errs.UnexpectedError(
         'something went wrong',
       );
 
@@ -24,7 +24,7 @@ describe('PrettyStack.print', () => {
 
   describe('given an error without cause', () => {
     it('includes user frames', () => {
-      const error = errFn.UnexpectedError('top level');
+      const error = errs.UnexpectedError('top level');
       error.stack = [
         'UnexpectedError: top level',
         '    at userFn (/project/src/foo.ts:10:5)',
@@ -36,7 +36,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('omits native node: frames', () => {
-      const error = errFn.UnexpectedError('top level');
+      const error = errs.UnexpectedError('top level');
       error.stack = [
         'UnexpectedError: top level',
         '    at userFn (/project/src/foo.ts:10:5)',
@@ -51,7 +51,7 @@ describe('PrettyStack.print', () => {
 
   describe('given frames to reformat', () => {
     it('labels anonymous frames as <unknown>', () => {
-      const error = errFn.UnexpectedError('top level');
+      const error = errs.UnexpectedError('top level');
       error.stack = [
         'UnexpectedError: top level',
         '    at /project/src/anon.ts:3:1',
@@ -66,7 +66,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('renders frames that have no column', () => {
-      const error = errFn.UnexpectedError('top level');
+      const error = errs.UnexpectedError('top level');
       error.stack = [
         'UnexpectedError: top level',
         '    at noCol (/project/src/x.ts:7)',
@@ -82,7 +82,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('displays builtin frames with an <anonymous> location', () => {
-      const error = errFn.UnexpectedError('boom');
+      const error = errs.UnexpectedError('boom');
       error.stack = [
         'UnexpectedError: boom',
         '    at callback (/project/src/foo.ts:10:5)',
@@ -102,7 +102,7 @@ describe('PrettyStack.print', () => {
       let error: AyamariErr | undefined;
       try {
         [1].map(() => {
-          throw errFn.UnexpectedError('inside map', {
+          throw errs.UnexpectedError('inside map', {
             injectStack: true,
           });
         });
@@ -119,7 +119,7 @@ describe('PrettyStack.print', () => {
 
   describe('given a custom frameFilter', () => {
     it('drops frames the filter rejects', () => {
-      const error = errFn.UnexpectedError('boom');
+      const error = errs.UnexpectedError('boom');
       error.stack = [
         'UnexpectedError: boom',
         '    at keep (/project/src/keep.ts:1:1)',
@@ -137,7 +137,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('can retain node: frames the default would drop', () => {
-      const error = errFn.UnexpectedError('boom');
+      const error = errs.UnexpectedError('boom');
       error.stack = [
         'UnexpectedError: boom',
         '    at internal (node:internal/foo:1:1)',
@@ -152,7 +152,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('drops node: frames by default', () => {
-      const error = errFn.UnexpectedError('boom');
+      const error = errs.UnexpectedError('boom');
       error.stack = [
         'UnexpectedError: boom',
         '    at internal (node:internal/foo:1:1)',
@@ -166,8 +166,8 @@ describe('PrettyStack.print', () => {
 
   describe('given an error with one cause', () => {
     it('puts the top-level error before the cause', () => {
-      const cause = errFn.NotFound('record missing');
-      const error = errFn.UnexpectedError('query failed', {
+      const cause = errs.NotFound('record missing');
+      const error = errs.UnexpectedError('query failed', {
         cause,
       });
 
@@ -182,11 +182,11 @@ describe('PrettyStack.print', () => {
 
   describe('given an error with a deep chain', () => {
     it('outputs all errors in top-level-first order', () => {
-      const root = errFn.NotFound('not found');
-      const middle = errFn.UnexpectedError('query failed', {
+      const root = errs.NotFound('not found');
+      const middle = errs.UnexpectedError('query failed', {
         cause: root,
       });
-      const top = errFn.Timeout('service down', {
+      const top = errs.Timeout('service down', {
         cause: middle,
       });
 
@@ -200,15 +200,15 @@ describe('PrettyStack.print', () => {
     });
 
     it('includes unique frames from all levels', () => {
-      const root = errFn.NotFound('not found');
+      const root = errs.NotFound('not found');
       root.stack =
         'NotFound: not found\n    at rootFn (/project/src/root.ts:5:3)';
-      const middle = errFn.UnexpectedError('query failed', {
+      const middle = errs.UnexpectedError('query failed', {
         cause: root,
       });
       middle.stack =
         'UnexpectedError: query failed\n    at middleFn (/project/src/middle.ts:10:5)';
-      const top = errFn.Timeout('service down', {
+      const top = errs.Timeout('service down', {
         cause: middle,
       });
       top.stack =
@@ -224,9 +224,9 @@ describe('PrettyStack.print', () => {
     it('deduplicates a frame shared across 3 levels', () => {
       const sharedFrame =
         '    at sharedFn (/project/src/shared.ts:5:3)';
-      const root = errFn.NotFound('root');
+      const root = errs.NotFound('root');
       root.stack = `NotFound: root\n${sharedFrame}`;
-      const middle = errFn.UnexpectedError('middle', {
+      const middle = errs.UnexpectedError('middle', {
         cause: root,
       });
       middle.stack = [
@@ -234,7 +234,7 @@ describe('PrettyStack.print', () => {
         sharedFrame,
         '    at middleFn (/project/src/middle.ts:10:5)',
       ].join('\n');
-      const top = errFn.Timeout('top', {
+      const top = errs.Timeout('top', {
         cause: middle,
       });
       top.stack = [
@@ -251,8 +251,8 @@ describe('PrettyStack.print', () => {
 
   describe('given nested errors (cause chain)', () => {
     it('joins each level with a "caused by" connector', () => {
-      const cause = errFn.NotFound('record missing');
-      const error = errFn.UnexpectedError('query failed', {
+      const cause = errs.NotFound('record missing');
+      const error = errs.UnexpectedError('query failed', {
         cause,
       });
 
@@ -267,11 +267,11 @@ describe('PrettyStack.print', () => {
     });
 
     it('emits one connector per nesting level', () => {
-      const root = errFn.NotFound('not found');
-      const middle = errFn.UnexpectedError('query failed', {
+      const root = errs.NotFound('not found');
+      const middle = errs.UnexpectedError('query failed', {
         cause: root,
       });
-      const top = errFn.Timeout('service down', {
+      const top = errs.Timeout('service down', {
         cause: middle,
       });
 
@@ -283,7 +283,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('renders a single error without any connector', () => {
-      const error = errFn.UnexpectedError('lonely');
+      const error = errs.UnexpectedError('lonely');
 
       const result = PrettyStack.print(error);
 
@@ -292,7 +292,7 @@ describe('PrettyStack.print', () => {
 
     it('nests a native Error cause under an AyamariErr', () => {
       const cause = new Error('native boom');
-      const error = errFn.UnexpectedError('wrapped', {
+      const error = errs.UnexpectedError('wrapped', {
         cause,
       });
 
@@ -308,9 +308,9 @@ describe('PrettyStack.print', () => {
     it('includes each duplicate frame only once', () => {
       const sharedFrame =
         '    at sharedFn (/project/src/shared.ts:5:3)';
-      const root = errFn.NotFound('root error');
+      const root = errs.NotFound('root error');
       root.stack = `NotFound: root error\n${sharedFrame}`;
-      const top = errFn.UnexpectedError('top error', {
+      const top = errs.UnexpectedError('top error', {
         cause: root,
       });
       top.stack = [
@@ -330,7 +330,7 @@ describe('PrettyStack.print', () => {
   describe('given frames with absolute paths', () => {
     it('replaces process.cwd() with ~', () => {
       const cwd = process.cwd();
-      const error = errFn.UnexpectedError('path test');
+      const error = errs.UnexpectedError('path test');
       error.stack = `UnexpectedError: path test\n    at myFn (${cwd}/src/foo.ts:10:5)`;
 
       const result = PrettyStack.print(error);
@@ -341,7 +341,7 @@ describe('PrettyStack.print', () => {
 
     it('replaces all occurrences of cwd in a single frame', () => {
       const cwd = process.cwd();
-      const error = errFn.UnexpectedError('path test');
+      const error = errs.UnexpectedError('path test');
       error.stack = `UnexpectedError: path test\n    at myFn (${cwd}/src/foo.ts:10:5) ${cwd}/other.ts`;
 
       const result = PrettyStack.print(error);
@@ -357,7 +357,7 @@ describe('PrettyStack.print', () => {
         'Error: native failure',
         '    at nativeFn (/project/src/native.ts:20:3)',
       ].join('\n');
-      const error = errFn.UnexpectedError(
+      const error = errs.UnexpectedError(
         'wrapping native',
         {
           cause: nativeErr,
@@ -409,7 +409,7 @@ describe('PrettyStack.print', () => {
       };
       error.code = 'ERR_INVALID_URL';
       error.input = 'not-a-url';
-      const wrapped = errFn.UnexpectedError(
+      const wrapped = errs.UnexpectedError(
         'request failed',
         {
           cause: error,
@@ -424,7 +424,7 @@ describe('PrettyStack.print', () => {
 
     it('does not print standard Error properties as extras', () => {
       const error = new Error('oops');
-      const wrapped = errFn.UnexpectedError('failed', {
+      const wrapped = errs.UnexpectedError('failed', {
         cause: error,
       });
 
@@ -441,7 +441,7 @@ describe('PrettyStack.print', () => {
         nullProp: null;
       };
       error.nullProp = null;
-      const wrapped = errFn.UnexpectedError('failed', {
+      const wrapped = errs.UnexpectedError('failed', {
         cause: error,
       });
 
@@ -458,7 +458,7 @@ describe('PrettyStack.print', () => {
         url: 'https://example.com',
         status: 503,
       };
-      const wrapped = errFn.UnexpectedError('failed', {
+      const wrapped = errs.UnexpectedError('failed', {
         cause: error,
       });
 
@@ -468,7 +468,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('prints extra props from AyamariErr meta field', () => {
-      const error = errFn.NotFound('user not found', {
+      const error = errs.NotFound('user not found', {
         meta: { userId: 42 },
       });
 
@@ -486,7 +486,7 @@ describe('PrettyStack.print', () => {
         circularProp: unknown;
       };
       cause.circularProp = circular;
-      const wrapped = errFn.UnexpectedError('failed', {
+      const wrapped = errs.UnexpectedError('failed', {
         cause,
       });
 
@@ -506,7 +506,7 @@ describe('PrettyStack.print', () => {
         details: unknown;
       };
       cause.details = a;
-      const wrapped = errFn.UnexpectedError(
+      const wrapped = errs.UnexpectedError(
         'sso check failed',
         {
           cause,
@@ -533,7 +533,7 @@ describe('PrettyStack.print', () => {
         headers: { Cookie: 'auth_token=secret-jwt' },
         data: { password: 'shh' },
       };
-      const wrapped = errFn.UnexpectedError(
+      const wrapped = errs.UnexpectedError(
         'sso check failed',
         {
           cause,
@@ -569,7 +569,7 @@ describe('PrettyStack.print', () => {
         headers: { 'set-cookie': 'auth_token=leak' },
         data: 'Unauthorized',
       };
-      const wrapped = errFn.UnexpectedError(
+      const wrapped = errs.UnexpectedError(
         'sso check failed',
         {
           cause,
@@ -598,7 +598,7 @@ describe('PrettyStack.print', () => {
       };
       cause.code = 'ERR_BAD_REQUEST';
       cause.status = 401;
-      const wrapped = errFn.UnexpectedError('failed', {
+      const wrapped = errs.UnexpectedError('failed', {
         cause,
       });
 
@@ -616,7 +616,7 @@ describe('PrettyStack.print', () => {
 
   describe('given node_modules frames', () => {
     it('collapses consecutive frames from the same package into a summary', () => {
-      const error = errFn.UnexpectedError('render error');
+      const error = errs.UnexpectedError('render error');
       error.stack = [
         'UnexpectedError: render error',
         '    at userFn (/project/src/foo.ts:10:5)',
@@ -636,7 +636,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('produces a separate summary for each different package', () => {
-      const error = errFn.UnexpectedError('error');
+      const error = errs.UnexpectedError('error');
       error.stack = [
         'UnexpectedError: error',
         '    at fn1 (/project/node_modules/.pnpm/fastify@5.0.0/node_modules/fastify/lib/server.js:10:5)',
@@ -650,7 +650,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('keeps user frames between node_modules summaries', () => {
-      const error = errFn.UnexpectedError('error');
+      const error = errs.UnexpectedError('error');
       error.stack = [
         'UnexpectedError: error',
         '    at userFn (/project/src/handler.ts:10:5)',
@@ -674,7 +674,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('collapses node_modules frames at the end of the stack', () => {
-      const error = errFn.UnexpectedError('error');
+      const error = errs.UnexpectedError('error');
       error.stack = [
         'UnexpectedError: error',
         '    at userFn (/project/src/handler.ts:10:5)',
@@ -691,7 +691,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('handles npm (non-pnpm) node_modules paths', () => {
-      const error = errFn.UnexpectedError('error');
+      const error = errs.UnexpectedError('error');
       error.stack = [
         'UnexpectedError: error',
         '    at fn1 (/project/node_modules/fastify/lib/server.js:10:5)',
@@ -703,7 +703,7 @@ describe('PrettyStack.print', () => {
     });
 
     it('handles scoped packages in pnpm paths', () => {
-      const error = errFn.UnexpectedError('error');
+      const error = errs.UnexpectedError('error');
       error.stack = [
         'UnexpectedError: error',
         '    at fn1 (/project/node_modules/.pnpm/@fastify+static@8.0.0/node_modules/@fastify/static/index.js:10:5)',

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -5,7 +5,7 @@ import {
 
 import {
   PrettyStack,
-  type PrettyStackOpts,
+  type FormatStackOpts,
 } from './pretty_stack.js';
 
 // Re-exported so the stack prettifier's option types are reachable from the
@@ -15,7 +15,7 @@ export {
   defaultFrameFilter,
   type FrameFilter,
   type ParsedFrame,
-  type PrettyStackOpts,
+  type FormatStackOpts,
 } from './pretty_stack.js';
 
 type ValueOf<T> = T[keyof T];
@@ -109,7 +109,7 @@ export type AyamariErrCodeKey<CustomErrCode> =
 
 export function formatStack(
   err: AyamariErr | Error,
-  opts: PrettyStackOpts = {},
+  opts: FormatStackOpts = {},
 ): string {
   return PrettyStack.print(err, opts);
 }

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -1,6 +1,6 @@
 import {
   type AnzenResultFailure,
-  Result,
+  failure,
 } from '@daisugi/anzen';
 
 import {
@@ -201,7 +201,7 @@ export class Ayamari<CustomErrCode> {
 
   createErrResCreator(createErr: AyamariCreateErr) {
     return (msg: string, opts: AyamariOpts = {}) => {
-      return Result.failure(createErr(msg, opts));
+      return failure(createErr(msg, opts));
     };
   }
 
@@ -256,6 +256,6 @@ export class Ayamari<CustomErrCode> {
     msg: string,
     opts: AyamariOpts & { cause: AyamariErr | Error },
   ) => {
-    return Result.failure(this.propagateErr(msg, opts));
+    return failure(this.propagateErr(msg, opts));
   };
 }

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -1,6 +1,6 @@
 import {
-  type AnzenResultFailure,
-  failure,
+  type AnzenResultErr,
+  err as errRes,
 } from '@daisugi/anzen';
 
 import {
@@ -106,7 +106,7 @@ export type AyamariCreateErr = (
 export type AyamariCreateErrRes = (
   msg: string,
   opts?: AyamariOpts,
-) => AnzenResultFailure<AyamariErr>;
+) => AnzenResultErr<AyamariErr>;
 
 export type AyamariErrCodeKey<CustomErrCode> =
   | keyof CustomErrCode
@@ -201,7 +201,7 @@ export class Ayamari<CustomErrCode> {
 
   createErrResCreator(createErr: AyamariCreateErr) {
     return (msg: string, opts: AyamariOpts = {}) => {
-      return failure(createErr(msg, opts));
+      return errRes(createErr(msg, opts));
     };
   }
 
@@ -256,6 +256,6 @@ export class Ayamari<CustomErrCode> {
     msg: string,
     opts: AyamariOpts & { cause: AyamariErr | Error },
   ) => {
-    return failure(this.propagateErr(msg, opts));
+    return errRes(this.propagateErr(msg, opts));
   };
 }

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -8,10 +8,9 @@ import {
   type PrettyStackOpts,
 } from './pretty_stack.js';
 
-// Re-exported so the stack prettifier's option types are reachable from
-// the package root. These are type-only (plus the tiny `defaultFrameFilter`
-// const); none of them retain `PrettyStack`, so error-only consumers still
-// tree-shake `pretty_stack.js` away.
+// Re-exported so the stack prettifier's option types are reachable from the
+// package root. All type-only (plus the tiny `defaultFrameFilter` const) and none
+// retain `PrettyStack`, so error-only consumers still tree-shake `pretty_stack.js`.
 export {
   defaultFrameFilter,
   type FrameFilter,
@@ -22,11 +21,9 @@ export {
 type ValueOf<T> = T[keyof T];
 type Entries<T> = [keyof T, ValueOf<T>][];
 
-// Registry-global brand stamped on every AyamariErr. `Symbol.for` keeps
-// it stable across realms/bundles (and duplicated module copies), so
-// `isAyamariErr` works where `instanceof` can't — AyamariErr is a
-// plain branded object, not a class instance. The same key is recomputed
-// in pretty_stack.ts; keep the two in sync.
+// Registry-global brand stamped on every AyamariErr. `Symbol.for` keeps it
+// stable across realms/bundles, so `isAyamariErr` works where `instanceof` can't
+// (it's a plain branded object). Key recomputed in pretty_stack.ts; keep in sync.
 const ayamariBrand = Symbol.for('@daisugi/ayamari');
 
 // Pino-style numeric severity levels. Higher = more severe, so
@@ -76,10 +73,8 @@ export interface AyamariErr extends Error {
 }
 
 // Shared prototype for every AyamariErr. Inheriting the brand and a lazily
-// derived `stack` from here (instead of stamping both onto each error) keeps
-// instances smaller and skips building `stack` until it is actually read.
-// `injectStack` installs an own `stack` via captureStackTrace that shadows
-// the getter; the setter lets callers assign `err.stack` directly too.
+// derived `stack` keeps instances small and defers building `stack` until read.
+// `injectStack` installs an own `stack` (via captureStackTrace) shadowing the getter.
 const ayamariErrProto = Object.create(Error.prototype, {
   [ayamariBrand]: { value: true },
   stack: {
@@ -132,10 +127,9 @@ export function isAyamariErr(
   );
 }
 
-// Walk the cause chain (the error itself first) and return the first
-// error whose `code` matches, or null. Lets a boundary branch on a
-// failure mode no matter how deeply it was wrapped. Reads `code`
-// generically, so native errors carrying one (e.g. `ENOENT`) match too.
+// Walk the cause chain (the error itself first) and return the first error whose
+// `code` matches, or null, so a boundary can branch on a failure mode however
+// deeply wrapped. Reads `code` generically, so native errors (e.g. `ENOENT`) match.
 export function findCauseByCode(
   err: AyamariErr | Error | null | undefined,
   code: string,

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -50,12 +50,12 @@ export const errCode = {
   ValidationFailed: 'ValidationFailed',
 };
 
-export interface AyamariGlobalOpts<CustomErrCode> {
+export interface AyamariOpts<CustomErrCode> {
   injectStack?: boolean;
   customErrCode?: CustomErrCode;
 }
 
-export interface AyamariOpts {
+export interface AyamariErrOpts {
   cause?: AyamariErr | Error;
   meta?: unknown;
   injectStack?: boolean;
@@ -93,21 +93,21 @@ const ayamariErrProto = Object.create(Error.prototype, {
   },
 }) as object;
 
-export type AyamariCreateErr = (
+export type AyamariErrCreator = (
   msg: string,
-  opts?: AyamariOpts,
+  opts?: AyamariErrOpts,
 ) => AyamariErr;
 
-export type AyamariCreateErrRes = (
+export type AyamariErrResultCreator = (
   msg: string,
-  opts?: AyamariOpts,
+  opts?: AyamariErrOpts,
 ) => AnzenResultErr<AyamariErr>;
 
 export type AyamariErrCodeKey<CustomErrCode> =
   | keyof CustomErrCode
   | keyof typeof errCode;
 
-export function prettifyStack(
+export function formatStack(
   err: AyamariErr | Error,
   opts: PrettyStackOpts = {},
 ): string {
@@ -154,14 +154,14 @@ export function findCauseByCode(
 export class Ayamari<CustomErrCode> {
   // Defaults to the module-level `errCode`; `customErrCode` is merged in
   // by the constructor.
-  errCode = errCode;
-  errFn = {} as Record<
+  codes = errCode;
+  errs = {} as Record<
     AyamariErrCodeKey<CustomErrCode>,
-    AyamariCreateErr
+    AyamariErrCreator
   >;
-  errFnRes = {} as Record<
+  errsResult = {} as Record<
     AyamariErrCodeKey<CustomErrCode>,
-    AyamariCreateErrRes
+    AyamariErrResultCreator
   >;
   #errName = new Map<
     string,
@@ -169,32 +169,32 @@ export class Ayamari<CustomErrCode> {
   >();
   #injectStack: boolean;
 
-  constructor(opts: AyamariGlobalOpts<CustomErrCode> = {}) {
+  constructor(opts: AyamariOpts<CustomErrCode> = {}) {
     this.#injectStack = opts.injectStack ?? false;
     if (opts.customErrCode) {
-      this.errCode = {
-        ...this.errCode,
+      this.codes = {
+        ...this.codes,
         ...opts.customErrCode,
       };
     }
     for (const [errName, code] of Object.entries(
-      this.errCode,
+      this.codes,
     ) as Entries<
       Record<AyamariErrCodeKey<CustomErrCode>, string>
     >) {
-      this.errFn[errName] = this.createErrCreator(
+      this.errs[errName] = this.createErrCreator(
         errName,
         code,
       );
-      this.errFnRes[errName] = this.createErrResCreator(
-        this.errFn[errName],
+      this.errsResult[errName] = this.createErrResCreator(
+        this.errs[errName],
       );
       this.#errName.set(code, errName);
     }
   }
 
-  createErrResCreator(createErr: AyamariCreateErr) {
-    return (msg: string, opts: AyamariOpts = {}) => {
+  createErrResCreator(createErr: AyamariErrCreator) {
+    return (msg: string, opts: AyamariErrOpts = {}) => {
       return errRes(createErr(msg, opts));
     };
   }
@@ -207,7 +207,7 @@ export class Ayamari<CustomErrCode> {
     const errorLevel = level.error;
     const createErr = (
       msg: string,
-      opts: AyamariOpts = {},
+      opts: AyamariErrOpts = {},
     ) => {
       const err = {
         __proto__: ayamariErrProto,
@@ -227,10 +227,10 @@ export class Ayamari<CustomErrCode> {
   }
 
   // Arrow fields so they stay bound to `this` when destructured
-  // (e.g. `const { propagateErr } = new Ayamari()`).
-  propagateErr = (
+  // (e.g. `const { wrapErr } = new Ayamari()`).
+  wrapErr = (
     msg: string,
-    opts: AyamariOpts & { cause: AyamariErr | Error },
+    opts: AyamariErrOpts & { cause: AyamariErr | Error },
   ) => {
     // Reuse the cause's code when it is a recognized Ayamari error.
     // A native Error (or an unknown code) has no registered name, so
@@ -240,16 +240,16 @@ export class Ayamari<CustomErrCode> {
       this.#errName.get(cause.code) ?? 'UnexpectedError';
     // Carry the cause's severity through so the wrapper matches it
     // (a native Error has none, so fall back to the code's default).
-    return this.errFn[errName](msg, {
+    return this.errs[errName](msg, {
       ...opts,
       levelValue: opts.levelValue ?? cause.levelValue,
     });
   };
 
-  propagateErrRes = (
+  wrapErrResult = (
     msg: string,
-    opts: AyamariOpts & { cause: AyamariErr | Error },
+    opts: AyamariErrOpts & { cause: AyamariErr | Error },
   ) => {
-    return errRes(this.propagateErr(msg, opts));
+    return errRes(this.wrapErr(msg, opts));
   };
 }

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -4,26 +4,26 @@ import {
 } from '@daisugi/anzen';
 
 import {
-  PrettyStack,
+  FormatStack,
   type FormatStackOpts,
-} from './pretty_stack.js';
+} from './format_stack.js';
 
 // Re-exported so the stack prettifier's option types are reachable from the
 // package root. All type-only (plus the tiny `defaultFrameFilter` const) and none
-// retain `PrettyStack`, so error-only consumers still tree-shake `pretty_stack.js`.
+// retain `FormatStack`, so error-only consumers still tree-shake `format_stack.js`.
 export {
   defaultFrameFilter,
   type FrameFilter,
   type ParsedFrame,
   type FormatStackOpts,
-} from './pretty_stack.js';
+} from './format_stack.js';
 
 type ValueOf<T> = T[keyof T];
 type Entries<T> = [keyof T, ValueOf<T>][];
 
 // Registry-global brand stamped on every AyamariErr. `Symbol.for` keeps it
 // stable across realms/bundles, so `isAyamariErr` works where `instanceof` can't
-// (it's a plain branded object). Key recomputed in pretty_stack.ts; keep in sync.
+// (it's a plain branded object). Key recomputed in format_stack.ts; keep in sync.
 const ayamariBrand = Symbol.for('@daisugi/ayamari');
 
 // Pino-style numeric severity levels. Higher = more severe, so
@@ -111,7 +111,7 @@ export function formatStack(
   err: AyamariErr | Error,
   opts: FormatStackOpts = {},
 ): string {
-  return PrettyStack.print(err, opts);
+  return FormatStack.print(err, opts);
 }
 
 // Brand-based type guard. Reliable across realms/bundles, unlike

--- a/packages/ayamari/src/format_stack.ts
+++ b/packages/ayamari/src/format_stack.ts
@@ -282,7 +282,7 @@ function formatHeader(line: string, c: Palette): string {
   return `${c.red}${name}${c.reset}${c.gray}:${c.reset} ${message}`;
 }
 
-export class PrettyStack {
+export class FormatStack {
   static print(
     error: AyamariErr | Error,
     opts: FormatStackOpts = {},

--- a/packages/ayamari/src/format_stack.ts
+++ b/packages/ayamari/src/format_stack.ts
@@ -119,7 +119,7 @@ function extractPackageFromPath(
 ): string | null {
   const pnpmMatch = pnpmPkgRe.exec(path);
   if (pnpmMatch?.[1]) {
-    // pnpm encodes @scope/pkg as @scope+pkg — restore the slash
+    // pnpm encodes @scope/pkg as @scope+pkg - restore the slash
     const normalized = pnpmMatch[1].replace(
       /^(@[^+]+)\+/u,
       '$1/',

--- a/packages/ayamari/src/pretty_stack.ts
+++ b/packages/ayamari/src/pretty_stack.ts
@@ -15,7 +15,7 @@ export interface ParsedFrame {
 /** Predicate deciding whether a parsed frame is kept in the output. */
 export type FrameFilter = (frame: ParsedFrame) => boolean;
 
-export interface PrettyStackOpts {
+export interface FormatStackOpts {
   color?: boolean;
   sensitiveKeys?: readonly string[];
   frameFilter?: FrameFilter;
@@ -285,7 +285,7 @@ function formatHeader(line: string, c: Palette): string {
 export class PrettyStack {
   static print(
     error: AyamariErr | Error,
-    opts: PrettyStackOpts = {},
+    opts: FormatStackOpts = {},
   ): string {
     const color = opts.color ?? false;
     const sensitiveKeys = opts.sensitiveKeys ?? [];

--- a/packages/ayamari/src/pretty_stack.ts
+++ b/packages/ayamari/src/pretty_stack.ts
@@ -111,12 +111,8 @@ function parseFrame(line: string): ParsedFrame | null {
 
 /**
  * Extracts a human-readable package identifier from a node_modules path.
- * - pnpm:  /node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom/...
- *          → "react-dom@19.2.3"
- * - pnpm scoped: /node_modules/.pnpm/@fastify+static@8.0.0/node_modules/@fastify/static/...
- *          → "@fastify/static@8.0.0"
- * - npm:   /node_modules/fastify/...
- *          → "fastify"
+ * Handles pnpm (`.pnpm/react-dom@19.2.3.../` -> "react-dom@19.2.3"), pnpm scoped
+ * (`.pnpm/@fastify+static@8.0.0/...` -> "@fastify/static@8.0.0"), and npm -> "fastify".
  */
 function extractPackageFromPath(
   path: string,
@@ -152,10 +148,9 @@ function safeStringify(value: unknown): string {
           if (typeof val !== 'object' || val === null) {
             return val;
           }
-          // Trim ancestors back to the current parent so siblings start fresh.
-          // `this` is the parent object JSON.stringify is currently serializing.
-          // Note: JSON.stringify can re-emit a property when toJSON returns
-          // another object, so an exact-equality lookup is safest here.
+          // Trim ancestors back to the current parent (`this`) so siblings start
+          // fresh. JSON.stringify can re-emit a property when toJSON returns another
+          // object, so an exact-equality lookup is safest here.
           while (
             ancestors.length > 0 &&
             ancestors.at(-1) !== this

--- a/packages/daisugi/README.md
+++ b/packages/daisugi/README.md
@@ -246,7 +246,7 @@ function addLastName(arg) {
 }
 
 const response = sequenceOf([addName, addLastName])('Hi');
-// response.getError().value === 'Hi John'
+// response.unwrapErr().value === 'Hi John'
 ```
 
 [:top: Back to top](#-table-of-contents)

--- a/packages/daisugi/src/__tests__/daisugi_test.ts
+++ b/packages/daisugi/src/__tests__/daisugi_test.ts
@@ -104,7 +104,7 @@ describe('sequenceOf ', () => {
         ])(0);
 
         assert.strictEqual(
-          result.getError().meta.value,
+          result.unwrapErr().meta.value,
           '012',
         );
       });

--- a/packages/daisugi/src/daisugi.ts
+++ b/packages/daisugi/src/daisugi.ts
@@ -11,7 +11,7 @@ export type {
   DaisugiToolkit,
 } from './types.js';
 
-const { errFn, errCode } = new Ayamari();
+const { errs, codes } = new Ayamari();
 
 // Duck type validation.
 function isFnAsync(handler: DaisugiHandler) {
@@ -59,12 +59,11 @@ function decorateHandler(
     // Duck type condition, maybe use instanceof and result class here.
     if (args[0]?.isErr) {
       const firstArg = args[0];
-      if (firstArg.unwrapErr().code === errCode.Fail) {
+      if (firstArg.unwrapErr().code === codes.Fail) {
         return firstArg;
       }
       if (
-        firstArg.unwrapErr().code ===
-        errCode.StopPropagation
+        firstArg.unwrapErr().code === codes.StopPropagation
       ) {
         return firstArg.unwrapErr().meta.value;
       }
@@ -129,7 +128,7 @@ export class Daisugi {
 
   static stopPropagationWith(value: any) {
     return err(
-      errFn.StopPropagation('Daisugi stop propagation.', {
+      errs.StopPropagation('Daisugi stop propagation.', {
         meta: { value },
       }),
     );
@@ -137,7 +136,7 @@ export class Daisugi {
 
   static failWith(value: any) {
     return err(
-      errFn.Fail('Daisugi fail.', {
+      errs.Fail('Daisugi fail.', {
         meta: { value },
       }),
     );

--- a/packages/daisugi/src/daisugi.ts
+++ b/packages/daisugi/src/daisugi.ts
@@ -1,4 +1,4 @@
-import { failure } from '@daisugi/anzen';
+import { err } from '@daisugi/anzen';
 import { Ayamari } from '@daisugi/ayamari';
 
 import type {
@@ -57,7 +57,7 @@ function decorateHandler(
   // Maybe use of arguments instead.
   function handler(...args: any[]) {
     // Duck type condition, maybe use instanceof and result class here.
-    if (args[0]?.isFailure) {
+    if (args[0]?.isErr) {
       const firstArg = args[0];
       if (firstArg.unwrapErr().code === errCode.Fail) {
         return firstArg;
@@ -128,7 +128,7 @@ export class Daisugi {
   }
 
   static stopPropagationWith(value: any) {
-    return failure(
+    return err(
       errFn.StopPropagation('Daisugi stop propagation.', {
         meta: { value },
       }),
@@ -136,7 +136,7 @@ export class Daisugi {
   }
 
   static failWith(value: any) {
-    return failure(
+    return err(
       errFn.Fail('Daisugi fail.', {
         meta: { value },
       }),

--- a/packages/daisugi/src/daisugi.ts
+++ b/packages/daisugi/src/daisugi.ts
@@ -1,4 +1,4 @@
-import { Result } from '@daisugi/anzen';
+import { failure } from '@daisugi/anzen';
 import { Ayamari } from '@daisugi/ayamari';
 
 import type {
@@ -127,7 +127,7 @@ export class Daisugi {
   }
 
   static stopPropagationWith(value: any) {
-    return Result.failure(
+    return failure(
       errFn.StopPropagation('Daisugi stop propagation.', {
         meta: { value },
       }),
@@ -135,7 +135,7 @@ export class Daisugi {
   }
 
   static failWith(value: any) {
-    return Result.failure(
+    return failure(
       errFn.Fail('Daisugi fail.', {
         meta: { value },
       }),

--- a/packages/daisugi/src/daisugi.ts
+++ b/packages/daisugi/src/daisugi.ts
@@ -59,13 +59,14 @@ function decorateHandler(
     // Duck type condition, maybe use instanceof and result class here.
     if (args[0]?.isFailure) {
       const firstArg = args[0];
-      if (firstArg.getError().code === errCode.Fail) {
+      if (firstArg.unwrapErr().code === errCode.Fail) {
         return firstArg;
       }
       if (
-        firstArg.getError().code === errCode.StopPropagation
+        firstArg.unwrapErr().code ===
+        errCode.StopPropagation
       ) {
-        return firstArg.getError().meta.value;
+        return firstArg.unwrapErr().meta.value;
       }
     }
     if (injectToolkit) {

--- a/packages/daisugi/src/types.ts
+++ b/packages/daisugi/src/types.ts
@@ -1,10 +1,10 @@
-import type { AnzenResultFailure } from '@daisugi/anzen';
+import type { AnzenResultErr } from '@daisugi/anzen';
 import type { AyamariErr } from '@daisugi/ayamari';
 
 export interface DaisugiToolkit {
   next: any;
   nextWith(...args: any): any;
-  failWith(arg: any): AnzenResultFailure<AyamariErr>;
+  failWith(arg: any): AnzenResultErr<AyamariErr>;
   [key: string]: any;
 }
 

--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -101,7 +101,7 @@ pnpm install @daisugi/kado
 
 Kado has no required runtime dependencies. To get richer errors (with
 codes, causes and prettified stacks), optionally install
-[@daisugi/ayamari](../ayamari) and inject its `errFn`:
+[@daisugi/ayamari](../ayamari) and inject its `errs`:
 
 ```sh
 pnpm install @daisugi/ayamari
@@ -111,13 +111,13 @@ pnpm install @daisugi/ayamari
 import { Kado } from '@daisugi/kado';
 import { Ayamari } from '@daisugi/ayamari';
 
-const { errFn } = new Ayamari();
-const { container } = new Kado({ errFn });
+const { errs } = new Ayamari();
+const { container } = new Kado({ errs });
 ```
 
-When no `errFn` is provided, Kado throws native `Error`s that mirror
+When no `errs` is provided, Kado throws native `Error`s that mirror
 Ayamari's contract (e.g. `name: 'NotFound'`, `code: 'NotFound'`). The
-`code` is not required by the factory contract, so a custom `errFn` may
+`code` is not required by the factory contract, so a custom `errs` may
 return plain `Error`s without one; Kado accepts either.
 
 [:top: Back to top](#-table-of-contents)
@@ -128,7 +128,7 @@ return plain `Error`s without one; Kado accepts either.
 
 **Kado** wires your application together by resolving dependencies from a declarative manifest, so construction logic stays out of your business code. It provides:
 
-- ✅ Multiple isolated containers — no global state
+- ✅ Multiple isolated containers - no global state
 - ✅ Child containers with fall-through resolution to ancestors
 - ✅ Async resolution (`resolve` returns a `Promise`)
 - ✅ `Singleton` (cached), `Transient` (per-resolve), and `ContainerScoped` (per-container) scopes
@@ -169,7 +169,7 @@ const { container } = new Kado();
 
 ### `container.register(manifestItems)`
 
-Registers one or more dependencies in the container. Registration only records the manifest — nothing is instantiated until you `resolve`.
+Registers one or more dependencies in the container. Registration only records the manifest - nothing is instantiated until you `resolve`.
 
 ```ts
 container.register(manifestItems: KadoManifestItem[]): void
@@ -179,7 +179,7 @@ container.register(manifestItems: KadoManifestItem[]): void
 | --------------- | -------------------- | --------------------------------------------------------------------- |
 | `manifestItems` | `KadoManifestItem[]` | The dependencies to register (see [Manifest items](#manifest-items)). |
 
-Each entry is a [manifest item](#manifest-items). The `token` is optional; when omitted, Kado generates a unique one for you. Registering is idempotent per token — registering the same token again overwrites the previous entry.
+Each entry is a [manifest item](#manifest-items). The `token` is optional; when omitted, Kado generates a unique one for you. Registering is idempotent per token - registering the same token again overwrites the previous entry.
 
 ```js
 container.register([
@@ -227,8 +227,8 @@ container.createChildContainer(): KadoContainer
 
 Returns a new `KadoContainer` whose `#parent` is the current container.
 
-- Inherited `Singleton` and `useValue` registrations are shared across the whole chain — resolved once, cached on the owning ancestor.
-- Inherited `ContainerScoped` registrations are isolated per child — each container that resolves the token builds and caches its own instance.
+- Inherited `Singleton` and `useValue` registrations are shared across the whole chain - resolved once, cached on the owning ancestor.
+- Inherited `ContainerScoped` registrations are isolated per child - each container that resolves the token builds and caches its own instance.
 - A token registered on the child shadows the same token on an ancestor for that child only.
 - Circular-dependency detection walks the ancestor chain, so cross-level `params` are validated too.
 
@@ -394,7 +394,7 @@ container.register([
 
 Defines the lifecycle of a dependency.
 
-- **`Singleton`** (default) — reuses the same instance across resolves, shared by the whole container chain.
+- **`Singleton`** (default) - reuses the same instance across resolves, shared by the whole container chain.
 - **`Transient`** - creates a new instance on each resolve.
 - **`ContainerScoped`** - caches one instance per container. Behaves like `Singleton` within a container and like `Transient` across sibling containers. See [`container.createChildContainer()`](#containercreatechildcontainer).
 
@@ -408,7 +408,7 @@ container.register([
 
 ### `meta`
 
-Stores arbitrary metadata on a manifest item. Kado never reads it — it's there for your own tooling (telemetry, grouping, conditional wiring, etc.).
+Stores arbitrary metadata on a manifest item. Kado never reads it - it's there for your own tooling (telemetry, grouping, conditional wiring, etc.).
 
 ```js
 container.register([{ token: 'Foo', useClass: Foo, meta: { isFoo: true } }]);
@@ -557,7 +557,7 @@ Kado aims to provide a simple yet effective IoC solution with minimal overhead.
 
 ## 🌸 Etymology
 
-*Kado* (華道) is the Japanese art of flower arrangement, emphasizing form, lines, and balance—similar to how Kado structures dependencies.
+*Kado* (華道) is the Japanese art of flower arrangement, emphasizing form, lines, and balance-similar to how Kado structures dependencies.
 
 [:top: Back to top](#-table-of-contents)
 

--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -17,7 +17,9 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 📦 Zero required dependencies
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
-- 🤝 Used in production
+- 🤝 Used in production by millions of users
+- 🌳 Tree-shakeable
+- 🌐 Universal — runs in the browser and on the server (Node.js)
 - 🔀 Supports both ES Modules and CommonJS
 
 ---

--- a/packages/kado/README.md
+++ b/packages/kado/README.md
@@ -17,9 +17,9 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 📦 Zero required dependencies
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
-- 🤝 Used in production by millions of users
+- 🤝 Used in production
 - 🌳 Tree-shakeable
-- 🌐 Universal — runs in the browser and on the server (Node.js)
+- 🌐 Universal - runs in the browser and on the server (Node.js)
 - 🔀 Supports both ES Modules and CommonJS
 
 ---
@@ -73,10 +73,10 @@ const foo = await container.resolve('Foo');
     - [`params`](#params)
     - [`scope`](#scope)
     - [`meta`](#meta)
-    - [`Kado.scope`](#kadoscope)
-    - [`Kado.value`](#kadovalue)
-    - [`Kado.map`](#kadomap)
-    - [`Kado.flatMap`](#kadoflatmap)
+    - [`scope`](#scope-1)
+    - [`value(value)`](#valuevalue)
+    - [`map(params)`](#mapparams)
+    - [`flatMap(params)`](#flatmapparams)
   - [🔷 TypeScript Support](#-typescript-support)
   - [🎯 Goal](#-goal)
   - [🌸 Etymology](#-etymology)
@@ -161,7 +161,7 @@ Kado was created to address limitations found in other IoC libraries. If these r
 
 ## 📚 API
 
-A `Kado` instance exposes a `container` plus a set of static helpers:
+A `Kado` instance exposes a `container`. Manifests are assembled with the standalone `scope`, `value`, `map`, and `flatMap` helpers (each a named export, so unused ones are tree-shaken away):
 
 ```ts
 const { container } = new Kado();
@@ -233,6 +233,8 @@ Returns a new `KadoContainer` whose `#parent` is the current container.
 - Circular-dependency detection walks the ancestor chain, so cross-level `params` are validated too.
 
 ```js
+import { Kado, scope } from '@daisugi/kado';
+
 // App-wide singletons live on the root.
 const { container: root } = new Kado();
 root.register([
@@ -250,7 +252,7 @@ function handleRequest(req) {
       useClass: UserRepo,
       // `DbPool` falls through to the root automatically.
       params: ['DbPool', 'RequestContext'],
-      scope: Kado.scope.ContainerScoped,
+      scope: scope.ContainerScoped,
     },
   ]);
   return scoped.resolve('UserRepo');
@@ -416,28 +418,30 @@ container.get('Foo').meta; // { isFoo: true }
 
 ---
 
-### `Kado.scope`
+### `scope`
 
-A static map of the available scope names, handy for avoiding string literals.
+A map of the available scope names, handy for avoiding string literals.
 
 ```ts
-Kado.scope: Record<KadoScope, KadoScope>
+scope: Record<KadoScope, KadoScope>
 ```
 
 ```js
+import { scope } from '@daisugi/kado';
+
 container.register([
-  { token: 'Foo', useClass: Foo, scope: Kado.scope.Transient },
+  { token: 'Foo', useClass: Foo, scope: scope.Transient },
 ]);
 ```
 
 ---
 
-### `Kado.value`
+### `value(value)`
 
 Helper that builds a `useValue` manifest item, for inlining a constant inside `params`.
 
 ```ts
-Kado.value(value: unknown): KadoManifestItem
+value(value: unknown): KadoManifestItem
 ```
 
 | Parameter | Type      | Description                                    |
@@ -445,19 +449,21 @@ Kado.value(value: unknown): KadoManifestItem
 | `value`   | `unknown` | The constant value to wrap as a manifest item. |
 
 ```js
+import { value } from '@daisugi/kado';
+
 container.register([
-  { token: 'Foo', useClass: Foo, params: [Kado.value('text')] },
+  { token: 'Foo', useClass: Foo, params: [value('text')] },
 ]);
 ```
 
 ---
 
-### `Kado.map`
+### `map(params)`
 
 Helper that resolves a list of `params` into an array, ready to inject.
 
 ```ts
-Kado.map(params: KadoParam[]): KadoManifestItem
+map(params: KadoParam[]): KadoManifestItem
 ```
 
 | Parameter | Type          | Description                                        |
@@ -465,9 +471,11 @@ Kado.map(params: KadoParam[]): KadoManifestItem
 | `params`  | `KadoParam[]` | Dependencies resolved and collected into an array. |
 
 ```js
+import { map } from '@daisugi/kado';
+
 container.register([
   { token: 'bar', useValue: 'text' },
-  { token: 'Foo', useClass: Foo, params: [Kado.map(['bar'])] },
+  { token: 'Foo', useClass: Foo, params: [map(['bar'])] },
 ]);
 
 // Foo receives ['text'].
@@ -475,12 +483,12 @@ container.register([
 
 ---
 
-### `Kado.flatMap`
+### `flatMap(params)`
 
-Like [`Kado.map`](#kadomap), but flattens the resolved array one level.
+Like [`map`](#mapparams), but flattens the resolved array one level.
 
 ```ts
-Kado.flatMap(params: KadoParam[]): KadoManifestItem
+flatMap(params: KadoParam[]): KadoManifestItem
 ```
 
 | Parameter | Type          | Description                                                    |
@@ -488,9 +496,11 @@ Kado.flatMap(params: KadoParam[]): KadoManifestItem
 | `params`  | `KadoParam[]` | Dependencies resolved into an array, then flattened one level. |
 
 ```js
+import { flatMap } from '@daisugi/kado';
+
 container.register([
   { token: 'bar', useValue: ['text'] },
-  { token: 'Foo', useClass: Foo, params: [Kado.flatMap(['bar'])] },
+  { token: 'Foo', useClass: Foo, params: [flatMap(['bar'])] },
 ]);
 
 // Foo receives ['text'], not [['text']].
@@ -519,7 +529,7 @@ class Foo {}
 
 const myContainer: KadoContainer = container;
 const token: KadoToken = 'Foo';
-const scope: KadoScope = Kado.scope.Transient;
+const scope: KadoScope = 'Transient';
 const manifestItems: KadoManifestItem[] = [
   {
     token,

--- a/packages/kado/src/__tests__/kado_child_container_test.ts
+++ b/packages/kado/src/__tests__/kado_child_container_test.ts
@@ -285,7 +285,7 @@ describe('circular dependency across containers', () => {
     }
 
     // The cycle p ➡️ q 🔄 p lives entirely in the parent (a
-    // parent token cannot reference a child token — that would be
+    // parent token cannot reference a child token - that would be
     // a NotFound, never a cycle).
     root.register([
       { token: 'p', useClass: P, params: ['q'] },
@@ -438,7 +438,7 @@ describe('list() across the chain', () => {
     ]);
 
     // `createChildContainer` copies the ContainerScoped item into
-    // the child, so it lives in both maps — `list()` must dedupe.
+    // the child, so it lives in both maps - `list()` must dedupe.
     const child = root.createChildContainer();
 
     const svcItems = child

--- a/packages/kado/src/__tests__/kado_child_container_test.ts
+++ b/packages/kado/src/__tests__/kado_child_container_test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { Kado } from '../kado.js';
+import { Kado, scope } from '../kado.js';
 
 // Kado throws native `Error`s; an injected factory may enrich them with
 // a `code` (e.g. `@daisugi/ayamari`), so it is optional here.
@@ -71,7 +71,7 @@ describe('child container', () => {
         token: 'UserRepo',
         useClass: UserRepo,
         params: ['DbPool'],
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 
@@ -88,7 +88,7 @@ describe('ContainerScoped scope', () => {
       {
         token: 'Svc',
         useClass: Svc,
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 
@@ -107,7 +107,7 @@ describe('ContainerScoped scope', () => {
       {
         token: 'Svc',
         useClass: Svc,
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 
@@ -127,7 +127,7 @@ describe('ContainerScoped scope', () => {
       {
         token: 'Svc',
         useClass: Svc,
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 
@@ -146,7 +146,7 @@ describe('ContainerScoped scope', () => {
       {
         token: 'Logger',
         useClass: Logger,
-        scope: Kado.scope.Singleton,
+        scope: scope.Singleton,
       },
     ]);
 
@@ -199,7 +199,7 @@ describe('nested scopes (app → request → transaction)', () => {
         token: 'UserRepo',
         useClass: UserRepo,
         params: ['DbPool', 'RequestContext'],
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 
@@ -211,13 +211,13 @@ describe('nested scopes (app → request → transaction)', () => {
         token: 'OrderRepo',
         useClass: OrderRepo,
         params: ['Transaction', 'DbPool'],
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
       {
         token: 'OrderService',
         useClass: OrderService,
         params: ['OrderRepo', 'UserRepo'],
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 
@@ -251,7 +251,7 @@ describe('nested scopes (app → request → transaction)', () => {
           token: 'UserRepo',
           useClass: UserRepo,
           params: ['DbPool'],
-          scope: Kado.scope.ContainerScoped,
+          scope: scope.ContainerScoped,
         },
       ]);
       return request;
@@ -300,7 +300,7 @@ describe('circular dependency across containers', () => {
         token: 'Controller',
         useClass: Controller,
         params: ['p'],
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 
@@ -332,13 +332,13 @@ describe('circular dependency across containers', () => {
         token: 'Repo',
         useClass: Repo,
         params: ['Pool'],
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
       {
         token: 'Service',
         useClass: Service,
         params: ['Repo'],
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 
@@ -433,7 +433,7 @@ describe('list() across the chain', () => {
       {
         token: 'Svc',
         useClass: Svc,
-        scope: Kado.scope.ContainerScoped,
+        scope: scope.ContainerScoped,
       },
     ]);
 

--- a/packages/kado/src/__tests__/kado_params_test.ts
+++ b/packages/kado/src/__tests__/kado_params_test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { Kado } from '../kado.js';
+import { flatMap, Kado, map, value } from '../kado.js';
 
 describe('params', () => {
   it('should resolve properly manifest item', async () => {
@@ -31,7 +31,7 @@ describe('params', () => {
     assert.equal(a.c, 'bar');
   });
 
-  it('should resolve properly Kado.value', async () => {
+  it('should resolve properly value', async () => {
     const { container } = new Kado();
     class A {
       constructor(public b: string) {}
@@ -40,14 +40,14 @@ describe('params', () => {
       {
         token: 'A',
         useClass: A,
-        params: [Kado.value('foo')],
+        params: [value('foo')],
       },
     ]);
     const a = await container.resolve<A>('A');
     assert.equal(a.b, 'foo');
   });
 
-  it('should resolve properly Kado.map', async () => {
+  it('should resolve properly map', async () => {
     const { container } = new Kado();
     class A {
       constructor(public b: string) {}
@@ -57,14 +57,14 @@ describe('params', () => {
       {
         token: 'A',
         useClass: A,
-        params: [Kado.map(['b'])],
+        params: [map(['b'])],
       },
     ]);
     const a = await container.resolve<A>('A');
     assert.equal(a.b[0], 'foo');
   });
 
-  it('should resolve properly Kado.flatMap', async () => {
+  it('should resolve properly flatMap', async () => {
     const { container } = new Kado();
     class A {
       constructor(public b: string) {}
@@ -74,7 +74,7 @@ describe('params', () => {
       {
         token: 'A',
         useClass: A,
-        params: [Kado.flatMap(['b'])],
+        params: [flatMap(['b'])],
       },
     ]);
     const a = await container.resolve<A>('A');

--- a/packages/kado/src/__tests__/kado_test.ts
+++ b/packages/kado/src/__tests__/kado_test.ts
@@ -547,10 +547,10 @@ describe('Kado', () => {
 
   describe('when a custom error factory is injected', () => {
     it('throws the factory errors, preserving extra fields like `code`', async () => {
-      // Stands in for an `@daisugi/ayamari` `errFn`: coded errors that
+      // Stands in for an `@daisugi/ayamari` `errs`: coded errors that
       // are still plain `Error`s, so Kado accepts them transparently.
       // Distinct values prove the injected factory overrides the default.
-      const errFn = {
+      const errs = {
         NotFound: (msg: string) =>
           Object.assign(new Error(msg), {
             name: 'Custom NotFound',
@@ -562,7 +562,7 @@ describe('Kado', () => {
             code: 'CustomCircularDependencyDetected',
           }),
       };
-      const { container } = new Kado({ errFn });
+      const { container } = new Kado({ errs });
 
       await assert.rejects(
         container.resolve('missing'),

--- a/packages/kado/src/__tests__/kado_test.ts
+++ b/packages/kado/src/__tests__/kado_test.ts
@@ -2,9 +2,13 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  flatMap,
   Kado,
   type KadoContainer,
   type KadoManifestItem,
+  map,
+  scope,
+  value,
 } from '../kado.js';
 
 // Kado throws native `Error`s; an injected factory may enrich them with
@@ -14,9 +18,9 @@ type ThrownErr = Error & { code?: string };
 describe('Kado', () => {
   it('should have proper api', () => {
     assert.strictEqual(typeof Kado, 'function');
-    assert.strictEqual(typeof Kado.value, 'function');
-    assert.strictEqual(typeof Kado.map, 'function');
-    assert.strictEqual(typeof Kado.flatMap, 'function');
+    assert.strictEqual(typeof value, 'function');
+    assert.strictEqual(typeof map, 'function');
+    assert.strictEqual(typeof flatMap, 'function');
 
     const { container } = new Kado();
 
@@ -193,7 +197,7 @@ describe('Kado', () => {
           count++;
         },
         params: [{ useValue: 'foo' }],
-        scope: Kado.scope.Transient,
+        scope: scope.Transient,
       },
       {
         token: 'A',
@@ -219,7 +223,7 @@ describe('Kado', () => {
       {
         token: 'B',
         useClass: B,
-        scope: Kado.scope.Transient,
+        scope: scope.Transient,
       },
     ]);
 

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -385,15 +385,9 @@ export class Container {
   }
 }
 
-// Facade retained for back-compat: `new Kado()` plus the `Kado.scope`,
-// `Kado.value`, `Kado.map`, `Kado.flatMap` statics keep working. The statics
-// delegate to the standalone exports above, which are what tree-shaking-aware
-// consumers should import directly.
+// The container facade. Build manifests with the standalone `value`, `map`,
+// `flatMap` and `scope` exports above, then resolve through `kado.container`.
 export class Kado {
-  static scope = scope;
-  static value = value;
-  static map = map;
-  static flatMap = flatMap;
   container: KadoContainer;
 
   constructor(opts: KadoOpts = {}) {

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -7,12 +7,9 @@ export type KadoScope =
   | 'Singleton'
   | 'ContainerScoped';
 
-// Minimal error-factory surface Kado depends on. The factory only has
-// to return an `Error`; a richer error (e.g. an `@daisugi/ayamari` one
-// carrying a `code`, `cause` and prettified stack) is equally accepted,
-// since it is also an `Error`. `@daisugi/ayamari`'s `errFn` satisfies
-// this shape and can be injected directly; otherwise the built-in
-// `defaultErrFn` is used, keeping Kado free of any required dependency.
+// Minimal error-factory surface Kado depends on: the factory need only return
+// an `Error`, so a richer `@daisugi/ayamari` `errFn` can be injected directly.
+// Otherwise the built-in `defaultErrFn` is used, keeping Kado dependency-free.
 export interface KadoErrFn {
   NotFound(msg: string): Error;
   CircularDependencyDetected(msg: string): Error;
@@ -22,11 +19,9 @@ export interface KadoOpts {
   errFn?: KadoErrFn;
 }
 
-// Built-in fallback used when no `errFn` is injected. It mirrors the
-// observable contract of the matching `@daisugi/ayamari` errors (same
-// `name` and `code`), so the default behaves like Ayamari without
-// requiring it. The `code` is not part of the `KadoErrFn` contract,
-// so an injected factory may still return plain native `Error`s.
+// Built-in fallback used when no `errFn` is injected. Mirrors the matching
+// `@daisugi/ayamari` errors (same `name` and `code`) without requiring it;
+// `code` is outside the `KadoErrFn` contract, so injected factories may omit it.
 const defaultErrFn: KadoErrFn = {
   NotFound: (msg) =>
     Object.assign(new Error(msg), {
@@ -73,20 +68,18 @@ type KadoTokenToContainerItem = Map<
 >;
 export type KadoContainer = Container;
 
-// Scope constants exported standalone so they can be referenced without
-// pulling in the `Container`/`Kado` classes. `Container` reads these (rather
-// than `Kado.scope`) so the resolution engine does not depend on the `Kado`
-// facade, keeping the two independently tree-shakeable.
+// Scope constants exported standalone so they can be referenced without pulling
+// in the `Container`/`Kado` classes. `Container` reads these (not `Kado.scope`),
+// so the resolution engine and facade stay independently tree-shakeable.
 export const scope: Record<KadoScope, KadoScope> = {
   Transient: 'Transient',
   Singleton: 'Singleton',
   ContainerScoped: 'ContainerScoped',
 };
 
-// Manifest-item builders exported as standalone functions, so a module that
-// only assembles manifests can import them
-// (`import { value, map } from '@daisugi/kado'`) without dragging in the DI
-// container engine.
+// Manifest-item builders exported as standalone functions, so a module that only
+// assembles manifests can import them (`import { value, map } from '@daisugi/kado'`)
+// without dragging in the DI container engine.
 export function value(val: unknown): KadoManifestItem {
   return { useValue: val };
 }
@@ -116,15 +109,13 @@ export class Container {
   // Bumped on every `register` to invalidate prior circular-dep
   // validations in O(1) instead of resetting a flag per item.
   #generation = 0;
-  // Token lookup falls through to the parent when not found
-  // locally; `null` for a root container. Passed through the
-  // constructor's optional `parent`, which only
+  // Token lookup falls through to the parent when not found locally; `null` for
+  // a root container. Set via the constructor's optional `parent`, which only
   // `createChildContainer` is meant to supply.
   #parent: Container | null;
-  // Error factory used for thrown errors. Defaults to a built-in
-  // implementation; an `@daisugi/ayamari` `errFn` (or any compatible
-  // factory) can be injected via `Kado`'s config and is propagated to
-  // child containers.
+  // Error factory for thrown errors. Defaults to a built-in implementation; an
+  // `@daisugi/ayamari` `errFn` (or any compatible factory) can be injected via
+  // `Kado`'s config and is propagated to child containers.
   #errFn: KadoErrFn;
 
   constructor(
@@ -136,11 +127,9 @@ export class Container {
     this.#errFn = errFn;
   }
 
-  // Creates a container whose token lookup falls through to this
-  // one (and its ancestors) when a token is not registered
-  // locally. `ContainerScoped` registrations are copied down so
-  // each child caches its own instance instead of sharing the
-  // ancestor's.
+  // Creates a container whose token lookup falls through to this one (and its
+  // ancestors) when a token isn't registered locally. `ContainerScoped` items
+  // are copied down so each child caches its own instance, not the ancestor's.
   createChildContainer(): Container {
     const child = new Container(this, this.#errFn);
     for (const [
@@ -165,11 +154,9 @@ export class Container {
     const containerItem =
       this.#tokenToContainerItem.get(token);
     if (containerItem === undefined) {
-      // Not registered locally: fall through to the ancestor
-      // chain. The matching ancestor becomes the resolving
-      // container, so its singletons cache there and are shared,
-      // while `ContainerScoped` items were already copied down to
-      // this container by `createChildContainer`.
+      // Not registered locally: fall through to the ancestor chain. The matching
+      // ancestor becomes the resolving container, so its singletons cache and share
+      // there; `ContainerScoped` items were already copied down by createChildContainer.
       if (this.#parent !== null) {
         return this.#parent.resolve<T>(token);
       }
@@ -277,10 +264,9 @@ export class Container {
   }
 
   list(): KadoManifestItem[] {
-    // Merge the whole chain. A nearer container shadows its
-    // ancestors, so the first registration seen for a token wins
-    // (this also dedupes the `ContainerScoped` copies that
-    // `createChildContainer` placed in descendants).
+    // Merge the whole chain. A nearer container shadows its ancestors, so the first
+    // registration seen for a token wins (this also dedupes the `ContainerScoped`
+    // copies that `createChildContainer` placed in descendants).
     const manifestItemByToken = new Map<
       KadoToken,
       KadoManifestItem
@@ -354,11 +340,9 @@ export class Container {
         if (typeof param === 'object') {
           continue;
         }
-        // A param may live in an ancestor; validate it against
-        // its owner so each container memoizes with its own
-        // generation. Cycles can't span back down the chain
-        // (ancestors can't see descendant tokens), so walking up
-        // is sufficient.
+        // A param may live in an ancestor; validate it against its owner so each
+        // container memoizes with its own generation. Cycles can't span back down
+        // the chain (ancestors can't see descendant tokens), so walking up suffices.
         this.#checkTokenForCircularDep(param, path);
       }
       path.delete(token);

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -8,21 +8,21 @@ export type KadoScope =
   | 'ContainerScoped';
 
 // Minimal error-factory surface Kado depends on: the factory need only return
-// an `Error`, so a richer `@daisugi/ayamari` `errFn` can be injected directly.
-// Otherwise the built-in `defaultErrFn` is used, keeping Kado dependency-free.
-export interface KadoErrFn {
+// an `Error`, so a richer `@daisugi/ayamari` `errs` can be injected directly.
+// Otherwise the built-in `defaultErrs` is used, keeping Kado dependency-free.
+export interface KadoErrs {
   NotFound(msg: string): Error;
   CircularDependencyDetected(msg: string): Error;
 }
 
 export interface KadoOpts {
-  errFn?: KadoErrFn;
+  errs?: KadoErrs;
 }
 
-// Built-in fallback used when no `errFn` is injected. Mirrors the matching
+// Built-in fallback used when no `errs` is injected. Mirrors the matching
 // `@daisugi/ayamari` errors (same `name` and `code`) without requiring it;
-// `code` is outside the `KadoErrFn` contract, so injected factories may omit it.
-const defaultErrFn: KadoErrFn = {
+// `code` is outside the `KadoErrs` contract, so injected factories may omit it.
+const defaultErrs: KadoErrs = {
   NotFound: (msg) =>
     Object.assign(new Error(msg), {
       name: 'NotFound',
@@ -114,24 +114,24 @@ export class Container {
   // `createChildContainer` is meant to supply.
   #parent: Container | null;
   // Error factory for thrown errors. Defaults to a built-in implementation; an
-  // `@daisugi/ayamari` `errFn` (or any compatible factory) can be injected via
+  // `@daisugi/ayamari` `errs` (or any compatible factory) can be injected via
   // `Kado`'s config and is propagated to child containers.
-  #errFn: KadoErrFn;
+  #errs: KadoErrs;
 
   constructor(
     parent: Container | null = null,
-    errFn: KadoErrFn = defaultErrFn,
+    errs: KadoErrs = defaultErrs,
   ) {
     this.#tokenToContainerItem = new Map();
     this.#parent = parent;
-    this.#errFn = errFn;
+    this.#errs = errs;
   }
 
   // Creates a container whose token lookup falls through to this one (and its
   // ancestors) when a token isn't registered locally. `ContainerScoped` items
   // are copied down so each child caches its own instance, not the ancestor's.
   createChildContainer(): Container {
-    const child = new Container(this, this.#errFn);
+    const child = new Container(this, this.#errs);
     for (const [
       token,
       containerItem,
@@ -160,7 +160,7 @@ export class Container {
       if (this.#parent !== null) {
         return this.#parent.resolve<T>(token);
       }
-      throw this.#errFn.NotFound(
+      throw this.#errs.NotFound(
         `Attempted to resolve unregistered dependency token: "${token.toString()}".`,
       );
     }
@@ -305,7 +305,7 @@ export class Container {
     if (this.#parent !== null) {
       return this.#parent.get(token);
     }
-    throw this.#errFn.NotFound(
+    throw this.#errs.NotFound(
       `Attempted to get unregistered dependency token: "${token.toString()}".`,
     );
   }
@@ -329,7 +329,7 @@ export class Container {
       const chainOfTokens = Array.from(path)
         .map((t) => `"${t.toString()}"`)
         .join(' ➡️ ');
-      throw this.#errFn.CircularDependencyDetected(
+      throw this.#errs.CircularDependencyDetected(
         `Attempted to resolve circular dependency: ${chainOfTokens} 🔄 "${token.toString()}".`,
       );
     }
@@ -375,6 +375,6 @@ export class Kado {
   container: KadoContainer;
 
   constructor(opts: KadoOpts = {}) {
-    this.container = new Container(null, opts.errFn);
+    this.container = new Container(null, opts.errs);
   }
 }

--- a/packages/kado/src/kado.ts
+++ b/packages/kado/src/kado.ts
@@ -73,6 +73,44 @@ type KadoTokenToContainerItem = Map<
 >;
 export type KadoContainer = Container;
 
+// Scope constants exported standalone so they can be referenced without
+// pulling in the `Container`/`Kado` classes. `Container` reads these (rather
+// than `Kado.scope`) so the resolution engine does not depend on the `Kado`
+// facade, keeping the two independently tree-shakeable.
+export const scope: Record<KadoScope, KadoScope> = {
+  Transient: 'Transient',
+  Singleton: 'Singleton',
+  ContainerScoped: 'ContainerScoped',
+};
+
+// Manifest-item builders exported as standalone functions, so a module that
+// only assembles manifests can import them
+// (`import { value, map } from '@daisugi/kado'`) without dragging in the DI
+// container engine.
+export function value(val: unknown): KadoManifestItem {
+  return { useValue: val };
+}
+
+export function map(params: KadoParam[]): KadoManifestItem {
+  return {
+    useFn(...args: unknown[]) {
+      return args;
+    },
+    params,
+  };
+}
+
+export function flatMap(
+  params: KadoParam[],
+): KadoManifestItem {
+  return {
+    useFn(...args: unknown[]) {
+      return args.flat();
+    },
+    params,
+  };
+}
+
 export class Container {
   #tokenToContainerItem: KadoTokenToContainerItem;
   // Bumped on every `register` to invalidate prior circular-dep
@@ -111,7 +149,7 @@ export class Container {
     ] of this.#tokenToContainerItem) {
       if (
         containerItem.manifestItem.scope ===
-        Kado.scope.ContainerScoped
+        scope.ContainerScoped
       ) {
         child.#tokenToContainerItem.set(token, {
           ...containerItem,
@@ -147,7 +185,7 @@ export class Container {
       return containerItem.instance;
     }
     let resolve: ((value: any) => void) | undefined;
-    if (manifestItem.scope !== Kado.scope.Transient) {
+    if (manifestItem.scope !== scope.Transient) {
       containerItem.instance = new Promise((_resolve) => {
         resolve = _resolve;
       });
@@ -184,7 +222,7 @@ export class Container {
         default:
           break;
       }
-      if (manifestItem.scope === Kado.scope.Transient) {
+      if (manifestItem.scope === scope.Transient) {
         return instance;
       }
       resolve!(instance);
@@ -347,37 +385,18 @@ export class Container {
   }
 }
 
+// Facade retained for back-compat: `new Kado()` plus the `Kado.scope`,
+// `Kado.value`, `Kado.map`, `Kado.flatMap` statics keep working. The statics
+// delegate to the standalone exports above, which are what tree-shaking-aware
+// consumers should import directly.
 export class Kado {
-  static scope: Record<KadoScope, KadoScope> = {
-    Transient: 'Transient',
-    Singleton: 'Singleton',
-    ContainerScoped: 'ContainerScoped',
-  };
+  static scope = scope;
+  static value = value;
+  static map = map;
+  static flatMap = flatMap;
   container: KadoContainer;
 
   constructor(opts: KadoOpts = {}) {
     this.container = new Container(null, opts.errFn);
-  }
-
-  static value(value: unknown): KadoManifestItem {
-    return { useValue: value };
-  }
-
-  static map(params: KadoParam[]): KadoManifestItem {
-    return {
-      useFn(...args: unknown[]) {
-        return args;
-      },
-      params,
-    };
-  }
-
-  static flatMap(params: KadoParam[]): KadoManifestItem {
-    return {
-      useFn(...args: unknown[]) {
-        return args.flat();
-      },
-      params,
-    };
   }
 }

--- a/packages/kintsugi/README.md
+++ b/packages/kintsugi/README.md
@@ -168,7 +168,7 @@ function calculateCacheMaxAgeMs(maxAgeMs) {
 
 function shouldCache(response) {
   if (response.isSuccess) return true;
-  if (response.isFailure && response.getError().code === Ayamari.errCode.NotFound) return true;
+  if (response.isFailure && response.unwrapErr().code === Ayamari.errCode.NotFound) return true;
   return false;
 }
 
@@ -251,7 +251,7 @@ const nonRetryableErrCodes = [Ayamari.errCode.NotFound];
 
 function shouldRetry(response, retryNumber, maxRetries) {
   if (response.isFailure) {
-    if (nonRetryableErrCodes.includes(response.getError().code)) return false;
+    if (nonRetryableErrCodes.includes(response.unwrapErr().code)) return false;
     if (retryNumber < maxRetries) return true;
   }
   return false;
@@ -419,7 +419,7 @@ simpleMemoryStore.set('key', 'Benadryl Cumberbatch.');
 const response = simpleMemoryStore.get('key');
 
 if (response.isSuccess) {
-  console.log(response.getValue());
+  console.log(response.unwrap());
   // 'Benadryl Cumberbatch.'
 }
 ```

--- a/packages/kintsugi/README.md
+++ b/packages/kintsugi/README.md
@@ -125,11 +125,8 @@ If a function throws or rejects instead of returning a `Result`, lift it at the 
 import { wrapAsyncThrowable } from '@daisugi/anzen';
 import { withCache, withRetry, withTimeout } from '@daisugi/kintsugi';
 
-// Lift once; `fetchUserResult` is now an `AnzenResultFn`.
-const fetchUserResult = wrapAsyncThrowable(fetchUser);
-
 // Inner to outer: time-box each attempt, retry failures, cache the success.
-const getUser = withCache(withRetry(withTimeout(fetchUserResult)));
+const getUser = withCache(withRetry(withTimeout(wrapAsyncThrowable(fetchUser))));
 ```
 
 Pass a `parseErr` to turn thrown/rejected errors into a typed (e.g. [@daisugi/ayamari](../ayamari)) error so `withRetry` can branch on the error code: `wrapAsyncThrowable(fetchUser, (e) => ...)`.

--- a/packages/kintsugi/README.md
+++ b/packages/kintsugi/README.md
@@ -17,7 +17,9 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 📦 Uses only trusted dependencies
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
-- 🤝 Used in production
+- 🤝 Used in production by millions of users
+- 🌳 Tree-shakeable
+- 🌐 Universal — runs in the browser and on the server (Node.js)
 - 🔀 Supports both ES Modules and CommonJS
 
 ---

--- a/packages/kintsugi/README.md
+++ b/packages/kintsugi/README.md
@@ -33,11 +33,11 @@ import {
   withCache,
   withRetry,
 } from '@daisugi/kintsugi';
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
 async function fn() {
   await waitFor(1000);
-  return success('Hi Benadryl Cumberbatch.');
+  return ok('Hi Benadryl Cumberbatch.');
 }
 
 const rockSolidFn = withCache(
@@ -167,8 +167,8 @@ function calculateCacheMaxAgeMs(maxAgeMs) {
 }
 
 function shouldCache(response) {
-  if (response.isSuccess) return true;
-  if (response.isFailure && response.unwrapErr().code === Ayamari.errCode.NotFound) return true;
+  if (response.isOk) return true;
+  if (response.isErr && response.unwrapErr().code === Ayamari.errCode.NotFound) return true;
   return false;
 }
 
@@ -181,10 +181,10 @@ The helpers `buildCacheKey`, `calculateCacheMaxAgeMs`, `shouldCache`, and `shoul
 
 ```js
 import { withCache } from '@daisugi/kintsugi';
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
 function fnToBeCached() {
-  return success('Hi Benadryl Cumberbatch.');
+  return ok('Hi Benadryl Cumberbatch.');
 }
 
 const fnWithCache = withCache(fnToBeCached);
@@ -250,7 +250,7 @@ function calculateRetryDelayMs(firstDelayMs, maxDelayMs, timeFactor, retryNumber
 const nonRetryableErrCodes = [Ayamari.errCode.NotFound];
 
 function shouldRetry(response, retryNumber, maxRetries) {
-  if (response.isFailure) {
+  if (response.isErr) {
     if (nonRetryableErrCodes.includes(response.unwrapErr().code)) return false;
     if (retryNumber < maxRetries) return true;
   }
@@ -262,10 +262,10 @@ The helpers `calculateRetryDelayMs` and `shouldRetry` are also exported for cust
 
 ```js
 import { withRetry } from '@daisugi/kintsugi';
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
 function fn() {
-  return success('Hi Benadryl Cumberbatch.');
+  return ok('Hi Benadryl Cumberbatch.');
 }
 
 const fnWithRetry = withRetry(fn);
@@ -282,7 +282,7 @@ Races a `Result`-returning function against a timeout. If the function does not 
 withTimeout<Fn extends AnzenResultFn<unknown, unknown>>(
   fn: Fn,
   opts?: { maxTimeMs?: number },
-): (...args: Parameters<Fn>) => Promise<Awaited<ReturnType<Fn>> | AnzenResultFailure<AyamariErr>>
+): (...args: Parameters<Fn>) => Promise<Awaited<ReturnType<Fn>> | AnzenResultErr<AyamariErr>>
 ```
 
 | Option      | Type     | Default | Description                                          |
@@ -293,11 +293,11 @@ withTimeout<Fn extends AnzenResultFn<unknown, unknown>>(
 
 ```js
 import { withTimeout, waitFor } from '@daisugi/kintsugi';
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
 async function fn() {
   await waitFor(8000);
-  return success('Hi Benadryl Cumberbatch.');
+  return ok('Hi Benadryl Cumberbatch.');
 }
 
 const fnWithTimeout = withTimeout(fn);
@@ -353,11 +353,11 @@ reusePromise<Fn extends AsyncFn>(
 
 ```js
 import { reusePromise, waitFor } from '@daisugi/kintsugi';
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
 async function fnToBeReused() {
   await waitFor(1000);
-  return success('Hi Benadryl Cumberbatch.');
+  return ok('Hi Benadryl Cumberbatch.');
 }
 
 const fn = reusePromise(fnToBeReused);
@@ -404,8 +404,8 @@ class SimpleMemoryStore implements CacheStore {
     cacheKey: string,
     value: unknown,
     maxAgeMs?: number,
-  ): AnzenResultSuccess<string>;
-  delete(cacheKey: string): AnzenResultSuccess<string>;
+  ): AnzenResultOk<string>;
+  delete(cacheKey: string): AnzenResultOk<string>;
 }
 ```
 
@@ -418,7 +418,7 @@ simpleMemoryStore.set('key', 'Benadryl Cumberbatch.');
 
 const response = simpleMemoryStore.get('key');
 
-if (response.isSuccess) {
+if (response.isOk) {
   console.log(response.unwrap());
   // 'Benadryl Cumberbatch.'
 }

--- a/packages/kintsugi/README.md
+++ b/packages/kintsugi/README.md
@@ -17,9 +17,9 @@ This project is part of the [@daisugi](https://github.com/daisugiland/daisugi) m
 - 📦 Uses only trusted dependencies
 - 🔨 Powerful and agnostic to your code
 - 🧪 Well-tested
-- 🤝 Used in production by millions of users
+- 🤝 Used in production
 - 🌳 Tree-shakeable
-- 🌐 Universal — runs in the browser and on the server (Node.js)
+- 🌐 Universal - runs in the browser and on the server (Node.js)
 - 🔀 Supports both ES Modules and CommonJS
 
 ---
@@ -33,11 +33,11 @@ import {
   withCache,
   withRetry,
 } from '@daisugi/kintsugi';
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
 async function fn() {
   await waitFor(1000);
-  return Result.success('Hi Benadryl Cumberbatch.');
+  return success('Hi Benadryl Cumberbatch.');
 }
 
 const rockSolidFn = withCache(
@@ -56,6 +56,7 @@ const rockSolidFn = withCache(
   - [📦 Installation](#-installation)
   - [🔍 Overview](#-overview)
   - [📚 API](#-api)
+      - [Adapting a throwing function](#adapting-a-throwing-function)
     - [`withCache(fn, opts?)`](#withcachefn-opts)
     - [`withMemo(fn, opts?)`](#withmemofn-opts)
     - [`withRetry(fn, opts?)`](#withretryfn-opts)
@@ -114,18 +115,18 @@ pnpm install @daisugi/kintsugi
 ## 📚 API
 
 > [!NOTE]
-> **Error model.** These wrappers share one contract: each takes an async function that returns a [@daisugi/anzen](../anzen) `Result` (or a `Promise` of one) and returns a wrapper with the same signature. Domain failures travel as `Result.failure` (typically an [@daisugi/ayamari](../ayamari) error), **not** as thrown exceptions — a thrown or rejected error is treated as a programmer bug. `withTimeout` resolves `Result.failure(Timeout)` on timeout; `withPool` and `reusePromise` are error-agnostic plumbing that pass the `Result` (or a rejection) through unchanged. Because every wrapper has the same shape in and out, they compose in any order.
+> **Error model.** These wrappers share one contract: each takes an async function that returns a [@daisugi/anzen](../anzen) `Result` (or a `Promise` of one) and returns a wrapper with the same signature. Domain failures travel as a failure `Result` (typically an [@daisugi/ayamari](../ayamari) error), **not** as thrown exceptions — a thrown or rejected error is treated as a programmer bug. `withTimeout` resolves `failure(Timeout)` on timeout; `withPool` and `reusePromise` are error-agnostic plumbing that pass the `Result` (or a rejection) through unchanged. Because every wrapper has the same shape in and out, they compose in any order.
 
 #### Adapting a throwing function
 
-If a function rejects or throws instead of returning a `Result`, lift it at the boundary with anzen's `Result.fromThrowable` (it runs a thunk and returns a `Promise<Result>`), then compose freely:
+If a function rejects or throws instead of returning a `Result`, lift it at the boundary with anzen's `fromThrowable` (it runs a thunk and returns a `Promise<Result>`), then compose freely:
 
 ```ts
-import { Result } from '@daisugi/anzen';
+import { fromThrowable } from '@daisugi/anzen';
 import { withCache, withRetry, withTimeout } from '@daisugi/kintsugi';
 
 const fetchUserResult = (id: number) =>
-  Result.fromThrowable(() => fetchUser(id));
+  fromThrowable(() => fetchUser(id));
 
 // Inner to outer: time-box each attempt, retry failures, cache the success.
 const getUser = withCache(withRetry(withTimeout(fetchUserResult)));
@@ -144,15 +145,15 @@ withCache<E, T>(
 ): (...args: any[]) => Promise<AnzenAnyResult<E, T>>
 ```
 
-| Option                   | Type                                | Default                   | Description                                                            |
-| ------------------------ | ----------------------------------- | ------------------------- | ---------------------------------------------------------------------- |
-| `cacheStore`             | `CacheStore`                        | `new SimpleMemoryStore()` | Backing store implementing the `CacheStore` interface (`get` / `set` / `delete`). |
-| `version`                | `string`                            | `'v1'`                    | Version string for cache-key invalidation.                             |
-| `maxAgeMs`               | `number`                            | `14400000` (4h)           | Entry time-to-live in milliseconds.                                    |
-| `buildCacheKey`          | `(fnId, version, args) => string`   | _see below_               | Builds the cache key from the per-wrap function id, version, and arguments. |
-| `calculateCacheMaxAgeMs` | `(maxAgeMs) => number`              | _see below_               | Computes the TTL, adding jitter to avoid synchronized expiry.          |
-| `shouldCache`            | `(response) => boolean`             | _see below_               | Decides whether a response should be cached.                           |
-| `shouldInvalidateCache`  | `(args) => boolean`                 | _see below_               | Decides whether to evict the cached entry and refresh.                 |
+| Option                   | Type                              | Default                   | Description                                                                       |
+| ------------------------ | --------------------------------- | ------------------------- | --------------------------------------------------------------------------------- |
+| `cacheStore`             | `CacheStore`                      | `new SimpleMemoryStore()` | Backing store implementing the `CacheStore` interface (`get` / `set` / `delete`). |
+| `version`                | `string`                          | `'v1'`                    | Version string for cache-key invalidation.                                        |
+| `maxAgeMs`               | `number`                          | `14400000` (4h)           | Entry time-to-live in milliseconds.                                               |
+| `buildCacheKey`          | `(fnId, version, args) => string` | _see below_               | Builds the cache key from the per-wrap function id, version, and arguments.       |
+| `calculateCacheMaxAgeMs` | `(maxAgeMs) => number`            | _see below_               | Computes the TTL, adding jitter to avoid synchronized expiry.                     |
+| `shouldCache`            | `(response) => boolean`           | _see below_               | Decides whether a response should be cached.                                      |
+| `shouldInvalidateCache`  | `(args) => boolean`               | _see below_               | Decides whether to evict the cached entry and refresh.                            |
 
 Default implementations:
 
@@ -180,10 +181,10 @@ The helpers `buildCacheKey`, `calculateCacheMaxAgeMs`, `shouldCache`, and `shoul
 
 ```js
 import { withCache } from '@daisugi/kintsugi';
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
 function fnToBeCached() {
-  return Result.success('Hi Benadryl Cumberbatch.');
+  return success('Hi Benadryl Cumberbatch.');
 }
 
 const fnWithCache = withCache(fnToBeCached);
@@ -261,10 +262,10 @@ The helpers `calculateRetryDelayMs` and `shouldRetry` are also exported for cust
 
 ```js
 import { withRetry } from '@daisugi/kintsugi';
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
 function fn() {
-  return Result.success('Hi Benadryl Cumberbatch.');
+  return success('Hi Benadryl Cumberbatch.');
 }
 
 const fnWithRetry = withRetry(fn);
@@ -275,7 +276,7 @@ fnWithRetry();
 
 ### `withTimeout(fn, opts?)`
 
-Races a `Result`-returning function against a timeout. If the function does not settle in time, it resolves to a `Result.failure` carrying an Ayamari `Timeout` (504) error. It takes an `AnzenResultFn` (like `withCache`/`withRetry`), so the timeout failure composes as a normal `Result`.
+Races a `Result`-returning function against a timeout. If the function does not settle in time, it resolves to a failure `Result` carrying an Ayamari `Timeout` (504) error. It takes an `AnzenResultFn` (like `withCache`/`withRetry`), so the timeout failure composes as a normal `Result`.
 
 ```ts
 withTimeout<Fn extends AnzenResultFn<unknown, unknown>>(
@@ -292,11 +293,11 @@ withTimeout<Fn extends AnzenResultFn<unknown, unknown>>(
 
 ```js
 import { withTimeout, waitFor } from '@daisugi/kintsugi';
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
 async function fn() {
   await waitFor(8000);
-  return Result.success('Hi Benadryl Cumberbatch.');
+  return success('Hi Benadryl Cumberbatch.');
 }
 
 const fnWithTimeout = withTimeout(fn);
@@ -352,11 +353,11 @@ reusePromise<Fn extends AsyncFn>(
 
 ```js
 import { reusePromise, waitFor } from '@daisugi/kintsugi';
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
 async function fnToBeReused() {
   await waitFor(1000);
-  return Result.success('Hi Benadryl Cumberbatch.');
+  return success('Hi Benadryl Cumberbatch.');
 }
 
 const fn = reusePromise(fnToBeReused);

--- a/packages/kintsugi/README.md
+++ b/packages/kintsugi/README.md
@@ -119,18 +119,20 @@ pnpm install @daisugi/kintsugi
 
 #### Adapting a throwing function
 
-If a function rejects or throws instead of returning a `Result`, lift it at the boundary with anzen's `fromThrowable` (it runs a thunk and returns a `Promise<Result>`), then compose freely:
+If a function throws or rejects instead of returning a `Result`, lift it at the boundary with anzen's `wrapAsyncThrowable` (it adapts an async throwing function into a reusable `Result`-returning function), then compose freely:
 
 ```ts
-import { fromThrowable } from '@daisugi/anzen';
+import { wrapAsyncThrowable } from '@daisugi/anzen';
 import { withCache, withRetry, withTimeout } from '@daisugi/kintsugi';
 
-const fetchUserResult = (id: number) =>
-  fromThrowable(() => fetchUser(id));
+// Lift once; `fetchUserResult` is now an `AnzenResultFn`.
+const fetchUserResult = wrapAsyncThrowable(fetchUser);
 
 // Inner to outer: time-box each attempt, retry failures, cache the success.
 const getUser = withCache(withRetry(withTimeout(fetchUserResult)));
 ```
+
+Pass a `parseErr` to turn thrown/rejected errors into a typed (e.g. [@daisugi/ayamari](../ayamari)) error so `withRetry` can branch on the error code: `wrapAsyncThrowable(fetchUser, (e) => ...)`.
 
 `withTimeout` closest to the function bounds each attempt, `withRetry` retries timed-out or failed attempts, and `withCache` outermost caches the final success (`shouldCache` caches successes and `NotFound` by default, never transient failures like `Timeout`).
 
@@ -142,7 +144,7 @@ Caches the result of a `Result`-returning function. Successful (and, by default,
 withCache<E, T>(
   fn: AnzenResultFn<E, T>,
   opts?: WithCacheOpts,
-): (...args: any[]) => Promise<AnzenAnyResult<E, T>>
+): (...args: any[]) => Promise<AnzenResult<E, T>>
 ```
 
 | Option                   | Type                              | Default                   | Description                                                                       |
@@ -227,7 +229,7 @@ Retries a `Result`-returning function on failure, using exponential backoff with
 withRetry<E, T>(
   fn: AnzenResultFn<E, T>,
   opts?: WithRetryOpts,
-): (...args: any[]) => Promise<AnzenAnyResult<E, T>>
+): (...args: any[]) => Promise<AnzenResult<E, T>>
 ```
 
 | Option                  | Type                                                            | Default     | Description                                |
@@ -399,7 +401,7 @@ A basic in-memory cache store implementing the `CacheStore` interface. Every met
 ```ts
 class SimpleMemoryStore implements CacheStore {
   constructor(opts?: { maxSize?: number });
-  get(cacheKey: string): AnzenAnyResult<AyamariErr, unknown>;
+  get(cacheKey: string): AnzenResult<AyamariErr, unknown>;
   set(
     cacheKey: string,
     value: unknown,

--- a/packages/kintsugi/README.md
+++ b/packages/kintsugi/README.md
@@ -115,7 +115,7 @@ pnpm install @daisugi/kintsugi
 ## 📚 API
 
 > [!NOTE]
-> **Error model.** These wrappers share one contract: each takes an async function that returns a [@daisugi/anzen](../anzen) `Result` (or a `Promise` of one) and returns a wrapper with the same signature. Domain failures travel as a failure `Result` (typically an [@daisugi/ayamari](../ayamari) error), **not** as thrown exceptions — a thrown or rejected error is treated as a programmer bug. `withTimeout` resolves `failure(Timeout)` on timeout; `withPool` and `reusePromise` are error-agnostic plumbing that pass the `Result` (or a rejection) through unchanged. Because every wrapper has the same shape in and out, they compose in any order.
+> **Error model.** These wrappers share one contract: each takes an async function that returns a [@daisugi/anzen](../anzen) `Result` (or a `Promise` of one) and returns a wrapper with the same signature. Domain failures travel as a failure `Result` (typically an [@daisugi/ayamari](../ayamari) error), **not** as thrown exceptions - a thrown or rejected error is treated as a programmer bug. `withTimeout` resolves `failure(Timeout)` on timeout; `withPool` and `reusePromise` are error-agnostic plumbing that pass the `Result` (or a rejection) through unchanged. Because every wrapper has the same shape in and out, they compose in any order.
 
 #### Adapting a throwing function
 
@@ -507,7 +507,7 @@ const hash = hashFNV1A(JSON.stringify({ name: 'Hi Benadryl Cumberbatch.' }));
 Serializes a function's argument list into a stable string suitable for use as a cache key.
 
 - A single primitive (`null`, number, boolean) becomes a bare token (`"5"`, `"true"`, `"null"`) that cannot collide with any bracketed JSON form.
-- Everything else — multiple arguments or complex values — is JSON-serialized as an array, with object keys sorted for consistency.
+- Everything else - multiple arguments or complex values - is JSON-serialized as an array, with object keys sorted for consistency.
 
 ```ts
 stringifyArgs(args: unknown[]): string
@@ -526,7 +526,7 @@ stringifyArgs([null]);             // "null"
 stringifyArgs(['hello']);          // '["hello"]'
 stringifyArgs([1, 2]);             // "[1,2]"
 stringifyArgs([{ b: 2, a: 1 }]);   // '[{"a":1,"b":2}]'
-stringifyArgs([[5, 5]]);           // "[[5,5]]"  — array arg, not two args
+stringifyArgs([[5, 5]]);           // "[[5,5]]"  - array arg, not two args
 ```
 
 [:top: Back to top](#-table-of-contents)
@@ -535,7 +535,7 @@ stringifyArgs([[5, 5]]);           // "[[5,5]]"  — array arg, not two args
 
 ## 🌸 Etymology
 
-*Kintsugi* (金継ぎ) is the Japanese art of repairing broken objects by mending the cracks with gold, highlighting rather than hiding the damage—much like how Kintsugi keeps services running gracefully through failures.
+*Kintsugi* (金継ぎ) is the Japanese art of repairing broken objects by mending the cracks with gold, highlighting rather than hiding the damage-much like how Kintsugi keeps services running gracefully through failures.
 
 More info: [Esprit Kintsugi](https://esprit-kintsugi.com/en/quest-ce-que-le-kintsugi/)
 

--- a/packages/kintsugi/examples/redis_cache_store.ts
+++ b/packages/kintsugi/examples/redis_cache_store.ts
@@ -5,7 +5,7 @@ import IOREdis from 'ioredis';
 
 import { CacheStore } from '../src/with_cache.js';
 
-const { errFn } = new Ayamari();
+const { errs } = new Ayamari();
 
 export class RedisCacheStore implements CacheStore {
   #redisClient: IOREdis;
@@ -20,13 +20,13 @@ export class RedisCacheStore implements CacheStore {
       const response = await this.#redisClient.get(key);
       if (response === null) {
         return Result.failure(
-          errFn.NotFound('RedisCacheStore.get'),
+          errs.NotFound('RedisCacheStore.get'),
         );
       }
       return Result.success(JSON.parse(response));
     } catch (err) {
       return Result.failure(
-        errFn.UnexpectedError('RedisCacheStore.get', {
+        errs.UnexpectedError('RedisCacheStore.get', {
           cause: err,
         }),
       );
@@ -44,7 +44,7 @@ export class RedisCacheStore implements CacheStore {
       return Result.success(response);
     } catch (err) {
       return Result.failure(
-        errFn.UnexpectedError('RedisCacheStore.set', {
+        errs.UnexpectedError('RedisCacheStore.set', {
           cause: err,
         }),
       );

--- a/packages/kintsugi/src/__tests__/simple_memory_store_test.ts
+++ b/packages/kintsugi/src/__tests__/simple_memory_store_test.ts
@@ -9,36 +9,36 @@ describe('SimpleMemoryStore', () => {
     const store = new SimpleMemoryStore();
     store.set('k', 'v');
     const response = store.get('k');
-    assert.strictEqual(response.isSuccess, true);
+    assert.strictEqual(response.isOk, true);
     assert.strictEqual(response.unwrap(), 'v');
   });
 
   it('should return a failure for a missing key', () => {
     const store = new SimpleMemoryStore();
     const response = store.get('missing');
-    assert.strictEqual(response.isFailure, true);
+    assert.strictEqual(response.isErr, true);
   });
 
   it('should expire an entry after maxAgeMs', async () => {
     const store = new SimpleMemoryStore();
     store.set('k', 'v', 5);
-    assert.strictEqual(store.get('k').isSuccess, true);
+    assert.strictEqual(store.get('k').isOk, true);
     await waitFor(15);
-    assert.strictEqual(store.get('k').isFailure, true);
+    assert.strictEqual(store.get('k').isErr, true);
   });
 
   it('should not expire when no maxAgeMs is given', async () => {
     const store = new SimpleMemoryStore();
     store.set('k', 'v');
     await waitFor(10);
-    assert.strictEqual(store.get('k').isSuccess, true);
+    assert.strictEqual(store.get('k').isOk, true);
   });
 
   it('should remove the key on delete', () => {
     const store = new SimpleMemoryStore();
     store.set('k', 'v');
     store.delete('k');
-    assert.strictEqual(store.get('k').isFailure, true);
+    assert.strictEqual(store.get('k').isErr, true);
   });
 
   it('should ack set and delete with the cache key', () => {
@@ -53,8 +53,8 @@ describe('SimpleMemoryStore', () => {
     store.set('b', 2);
     store.get('a'); // 'a' becomes most-recently-used.
     store.set('c', 3); // Over cap -> evict 'b'.
-    assert.strictEqual(store.get('a').isSuccess, true);
-    assert.strictEqual(store.get('b').isFailure, true);
-    assert.strictEqual(store.get('c').isSuccess, true);
+    assert.strictEqual(store.get('a').isOk, true);
+    assert.strictEqual(store.get('b').isErr, true);
+    assert.strictEqual(store.get('c').isOk, true);
   });
 });

--- a/packages/kintsugi/src/__tests__/simple_memory_store_test.ts
+++ b/packages/kintsugi/src/__tests__/simple_memory_store_test.ts
@@ -10,7 +10,7 @@ describe('SimpleMemoryStore', () => {
     store.set('k', 'v');
     const response = store.get('k');
     assert.strictEqual(response.isSuccess, true);
-    assert.strictEqual(response.getValue(), 'v');
+    assert.strictEqual(response.unwrap(), 'v');
   });
 
   it('should return a failure for a missing key', () => {
@@ -43,8 +43,8 @@ describe('SimpleMemoryStore', () => {
 
   it('should ack set and delete with the cache key', () => {
     const store = new SimpleMemoryStore();
-    assert.strictEqual(store.set('k', 'v').getValue(), 'k');
-    assert.strictEqual(store.delete('k').getValue(), 'k');
+    assert.strictEqual(store.set('k', 'v').unwrap(), 'k');
+    assert.strictEqual(store.delete('k').unwrap(), 'k');
   });
 
   it('should evict the least-recently-used entry over maxSize', () => {

--- a/packages/kintsugi/src/__tests__/with_cache_test.ts
+++ b/packages/kintsugi/src/__tests__/with_cache_test.ts
@@ -1,10 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import {
-  failure,
-  type ResultSuccess,
-  success,
-} from '@daisugi/anzen';
+import { err, type ResultOk, ok } from '@daisugi/anzen';
 
 import { SimpleMemoryStore } from '../simple_memory_store.js';
 import {
@@ -36,7 +32,7 @@ describe('withCache', () => {
       async fn(response: string) {
         this.count = this.count + 1;
 
-        return success(response);
+        return ok(response);
       }
     }
     const foo = new Foo();
@@ -54,7 +50,7 @@ describe('withCache', () => {
       let count = 0;
       async function fn() {
         count = count + 1;
-        return success('ok');
+        return ok('ok');
       }
       const fnWithCache = withCache(fn);
       const response1 = await fnWithCache();
@@ -70,8 +66,8 @@ describe('withCache', () => {
     const simpleMemoryStore = new SimpleMemoryStore();
     const getMock = t.mock.method(simpleMemoryStore, 'get');
     const setMock = t.mock.method(simpleMemoryStore, 'set');
-    function fn(): ResultSuccess<string> {
-      return success('ok');
+    function fn(): ResultOk<string> {
+      return ok('ok');
     }
     const fnWithCache = withCache(fn, {
       cacheStore: simpleMemoryStore,
@@ -82,8 +78,8 @@ describe('withCache', () => {
     assert.match(String(cacheKey), /^\d+:v1:\[\]$/u);
     const setArgs = setMock.mock.calls[0]?.arguments;
     assert.strictEqual(setArgs?.[0], cacheKey);
-    const cached = setArgs?.[1] as ResultSuccess<string>;
-    assert.strictEqual(cached?.isSuccess, true);
+    const cached = setArgs?.[1] as ResultOk<string>;
+    assert.strictEqual(cached?.isOk, true);
     assert.strictEqual(cached?.unwrap(), 'ok');
     const maxAgeMs = setArgs?.[2];
     assert.ok(
@@ -97,8 +93,8 @@ describe('withCache', () => {
     const simpleMemoryStore = new SimpleMemoryStore();
     const getMock = t.mock.method(simpleMemoryStore, 'get');
     const setMock = t.mock.method(simpleMemoryStore, 'set');
-    function fn(): ResultSuccess<string> {
-      return success('ok');
+    function fn(): ResultOk<string> {
+      return ok('ok');
     }
     const fnWithCache = withCache(fn, {
       cacheStore: simpleMemoryStore,
@@ -117,8 +113,8 @@ describe('withCache', () => {
     assert.match(String(cacheKey), /^\d+v2\[\]$/u);
     const setArgs = setMock.mock.calls[0]?.arguments;
     assert.strictEqual(setArgs?.[0], cacheKey);
-    const cached = setArgs?.[1] as ResultSuccess<string>;
-    assert.strictEqual(cached?.isSuccess, true);
+    const cached = setArgs?.[1] as ResultOk<string>;
+    assert.strictEqual(cached?.isOk, true);
     assert.strictEqual(cached?.unwrap(), 'ok');
     assert.strictEqual(setArgs?.[2], 1000);
   });
@@ -127,7 +123,7 @@ describe('withCache', () => {
     const simpleMemoryStore = new SimpleMemoryStore();
     const getMock = t.mock.method(simpleMemoryStore, 'get');
     const fnWithCache = withCache(
-      (): ResultSuccess<string> => success('ok'),
+      (): ResultOk<string> => ok('ok'),
       { cacheStore: simpleMemoryStore, version: '' },
     );
 
@@ -139,9 +135,9 @@ describe('withCache', () => {
   describe('when `shouldInvalidateCache` returns true', () => {
     it('should invalidate cache', async () => {
       let count = 0;
-      function fn(_arg: boolean): ResultSuccess<string> {
+      function fn(_arg: boolean): ResultOk<string> {
         count = count + 1;
-        return success('ok');
+        return ok('ok');
       }
       const fnWithCache = withCache(fn, {
         shouldInvalidateCache(args) {
@@ -163,16 +159,15 @@ describe('withCache', () => {
     it('should evict the entry via the store delete', async () => {
       const deleted: string[] = [];
       const cacheStore: CacheStore = {
-        get: () => failure('miss'),
-        set: (_cacheKey, value) => success(value),
+        get: () => err('miss'),
+        set: (_cacheKey, value) => ok(value),
         delete(cacheKey) {
           deleted.push(cacheKey);
-          return success(cacheKey);
+          return ok(cacheKey);
         },
       };
       const fnWithCache = withCache(
-        (_arg: boolean): ResultSuccess<string> =>
-          success('ok'),
+        (_arg: boolean): ResultOk<string> => ok('ok'),
         {
           cacheStore,
           shouldInvalidateCache: () => true,
@@ -188,9 +183,9 @@ describe('withCache', () => {
   describe('when `shouldCache` is provided', () => {
     it('should return expected response', async () => {
       let count = 0;
-      function fn(_arg: boolean): ResultSuccess<string> {
+      function fn(_arg: boolean): ResultOk<string> {
         count = count + 1;
-        return success('ok');
+        return ok('ok');
       }
       const fnWithCache = withCache(fn, {
         shouldCache(response) {

--- a/packages/kintsugi/src/__tests__/with_cache_test.ts
+++ b/packages/kintsugi/src/__tests__/with_cache_test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { Result, type ResultSuccess } from '@daisugi/anzen';
+import {
+  failure,
+  type ResultSuccess,
+  success,
+} from '@daisugi/anzen';
 
 import { SimpleMemoryStore } from '../simple_memory_store.js';
 import {
@@ -32,7 +36,7 @@ describe('withCache', () => {
       async fn(response: string) {
         this.count = this.count + 1;
 
-        return Result.success(response);
+        return success(response);
       }
     }
     const foo = new Foo();
@@ -50,7 +54,7 @@ describe('withCache', () => {
       let count = 0;
       async function fn() {
         count = count + 1;
-        return Result.success('ok');
+        return success('ok');
       }
       const fnWithCache = withCache(fn);
       const response1 = await fnWithCache();
@@ -67,7 +71,7 @@ describe('withCache', () => {
     const getMock = t.mock.method(simpleMemoryStore, 'get');
     const setMock = t.mock.method(simpleMemoryStore, 'set');
     function fn(): ResultSuccess<string> {
-      return Result.success('ok');
+      return success('ok');
     }
     const fnWithCache = withCache(fn, {
       cacheStore: simpleMemoryStore,
@@ -94,7 +98,7 @@ describe('withCache', () => {
     const getMock = t.mock.method(simpleMemoryStore, 'get');
     const setMock = t.mock.method(simpleMemoryStore, 'set');
     function fn(): ResultSuccess<string> {
-      return Result.success('ok');
+      return success('ok');
     }
     const fnWithCache = withCache(fn, {
       cacheStore: simpleMemoryStore,
@@ -123,7 +127,7 @@ describe('withCache', () => {
     const simpleMemoryStore = new SimpleMemoryStore();
     const getMock = t.mock.method(simpleMemoryStore, 'get');
     const fnWithCache = withCache(
-      (): ResultSuccess<string> => Result.success('ok'),
+      (): ResultSuccess<string> => success('ok'),
       { cacheStore: simpleMemoryStore, version: '' },
     );
 
@@ -137,7 +141,7 @@ describe('withCache', () => {
       let count = 0;
       function fn(_arg: boolean): ResultSuccess<string> {
         count = count + 1;
-        return Result.success('ok');
+        return success('ok');
       }
       const fnWithCache = withCache(fn, {
         shouldInvalidateCache(args) {
@@ -159,16 +163,16 @@ describe('withCache', () => {
     it('should evict the entry via the store delete', async () => {
       const deleted: string[] = [];
       const cacheStore: CacheStore = {
-        get: () => Result.failure('miss'),
-        set: (_cacheKey, value) => Result.success(value),
+        get: () => failure('miss'),
+        set: (_cacheKey, value) => success(value),
         delete(cacheKey) {
           deleted.push(cacheKey);
-          return Result.success(cacheKey);
+          return success(cacheKey);
         },
       };
       const fnWithCache = withCache(
         (_arg: boolean): ResultSuccess<string> =>
-          Result.success('ok'),
+          success('ok'),
         {
           cacheStore,
           shouldInvalidateCache: () => true,
@@ -186,7 +190,7 @@ describe('withCache', () => {
       let count = 0;
       function fn(_arg: boolean): ResultSuccess<string> {
         count = count + 1;
-        return Result.success('ok');
+        return success('ok');
       }
       const fnWithCache = withCache(fn, {
         shouldCache(response) {

--- a/packages/kintsugi/src/__tests__/with_cache_test.ts
+++ b/packages/kintsugi/src/__tests__/with_cache_test.ts
@@ -43,10 +43,10 @@ describe('withCache', () => {
     const fnWithCache = withCache(foo.fn.bind(foo));
     const response1 = await fnWithCache('ok');
     assert.strictEqual(foo.count, 1);
-    assert.strictEqual(response1.getValue(), 'ok');
+    assert.strictEqual(response1.unwrap(), 'ok');
     const response2 = await fnWithCache('ok');
     assert.strictEqual(foo.count, 1);
-    assert.strictEqual(response2.getValue(), 'ok');
+    assert.strictEqual(response2.unwrap(), 'ok');
   });
 
   describe('when async method is provided', () => {
@@ -59,10 +59,10 @@ describe('withCache', () => {
       const fnWithCache = withCache(fn);
       const response1 = await fnWithCache();
       assert.strictEqual(count, 1);
-      assert.strictEqual(response1.getValue(), 'ok');
+      assert.strictEqual(response1.unwrap(), 'ok');
       const response2 = await fnWithCache();
       assert.strictEqual(count, 1);
-      assert.strictEqual(response2.getValue(), 'ok');
+      assert.strictEqual(response2.unwrap(), 'ok');
     });
   });
 
@@ -84,7 +84,7 @@ describe('withCache', () => {
     assert.strictEqual(setArgs?.[0], cacheKey);
     const cached = setArgs?.[1] as ResultSuccess<string>;
     assert.strictEqual(cached?.isSuccess, true);
-    assert.strictEqual(cached?.getValue(), 'ok');
+    assert.strictEqual(cached?.unwrap(), 'ok');
     const maxAgeMs = setArgs?.[2];
     assert.ok(
       typeof maxAgeMs === 'number' &&
@@ -119,7 +119,7 @@ describe('withCache', () => {
     assert.strictEqual(setArgs?.[0], cacheKey);
     const cached = setArgs?.[1] as ResultSuccess<string>;
     assert.strictEqual(cached?.isSuccess, true);
-    assert.strictEqual(cached?.getValue(), 'ok');
+    assert.strictEqual(cached?.unwrap(), 'ok');
     assert.strictEqual(setArgs?.[2], 1000);
   });
 
@@ -154,10 +154,10 @@ describe('withCache', () => {
 
       const response1 = await fnWithCache(true);
       assert.strictEqual(count, 1);
-      assert.strictEqual(response1.getValue(), 'ok');
+      assert.strictEqual(response1.unwrap(), 'ok');
       const response2 = await fnWithCache(true);
       assert.strictEqual(count, 2);
-      assert.strictEqual(response2.getValue(), 'ok');
+      assert.strictEqual(response2.unwrap(), 'ok');
     });
 
     it('should evict the entry via the store delete', async () => {
@@ -194,15 +194,15 @@ describe('withCache', () => {
       }
       const fnWithCache = withCache(fn, {
         shouldCache(response) {
-          return response.getValue() !== 'ok';
+          return response.unwrap() !== 'ok';
         },
       });
       const response1 = await fnWithCache(true);
       assert.strictEqual(count, 1);
-      assert.strictEqual(response1.getValue(), 'ok');
+      assert.strictEqual(response1.unwrap(), 'ok');
       const response2 = await fnWithCache(true);
       assert.strictEqual(count, 2);
-      assert.strictEqual(response2.getValue(), 'ok');
+      assert.strictEqual(response2.unwrap(), 'ok');
     });
   });
 });

--- a/packages/kintsugi/src/__tests__/with_memo_test.ts
+++ b/packages/kintsugi/src/__tests__/with_memo_test.ts
@@ -18,8 +18,8 @@ describe('withMemo', () => {
     const second = await memoized(1);
 
     assert.strictEqual(count, 1);
-    assert.strictEqual(first.getValue(), 1);
-    assert.strictEqual(second.getValue(), 1);
+    assert.strictEqual(first.unwrap(), 1);
+    assert.strictEqual(second.unwrap(), 1);
   });
 
   it('should share one execution across concurrent calls', async () => {

--- a/packages/kintsugi/src/__tests__/with_memo_test.ts
+++ b/packages/kintsugi/src/__tests__/with_memo_test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { success } from '@daisugi/anzen';
+import { ok } from '@daisugi/anzen';
 
 import { waitFor } from '../wait_for.js';
 import { withMemo } from '../with_memo.js';
@@ -11,7 +11,7 @@ describe('withMemo', () => {
     let count = 0;
     const memoized = withMemo(async (a: number) => {
       count += 1;
-      return success(a);
+      return ok(a);
     });
 
     const first = await memoized(1);
@@ -27,7 +27,7 @@ describe('withMemo', () => {
     const memoized = withMemo(async (a: number) => {
       count += 1;
       await waitFor(5);
-      return success(a);
+      return ok(a);
     });
 
     await Promise.all([memoized(2), memoized(2)]);
@@ -39,7 +39,7 @@ describe('withMemo', () => {
     let count = 0;
     const memoized = withMemo(async (a: number) => {
       count += 1;
-      return success(a);
+      return ok(a);
     });
 
     await memoized(1);

--- a/packages/kintsugi/src/__tests__/with_memo_test.ts
+++ b/packages/kintsugi/src/__tests__/with_memo_test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { Result } from '@daisugi/anzen';
+import { success } from '@daisugi/anzen';
 
 import { waitFor } from '../wait_for.js';
 import { withMemo } from '../with_memo.js';
@@ -11,7 +11,7 @@ describe('withMemo', () => {
     let count = 0;
     const memoized = withMemo(async (a: number) => {
       count += 1;
-      return Result.success(a);
+      return success(a);
     });
 
     const first = await memoized(1);
@@ -27,7 +27,7 @@ describe('withMemo', () => {
     const memoized = withMemo(async (a: number) => {
       count += 1;
       await waitFor(5);
-      return Result.success(a);
+      return success(a);
     });
 
     await Promise.all([memoized(2), memoized(2)]);
@@ -39,7 +39,7 @@ describe('withMemo', () => {
     let count = 0;
     const memoized = withMemo(async (a: number) => {
       count += 1;
-      return Result.success(a);
+      return success(a);
     });
 
     await memoized(1);

--- a/packages/kintsugi/src/__tests__/with_retry_test.ts
+++ b/packages/kintsugi/src/__tests__/with_retry_test.ts
@@ -10,7 +10,7 @@ import { Ayamari } from '@daisugi/ayamari';
 
 import { withRetry } from '../with_retry.js';
 
-const { errFn } = new Ayamari();
+const { errs } = new Ayamari();
 
 describe('withRetry', () => {
   it('should return expected response', async () => {
@@ -58,7 +58,7 @@ describe('withRetry', () => {
     async function fn(a: number) {
       count = count + 1;
       if (count < 3) {
-        return err(errFn.Fail('fail'));
+        return err(errs.Fail('fail'));
       }
       return ok(a);
     }
@@ -75,7 +75,7 @@ describe('withRetry', () => {
     let count = 0;
     async function fn() {
       count = count + 1;
-      return err(errFn.Fail('fail'));
+      return err(errs.Fail('fail'));
     }
 
     const fnWithRetry = withRetry(fn, { maxRetries: 0 });
@@ -89,7 +89,7 @@ describe('withRetry', () => {
     let count = 0;
     async function fn() {
       count = count + 1;
-      return err(errFn.NotFound('missing'));
+      return err(errs.NotFound('missing'));
     }
 
     const fnWithRetry = withRetry(fn, { firstDelayMs: 1 });
@@ -104,7 +104,7 @@ describe('withRetry', () => {
     async function fn(a: number) {
       count = count + 1;
       if (count < 3) {
-        throw errFn.Fail('boom');
+        throw errs.Fail('boom');
       }
       return ok(a);
     }
@@ -119,7 +119,7 @@ describe('withRetry', () => {
 
   it('should re-throw the original error when retries are exhausted', async () => {
     let count = 0;
-    const error = errFn.Fail('always');
+    const error = errs.Fail('always');
     const fn: AnzenResultFn<
       unknown,
       unknown
@@ -144,7 +144,7 @@ describe('withRetry', () => {
       unknown
     > = async () => {
       count = count + 1;
-      throw errFn.NotFound('missing');
+      throw errs.NotFound('missing');
     };
 
     const fnWithRetry = withRetry(fn, { firstDelayMs: 1 });

--- a/packages/kintsugi/src/__tests__/with_retry_test.ts
+++ b/packages/kintsugi/src/__tests__/with_retry_test.ts
@@ -22,7 +22,7 @@ describe('withRetry', () => {
 
     const response = await fnWithRetry();
 
-    assert.strictEqual(response.getValue(), 'ok');
+    assert.strictEqual(response.unwrap(), 'ok');
   });
 
   it('should forward arguments to the wrapped function', async () => {
@@ -34,7 +34,7 @@ describe('withRetry', () => {
 
     const response = await fnWithRetry(2, 3);
 
-    assert.strictEqual(response.getValue(), 5);
+    assert.strictEqual(response.unwrap(), 5);
   });
 
   it('should preserve `this` context', async () => {
@@ -50,7 +50,7 @@ describe('withRetry', () => {
 
     const response = await fnWithRetry.call(foo);
 
-    assert.strictEqual(response.getValue(), 7);
+    assert.strictEqual(response.unwrap(), 7);
   });
 
   it('should retry on failure and forward arguments on each retry', async () => {
@@ -68,7 +68,7 @@ describe('withRetry', () => {
     const response = await fnWithRetry(42);
 
     assert.strictEqual(count, 3);
-    assert.strictEqual(response.getValue(), 42);
+    assert.strictEqual(response.unwrap(), 42);
   });
 
   it('should honor `maxRetries: 0` (no retries)', async () => {
@@ -114,7 +114,7 @@ describe('withRetry', () => {
     const response = await fnWithRetry(42);
 
     assert.strictEqual(count, 3);
-    assert.strictEqual(response.getValue(), 42);
+    assert.strictEqual(response.unwrap(), 42);
   });
 
   it('should re-throw the original error when retries are exhausted', async () => {

--- a/packages/kintsugi/src/__tests__/with_retry_test.ts
+++ b/packages/kintsugi/src/__tests__/with_retry_test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { type AnzenResultFn, Result } from '@daisugi/anzen';
+import {
+  type AnzenResultFn,
+  failure,
+  success,
+} from '@daisugi/anzen';
 import { Ayamari } from '@daisugi/ayamari';
 
 import { withRetry } from '../with_retry.js';
@@ -11,7 +15,7 @@ const { errFn } = new Ayamari();
 describe('withRetry', () => {
   it('should return expected response', async () => {
     async function fn() {
-      return Result.success('ok');
+      return success('ok');
     }
 
     const fnWithRetry = withRetry(fn);
@@ -23,7 +27,7 @@ describe('withRetry', () => {
 
   it('should forward arguments to the wrapped function', async () => {
     async function fn(a: number, b: number) {
-      return Result.success(a + b);
+      return success(a + b);
     }
 
     const fnWithRetry = withRetry(fn);
@@ -37,7 +41,7 @@ describe('withRetry', () => {
     class Foo {
       value = 7;
       async fn() {
-        return Result.success(this.value);
+        return success(this.value);
       }
     }
     const foo = new Foo();
@@ -54,9 +58,9 @@ describe('withRetry', () => {
     async function fn(a: number) {
       count = count + 1;
       if (count < 3) {
-        return Result.failure(errFn.Fail('fail'));
+        return failure(errFn.Fail('fail'));
       }
-      return Result.success(a);
+      return success(a);
     }
 
     const fnWithRetry = withRetry(fn, { firstDelayMs: 1 });
@@ -71,7 +75,7 @@ describe('withRetry', () => {
     let count = 0;
     async function fn() {
       count = count + 1;
-      return Result.failure(errFn.Fail('fail'));
+      return failure(errFn.Fail('fail'));
     }
 
     const fnWithRetry = withRetry(fn, { maxRetries: 0 });
@@ -85,7 +89,7 @@ describe('withRetry', () => {
     let count = 0;
     async function fn() {
       count = count + 1;
-      return Result.failure(errFn.NotFound('missing'));
+      return failure(errFn.NotFound('missing'));
     }
 
     const fnWithRetry = withRetry(fn, { firstDelayMs: 1 });
@@ -102,7 +106,7 @@ describe('withRetry', () => {
       if (count < 3) {
         throw errFn.Fail('boom');
       }
-      return Result.success(a);
+      return success(a);
     }
 
     const fnWithRetry = withRetry(fn, { firstDelayMs: 1 });

--- a/packages/kintsugi/src/__tests__/with_retry_test.ts
+++ b/packages/kintsugi/src/__tests__/with_retry_test.ts
@@ -3,8 +3,8 @@ import { describe, it } from 'node:test';
 
 import {
   type AnzenResultFn,
-  failure,
-  success,
+  err,
+  ok,
 } from '@daisugi/anzen';
 import { Ayamari } from '@daisugi/ayamari';
 
@@ -15,7 +15,7 @@ const { errFn } = new Ayamari();
 describe('withRetry', () => {
   it('should return expected response', async () => {
     async function fn() {
-      return success('ok');
+      return ok('ok');
     }
 
     const fnWithRetry = withRetry(fn);
@@ -27,7 +27,7 @@ describe('withRetry', () => {
 
   it('should forward arguments to the wrapped function', async () => {
     async function fn(a: number, b: number) {
-      return success(a + b);
+      return ok(a + b);
     }
 
     const fnWithRetry = withRetry(fn);
@@ -41,7 +41,7 @@ describe('withRetry', () => {
     class Foo {
       value = 7;
       async fn() {
-        return success(this.value);
+        return ok(this.value);
       }
     }
     const foo = new Foo();
@@ -58,9 +58,9 @@ describe('withRetry', () => {
     async function fn(a: number) {
       count = count + 1;
       if (count < 3) {
-        return failure(errFn.Fail('fail'));
+        return err(errFn.Fail('fail'));
       }
-      return success(a);
+      return ok(a);
     }
 
     const fnWithRetry = withRetry(fn, { firstDelayMs: 1 });
@@ -75,7 +75,7 @@ describe('withRetry', () => {
     let count = 0;
     async function fn() {
       count = count + 1;
-      return failure(errFn.Fail('fail'));
+      return err(errFn.Fail('fail'));
     }
 
     const fnWithRetry = withRetry(fn, { maxRetries: 0 });
@@ -89,7 +89,7 @@ describe('withRetry', () => {
     let count = 0;
     async function fn() {
       count = count + 1;
-      return failure(errFn.NotFound('missing'));
+      return err(errFn.NotFound('missing'));
     }
 
     const fnWithRetry = withRetry(fn, { firstDelayMs: 1 });
@@ -106,7 +106,7 @@ describe('withRetry', () => {
       if (count < 3) {
         throw errFn.Fail('boom');
       }
-      return success(a);
+      return ok(a);
     }
 
     const fnWithRetry = withRetry(fn, { firstDelayMs: 1 });

--- a/packages/kintsugi/src/__tests__/with_timeout_test.ts
+++ b/packages/kintsugi/src/__tests__/with_timeout_test.ts
@@ -17,7 +17,7 @@ describe('withTimeout', () => {
     const response = await fnWithTimeout(21);
 
     assert.strictEqual(
-      response.isSuccess && response.getValue(),
+      response.isSuccess && response.unwrap(),
       42,
     );
   });

--- a/packages/kintsugi/src/__tests__/with_timeout_test.ts
+++ b/packages/kintsugi/src/__tests__/with_timeout_test.ts
@@ -1,23 +1,20 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import {
-  type AnzenResultFn,
-  success,
-} from '@daisugi/anzen';
+import { type AnzenResultFn, ok } from '@daisugi/anzen';
 
 import { withTimeout } from '../with_timeout.js';
 
 describe('withTimeout', () => {
   it('should forward arguments and resolve the value', async () => {
     const fnWithTimeout = withTimeout(async (a: number) =>
-      success(a * 2),
+      ok(a * 2),
     );
 
     const response = await fnWithTimeout(21);
 
     assert.strictEqual(
-      response.isSuccess && response.unwrap(),
+      response.isOk && response.unwrap(),
       42,
     );
   });

--- a/packages/kintsugi/src/__tests__/with_timeout_test.ts
+++ b/packages/kintsugi/src/__tests__/with_timeout_test.ts
@@ -1,14 +1,17 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { type AnzenResultFn, Result } from '@daisugi/anzen';
+import {
+  type AnzenResultFn,
+  success,
+} from '@daisugi/anzen';
 
 import { withTimeout } from '../with_timeout.js';
 
 describe('withTimeout', () => {
   it('should forward arguments and resolve the value', async () => {
     const fnWithTimeout = withTimeout(async (a: number) =>
-      Result.success(a * 2),
+      success(a * 2),
     );
 
     const response = await fnWithTimeout(21);

--- a/packages/kintsugi/src/deferred_promise.ts
+++ b/packages/kintsugi/src/deferred_promise.ts
@@ -17,10 +17,9 @@ export function deferredPromise<T = unknown>() {
     isRejected() {
       return isRejected;
     },
-    // Flags flip synchronously on the first settle (the previous `.then`
-    // based version only updated them a microtask later). Resolving with a
-    // thenable marks `isFulfilled` optimistically, before that thenable
-    // settles.
+    // Flags flip synchronously on the first settle (the previous `.then`-based
+    // version updated them a microtask later). Resolving with a thenable marks
+    // `isFulfilled` optimistically, before that thenable settles.
     resolve(value: T | PromiseLike<T>) {
       if (isPending) {
         isPending = false;

--- a/packages/kintsugi/src/simple_memory_store.ts
+++ b/packages/kintsugi/src/simple_memory_store.ts
@@ -1,4 +1,4 @@
-import { Result } from '@daisugi/anzen';
+import { failure, success } from '@daisugi/anzen';
 import { Ayamari } from '@daisugi/ayamari';
 
 import type { CacheStore } from './with_cache.js';
@@ -43,11 +43,11 @@ export class SimpleMemoryStore implements CacheStore {
       // Reinsert to mark the key as most-recently-used.
       this.#store.delete(cacheKey);
       this.#store.set(cacheKey, entry);
-      return Result.success(entry.value);
+      return success(entry.value);
     }
     // Missing or expired; drop any stale entry and report a miss.
     this.#store.delete(cacheKey);
-    return Result.failure(notFoundErr());
+    return failure(notFoundErr());
   }
 
   set(cacheKey: string, value: unknown, maxAgeMs?: number) {
@@ -68,11 +68,11 @@ export class SimpleMemoryStore implements CacheStore {
     }
     // Writes ack with the affected key, matching `delete`; the read payload
     // belongs to `get`. Callers ignore this, so keep both writes consistent.
-    return Result.success(cacheKey);
+    return success(cacheKey);
   }
 
   delete(cacheKey: string) {
     this.#store.delete(cacheKey);
-    return Result.success(cacheKey);
+    return success(cacheKey);
   }
 }

--- a/packages/kintsugi/src/simple_memory_store.ts
+++ b/packages/kintsugi/src/simple_memory_store.ts
@@ -1,4 +1,4 @@
-import { failure, success } from '@daisugi/anzen';
+import { err, ok } from '@daisugi/anzen';
 import { Ayamari } from '@daisugi/ayamari';
 
 import type { CacheStore } from './with_cache.js';
@@ -43,11 +43,11 @@ export class SimpleMemoryStore implements CacheStore {
       // Reinsert to mark the key as most-recently-used.
       this.#store.delete(cacheKey);
       this.#store.set(cacheKey, entry);
-      return success(entry.value);
+      return ok(entry.value);
     }
     // Missing or expired; drop any stale entry and report a miss.
     this.#store.delete(cacheKey);
-    return failure(notFoundErr());
+    return err(notFoundErr());
   }
 
   set(cacheKey: string, value: unknown, maxAgeMs?: number) {
@@ -68,11 +68,11 @@ export class SimpleMemoryStore implements CacheStore {
     }
     // Writes ack with the affected key, matching `delete`; the read payload
     // belongs to `get`. Callers ignore this, so keep both writes consistent.
-    return success(cacheKey);
+    return ok(cacheKey);
   }
 
   delete(cacheKey: string) {
     this.#store.delete(cacheKey);
-    return success(cacheKey);
+    return ok(cacheKey);
   }
 }

--- a/packages/kintsugi/src/simple_memory_store.ts
+++ b/packages/kintsugi/src/simple_memory_store.ts
@@ -5,10 +5,9 @@ import type { CacheStore } from './with_cache.js';
 
 const defaultMaxSize = 1000;
 
-// `new Ayamari()` builds its error-factory records by iterating every error
-// code, so it is kept out of module scope and created lazily on the first
-// cache miss. This keeps the module free of top-level side effects (honoring
-// the package's `sideEffects: false`) and shares one factory across stores.
+// `new Ayamari()` builds its error-factory records by iterating every error code,
+// so it is created lazily on the first cache miss (not at module scope), keeping
+// the module free of top-level side effects and sharing one factory across stores.
 let ayamari: Ayamari<unknown> | undefined;
 function notFoundErr() {
   return (ayamari ??= new Ayamari()).errFn.NotFound(

--- a/packages/kintsugi/src/simple_memory_store.ts
+++ b/packages/kintsugi/src/simple_memory_store.ts
@@ -10,7 +10,7 @@ const defaultMaxSize = 1000;
 // the module free of top-level side effects and sharing one factory across stores.
 let ayamari: Ayamari<unknown> | undefined;
 function notFoundErr() {
-  return (ayamari ??= new Ayamari()).errFn.NotFound(
+  return (ayamari ??= new Ayamari()).errs.NotFound(
     'Not found in cache.',
   );
 }

--- a/packages/kintsugi/src/stringify_args.ts
+++ b/packages/kintsugi/src/stringify_args.ts
@@ -60,10 +60,9 @@ export function stringifyArgs(args: unknown[]): string {
   if (args.length === 1 && usesStringCoercion(args[0])) {
     return String(args[0]);
   }
-  // The `sortObjectKeys` replacer is only needed when an object/array is
-  // present. Passing a replacer also disables V8's fast JSON path, so for the
-  // common all-primitive arg list (where ordering is already deterministic)
-  // serialize without it.
+  // The `sortObjectKeys` replacer is only needed when an object/array is present,
+  // and it disables V8's fast JSON path. So for the common all-primitive arg list
+  // (already deterministic ordering) serialize without it.
   if (!hasObjectArg(args)) {
     return JSON.stringify(args);
   }

--- a/packages/kintsugi/src/with_cache.ts
+++ b/packages/kintsugi/src/with_cache.ts
@@ -40,10 +40,8 @@ function isThenable(
 }
 
 // Per-wrap identity, assigned in call order. Unlike hashing `fn.toString()`,
-// distinct closures from the same factory get distinct ids (no collision on a
-// shared cacheStore) and minification/comment changes don't shift keys. It is
-// stable across processes that wrap in the same order; for non-deterministic
-// wrapping with a persistent shared store, pass an explicit `version`.
+// distinct closures get distinct ids (no shared-store collision) and minification
+// doesn't shift keys. For non-deterministic wrap order + shared store, pass `version`.
 let nextFnId = 0;
 
 export interface CacheStore {

--- a/packages/kintsugi/src/with_cache.ts
+++ b/packages/kintsugi/src/with_cache.ts
@@ -85,13 +85,13 @@ export function shouldInvalidateCache() {
 export function shouldCache(
   response: AnzenAnyResult<any, any>,
 ) {
-  if (response.isSuccess) {
+  if (response.isOk) {
     return true;
   }
   // Cache NotFound by default.
   // https://docs.fastly.com/en/guides/http-code-codes-cached-by-default
   if (
-    response.isFailure &&
+    response.isErr &&
     response.unwrapErr().code === errCode.NotFound
   ) {
     return true;
@@ -133,7 +133,7 @@ export function withCache<
       const cacheResponse = isThenable(got)
         ? await got
         : got;
-      if (cacheResponse.isSuccess) {
+      if (cacheResponse.isOk) {
         return cacheResponse.unwrap();
       }
     }

--- a/packages/kintsugi/src/with_cache.ts
+++ b/packages/kintsugi/src/with_cache.ts
@@ -92,7 +92,7 @@ export function shouldCache(
   // https://docs.fastly.com/en/guides/http-code-codes-cached-by-default
   if (
     response.isFailure &&
-    response.getError().code === errCode.NotFound
+    response.unwrapErr().code === errCode.NotFound
   ) {
     return true;
   }
@@ -134,7 +134,7 @@ export function withCache<
         ? await got
         : got;
       if (cacheResponse.isSuccess) {
-        return cacheResponse.getValue();
+        return cacheResponse.unwrap();
       }
     }
     const response = await fn.apply(this, args);

--- a/packages/kintsugi/src/with_cache.ts
+++ b/packages/kintsugi/src/with_cache.ts
@@ -130,7 +130,9 @@ export function withCache<
       }
     } else {
       const got = cacheStore.get(cacheKey);
-      const cacheResponse = isThenable(got) ? await got : got;
+      const cacheResponse = isThenable(got)
+        ? await got
+        : got;
       if (cacheResponse.isSuccess) {
         return cacheResponse.getValue();
       }

--- a/packages/kintsugi/src/with_cache.ts
+++ b/packages/kintsugi/src/with_cache.ts
@@ -1,5 +1,5 @@
 import type {
-  AnzenAnyResult,
+  AnzenResult,
   AnzenResultFn,
 } from '@daisugi/anzen';
 import { errCode } from '@daisugi/ayamari';
@@ -19,7 +19,7 @@ export interface WithCacheOpts {
     args: any[],
   ): string;
   calculateCacheMaxAgeMs?(maxAgeMs: number): number;
-  shouldCache?(response: AnzenAnyResult<any, any>): boolean;
+  shouldCache?(response: AnzenResult<any, any>): boolean;
   shouldInvalidateCache?(args: any[]): boolean;
 }
 
@@ -49,21 +49,15 @@ let nextFnId = 0;
 export interface CacheStore {
   get(
     cacheKey: string,
-  ):
-    | AnzenAnyResult<any, any>
-    | Promise<AnzenAnyResult<any, any>>;
+  ): AnzenResult<any, any> | Promise<AnzenResult<any, any>>;
   set(
     cacheKey: string,
     value: any,
     maxAgeMs?: number,
-  ):
-    | AnzenAnyResult<any, any>
-    | Promise<AnzenAnyResult<any, any>>;
+  ): AnzenResult<any, any> | Promise<AnzenResult<any, any>>;
   delete(
     cacheKey: string,
-  ):
-    | AnzenAnyResult<any, any>
-    | Promise<AnzenAnyResult<any, any>>;
+  ): AnzenResult<any, any> | Promise<AnzenResult<any, any>>;
 }
 
 export function buildCacheKey(
@@ -83,7 +77,7 @@ export function shouldInvalidateCache() {
 }
 
 export function shouldCache(
-  response: AnzenAnyResult<any, any>,
+  response: AnzenResult<any, any>,
 ) {
   if (response.isOk) {
     return true;

--- a/packages/kintsugi/src/with_memo.ts
+++ b/packages/kintsugi/src/with_memo.ts
@@ -12,10 +12,9 @@ interface WithMemoOpts extends WithCacheOpts {
   maxSize?: number;
 }
 
-// Memoize an async function: cache its results (LRU, via withCache) and share
-// a single in-flight execution across concurrent callers with the same key
-// (via reusePromise, avoiding a cold-cache stampede). Failure caching follows
-// withCache's `shouldCache` default; override it to change that.
+// Memoize an async function: cache results (LRU, via withCache) and share one
+// in-flight execution across concurrent callers with the same key (via reusePromise,
+// avoiding a stampede). Failure caching follows withCache's `shouldCache` default.
 export function withMemo<Fn extends AsyncFn>(
   fn: Fn,
   opts: WithMemoOpts = {},

--- a/packages/kintsugi/src/with_pool.ts
+++ b/packages/kintsugi/src/with_pool.ts
@@ -14,21 +14,17 @@ interface Task {
 const defaultConcurrencyCount = 2;
 
 function createScheduler(concurrencyCount: number) {
-  // Pending tasks live in a FIFO queue advanced by a `head` pointer, so
-  // dequeuing is O(1) (no `splice`/`indexOf`/`find` scan per settle). Running
-  // tasks are not tracked in the array at all; only `runningCount` gates
-  // concurrency. This keeps scheduling linear in the number of tasks instead
-  // of quadratic on large fan-outs.
+  // Pending tasks live in a FIFO queue advanced by a `head` pointer, so dequeuing
+  // is O(1) (no `splice`/`indexOf` scan per settle). Running tasks aren't tracked;
+  // only `runningCount` gates concurrency, keeping scheduling linear, not quadratic.
   const queue: Task[] = [];
   let head = 0;
   let runningCount = 0;
 
   function runTask(task: Task) {
-    // Invoke `fn` synchronously so the task starts right away, but normalize
-    // the result with `Promise.resolve` so a non-thenable return still
-    // settles, and catch a synchronous throw so its slot is freed instead of
-    // being stranded. After each async settle, `pump` is re-driven to start
-    // the next pending task.
+    // Invoke `fn` synchronously so the task starts right away; normalize via
+    // `Promise.resolve` so a non-thenable return still settles, and catch a sync
+    // throw so its slot is freed. After each settle, `pump` re-drives the next task.
     try {
       Promise.resolve(task.fn(...task.args)).then(
         (value) => {

--- a/packages/kintsugi/src/with_retry.ts
+++ b/packages/kintsugi/src/with_retry.ts
@@ -1,5 +1,5 @@
 import {
-  type AnzenAnyResult,
+  type AnzenResult,
   type AnzenResultFn,
   err,
 } from '@daisugi/anzen';
@@ -21,7 +21,7 @@ interface WithRetryOpts {
     retryNumber: number,
   ): number;
   shouldRetry?(
-    response: AnzenAnyResult<unknown, unknown>,
+    response: AnzenResult<unknown, unknown>,
     retryNumber: number,
     maxRetries: number,
   ): boolean;
@@ -57,7 +57,7 @@ const nonRetryableErrCodes = new Set<string>([
 ]);
 
 export function shouldRetry(
-  response: AnzenAnyResult<unknown, unknown>,
+  response: AnzenResult<unknown, unknown>,
   retryNumber: number,
   maxRetries: number,
 ) {
@@ -90,8 +90,8 @@ export function withRetry<
     retryFn: AnzenResultFn<unknown, unknown>,
     args: any[],
     retryNumber: number,
-  ): Promise<AnzenAnyResult<unknown, unknown>> {
-    let response: AnzenAnyResult<unknown, unknown>;
+  ): Promise<AnzenResult<unknown, unknown>> {
+    let response: AnzenResult<unknown, unknown>;
     let rejection: unknown;
     let rejected = false;
     try {

--- a/packages/kintsugi/src/with_retry.ts
+++ b/packages/kintsugi/src/with_retry.ts
@@ -1,7 +1,7 @@
 import {
   type AnzenAnyResult,
   type AnzenResultFn,
-  failure,
+  err,
 } from '@daisugi/anzen';
 import { type AyamariErr, errCode } from '@daisugi/ayamari';
 
@@ -61,7 +61,7 @@ export function shouldRetry(
   retryNumber: number,
   maxRetries: number,
 ) {
-  if (response.isFailure) {
+  if (response.isErr) {
     const { code } = response.unwrapErr() as AyamariErr;
     if (nonRetryableErrCodes.has(code)) {
       return false;
@@ -102,7 +102,7 @@ export function withRetry<
       // still applies to a thrown AyamariErr).
       rejected = true;
       rejection = error;
-      response = failure(error);
+      response = err(error);
     }
     if (shouldRetryFn(response, retryNumber, maxRetries)) {
       await waitFor(

--- a/packages/kintsugi/src/with_retry.ts
+++ b/packages/kintsugi/src/with_retry.ts
@@ -62,7 +62,7 @@ export function shouldRetry(
   maxRetries: number,
 ) {
   if (response.isFailure) {
-    const { code } = response.getError() as AyamariErr;
+    const { code } = response.unwrapErr() as AyamariErr;
     if (nonRetryableErrCodes.has(code)) {
       return false;
     }

--- a/packages/kintsugi/src/with_retry.ts
+++ b/packages/kintsugi/src/with_retry.ts
@@ -1,12 +1,9 @@
 import {
   type AnzenAnyResult,
   type AnzenResultFn,
-  Result,
+  failure,
 } from '@daisugi/anzen';
-import {
-  type AyamariErr,
-  errCode,
-} from '@daisugi/ayamari';
+import { type AyamariErr, errCode } from '@daisugi/ayamari';
 
 import { randomIntBetween } from './random_int_between.js';
 import type { WrappedFn } from './types.js';
@@ -105,7 +102,7 @@ export function withRetry<
       // still applies to a thrown AyamariErr).
       rejected = true;
       rejection = error;
-      response = Result.failure(error);
+      response = failure(error);
     }
     if (shouldRetryFn(response, retryNumber, maxRetries)) {
       await waitFor(

--- a/packages/kintsugi/src/with_timeout.ts
+++ b/packages/kintsugi/src/with_timeout.ts
@@ -1,20 +1,20 @@
 import {
-  type AnzenResultFailure,
+  type AnzenResultErr,
   type AnzenResultFn,
-  failure,
+  err,
 } from '@daisugi/anzen';
 import { type AyamariErr, Ayamari } from '@daisugi/ayamari';
 
 const defaultMaxTimeMs = 600;
 
-type TimeoutErr = AnzenResultFailure<AyamariErr>;
+type TimeoutErr = AnzenResultErr<AyamariErr>;
 
 // Built lazily on the first timeout so importing this module does no
 // top-level work (no eager `new Ayamari()` or Result allocation), honoring
 // the package's `sideEffects: false`. The failure is shared across all calls.
 let timeoutErr: TimeoutErr | undefined;
 function getTimeoutErr(): TimeoutErr {
-  return (timeoutErr ??= failure(
+  return (timeoutErr ??= err(
     new Ayamari().errFn.Timeout('Operation timed out.'),
   ));
 }

--- a/packages/kintsugi/src/with_timeout.ts
+++ b/packages/kintsugi/src/with_timeout.ts
@@ -1,7 +1,7 @@
 import {
   type AnzenResultFailure,
   type AnzenResultFn,
-  Result,
+  failure,
 } from '@daisugi/anzen';
 import { type AyamariErr, Ayamari } from '@daisugi/ayamari';
 
@@ -14,7 +14,7 @@ type TimeoutErr = AnzenResultFailure<AyamariErr>;
 // the package's `sideEffects: false`. The failure is shared across all calls.
 let timeoutErr: TimeoutErr | undefined;
 function getTimeoutErr(): TimeoutErr {
-  return (timeoutErr ??= Result.failure(
+  return (timeoutErr ??= failure(
     new Ayamari().errFn.Timeout('Operation timed out.'),
   ));
 }
@@ -43,19 +43,17 @@ export function withTimeout<
         return Promise.reject(reason);
       }
     })();
-    const timeout = new Promise<TimeoutErr>(
-      (resolve) => {
-        const timeoutId = setTimeout(() => {
-          resolve(getTimeoutErr());
-        }, maxTimeMs);
-        // Attach a no-op handler so the work settling after a timeout does
-        // not raise an unhandled-rejection warning; callers must still handle
-        // the returned promise.
-        promise
-          .catch(() => {})
-          .then(() => clearTimeout(timeoutId));
-      },
-    );
+    const timeout = new Promise<TimeoutErr>((resolve) => {
+      const timeoutId = setTimeout(() => {
+        resolve(getTimeoutErr());
+      }, maxTimeMs);
+      // Attach a no-op handler so the work settling after a timeout does
+      // not raise an unhandled-rejection warning; callers must still handle
+      // the returned promise.
+      promise
+        .catch(() => {})
+        .then(() => clearTimeout(timeoutId));
+    });
     return Promise.race([timeout, promise]);
   } as (
     ...args: Parameters<Fn>

--- a/packages/kintsugi/src/with_timeout.ts
+++ b/packages/kintsugi/src/with_timeout.ts
@@ -15,7 +15,7 @@ type TimeoutErr = AnzenResultErr<AyamariErr>;
 let timeoutErr: TimeoutErr | undefined;
 function getTimeoutErr(): TimeoutErr {
   return (timeoutErr ??= err(
-    new Ayamari().errFn.Timeout('Operation timed out.'),
+    new Ayamari().errs.Timeout('Operation timed out.'),
   ));
 }
 

--- a/packages/land/src/__tests__/land_test.ts
+++ b/packages/land/src/__tests__/land_test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 describe('Land', () => {
-  describe('success', () => {
+  describe('ok', () => {
     it('should return expected value', () => {
       assert.equal(true, true);
     });


### PR DESCRIPTION
## Summary

This branch modernizes the `@daisugi` core packages around a single, canonical, tree-shakeable API surface, aligns naming across the ecosystem, and overhauls the documentation.

### API & tree-shaking
- **Anzen**: single canonical tree-shakeable API with standalone named exports (`ok`/`err`, `isOk`/`isErr`, `unwrap`/`unwrapErr`), Rust/neverthrow-style names (`AnzenResult`, `fromThrowable`/`fromAsyncThrowable`), `safeTry` generator (`?`-style) propagation, `promiseAll`/`promiseAllTuple`, and a brand-based `isAnzenResult` guard. Drops `ResultAsync`/`wrapAsyncThrowable`.
- **Kado**: tree-shakeable named manifest helpers.

### Naming alignment
- **Ayamari**: `pretty_stack`/`PrettyStack`/`PrettyStackOpts` -> `format_stack`/`FormatStack`/`FormatStackOpts`; instance members `errFn`/`errCode` -> `errs`/`codes`, plus `errsResult`, `wrapErr`/`wrapErrResult`, and option/type renames.
- **Kado**: error-factory surface renamed to match Ayamari (`KadoErrFn`/`errFn` -> `KadoErrs`/`errs`), so `new Ayamari().errs` drops straight into `new Kado({ errs })`.
- Propagated all the above renames to consumers in **Daisugi** and **Kintsugi** (src, tests, examples).

### Docs
- New marketing-focused **root README**: hero, value props, what's-inside table, quick-taste snippets, an ecosystem-in-action example built on `@daisugi/land`, philosophy/naming, and development/contributing sections.
- Refreshed package READMEs to the new APIs (Anzen `fromThrowable` boundary pattern, Ayamari `errs`/`errsResult`, Kado `errs`).

## Testing
- `pnpm build` - all 6 packages compile.
- `pnpm test` - all suites pass.