### PR TITLE
feat(ayamari): wrapErr/wrapErrResult accept AnzenResultErr as cause

### DIFF
--- a/packages/ayamari/README.md
+++ b/packages/ayamari/README.md
@@ -253,13 +253,20 @@ errs.NotFound('missing', { levelValue: level.debug })  // 20 (overridden)
 Re-wrap an error with a new message while keeping the original code. Useful at layer boundaries.
 
 ```ts
-wrapErr(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AyamariErr
-wrapErrResult(message: string, opts: { cause: AyamariErr | Error, meta?: unknown }): AnzenResultErr<AyamariErr>
+wrapErr(message: string, opts: { cause: AyamariErr | Error | AnzenResultErr<AyamariErr>, meta?: unknown }): AyamariErr
+wrapErrResult(message: string, opts: { cause: AyamariErr | Error | AnzenResultErr<AyamariErr>, meta?: unknown }): AnzenResultErr<AyamariErr>
 ```
 
-```ts
-const { errs, wrapErr } = new Ayamari();
+`cause` accepts three forms:
 
+- An `AyamariErr` — reuses its code and severity.
+- A native `Error` — falls back to `UnexpectedError`.
+- An `AnzenResultErr<AyamariErr>` — automatically unwrapped; the extracted error is used as cause.
+
+```ts
+const { errs, wrapErr, wrapErrResult } = new Ayamari();
+
+// From a plain error
 function readConfig(path: string) {
   try {
     // ...
@@ -267,6 +274,15 @@ function readConfig(path: string) {
     const inner = errs.UnexpectedError('Failed to read file.', { cause: err });
     return wrapErr('Config loading failed.', { cause: inner });
   }
+}
+
+// From a ResultErr — no manual unwrapErr() needed
+function loadUser(id: number) {
+  const result = findUser(id); // AnzenResultErr<AyamariErr>
+  if (result.isErr) {
+    return wrapErrResult('Failed to load user.', { cause: result });
+  }
+  return result;
 }
 ```
 

--- a/packages/ayamari/src/__tests__/ayamari_test.ts
+++ b/packages/ayamari/src/__tests__/ayamari_test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import { err as errRes } from '@daisugi/anzen';
+
 import {
   Ayamari,
   findCauseByCode,
@@ -142,6 +144,40 @@ describe('Ayamari', () => {
       });
       const err = wrapErr('wrapped', { cause });
       assert.equal(err.levelValue, level.fatal);
+    });
+
+    it('should unwrap a ResultErr and use the inner error as cause', () => {
+      const { errs, wrapErr } = new Ayamari();
+      const inner = errs.NotFound('missing');
+      const result = errRes(inner);
+      const err = wrapErr('wrapped', { cause: result });
+      assert.equal(err.code, 'NotFound');
+      assert.equal(err.name, 'NotFound');
+      assert.equal(err.message, 'wrapped');
+      assert.equal(err.cause, inner);
+    });
+
+    it('should carry the levelValue when cause is a ResultErr', () => {
+      const { errs, wrapErr } = new Ayamari();
+      const inner = errs.NotFound('missing', {
+        levelValue: level.fatal,
+      });
+      const err = wrapErr('wrapped', {
+        cause: errRes(inner),
+      });
+      assert.equal(err.levelValue, level.fatal);
+    });
+
+    it('wrapErrResult should unwrap a ResultErr cause', () => {
+      const { errs, wrapErrResult } = new Ayamari();
+      const inner = errs.NotFound('missing');
+      const res = wrapErrResult('wrapped', {
+        cause: errRes(inner),
+      });
+      assert.equal(res.isOk, false);
+      const err = res.unwrapErr();
+      assert.equal(err.code, 'NotFound');
+      assert.equal(err.cause, inner);
     });
   });
 

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -63,6 +63,13 @@ export interface AyamariErrOpts {
   levelValue?: number;
 }
 
+export interface AyamariWrapErrOpts {
+  cause: AyamariErr | Error | AnzenResultErr<AyamariErr>;
+  meta?: unknown;
+  injectStack?: boolean;
+  levelValue?: number;
+}
+
 export interface AyamariErr extends Error {
   name: string;
   message: string;
@@ -235,32 +242,28 @@ export class Ayamari<CustomErrCode> {
     return isAnzenResult(cause) ? cause.unwrapErr() : cause;
   }
 
-  wrapErr = (
-    msg: string,
-    opts: AyamariErrOpts & {
-      cause: AyamariErr | Error | AnzenResultErr<AyamariErr>;
-    },
-  ) => {
+  wrapErr = (msg: string, opts: AyamariWrapErrOpts) => {
     // Reuse the cause's code when it is a recognized Ayamari error.
     // A native Error (or an unknown code) has no registered name, so
     // fall back to UnexpectedError instead of crashing.
-    const cause = this.#resolveCause(opts.cause) as AyamariErr;
+    const { cause: rawCause, ...restOpts } = opts;
+    const cause = this.#resolveCause(
+      rawCause,
+    ) as AyamariErr;
     const errName =
       this.#errName.get(cause.code) ?? 'UnexpectedError';
     // Carry the cause's severity through so the wrapper matches it
     // (a native Error has none, so fall back to the code's default).
     return this.errs[errName](msg, {
-      ...opts,
+      ...restOpts,
       cause,
-      levelValue: opts.levelValue ?? cause.levelValue,
-    });
+      levelValue: restOpts.levelValue ?? cause.levelValue,
+    } as AyamariErrOpts);
   };
 
   wrapErrResult = (
     msg: string,
-    opts: AyamariErrOpts & {
-      cause: AyamariErr | Error | AnzenResultErr<AyamariErr>;
-    },
+    opts: AyamariWrapErrOpts,
   ) => {
     return errRes(this.wrapErr(msg, opts));
   };

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -1,6 +1,7 @@
 import {
   type AnzenResultErr,
   err as errRes,
+  isAnzenResult,
 } from '@daisugi/anzen';
 
 import {
@@ -228,27 +229,38 @@ export class Ayamari<CustomErrCode> {
 
   // Arrow fields so they stay bound to `this` when destructured
   // (e.g. `const { wrapErr } = new Ayamari()`).
+  #resolveCause(
+    cause: AyamariErr | Error | AnzenResultErr<AyamariErr>,
+  ): AyamariErr | Error {
+    return isAnzenResult(cause) ? cause.unwrapErr() : cause;
+  }
+
   wrapErr = (
     msg: string,
-    opts: AyamariErrOpts & { cause: AyamariErr | Error },
+    opts: AyamariErrOpts & {
+      cause: AyamariErr | Error | AnzenResultErr<AyamariErr>;
+    },
   ) => {
     // Reuse the cause's code when it is a recognized Ayamari error.
     // A native Error (or an unknown code) has no registered name, so
     // fall back to UnexpectedError instead of crashing.
-    const cause = opts.cause as AyamariErr;
+    const cause = this.#resolveCause(opts.cause) as AyamariErr;
     const errName =
       this.#errName.get(cause.code) ?? 'UnexpectedError';
     // Carry the cause's severity through so the wrapper matches it
     // (a native Error has none, so fall back to the code's default).
     return this.errs[errName](msg, {
       ...opts,
+      cause,
       levelValue: opts.levelValue ?? cause.levelValue,
     });
   };
 
   wrapErrResult = (
     msg: string,
-    opts: AyamariErrOpts & { cause: AyamariErr | Error },
+    opts: AyamariErrOpts & {
+      cause: AyamariErr | Error | AnzenResultErr<AyamariErr>;
+    },
   ) => {
     return errRes(this.wrapErr(msg, opts));
   };

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -63,11 +63,8 @@ export interface AyamariErrOpts {
   levelValue?: number;
 }
 
-export interface AyamariWrapErrOpts {
+export interface AyamariWrapErrOpts extends Omit<AyamariErrOpts, 'cause'> {
   cause: AyamariErr | Error | AnzenResultErr<AyamariErr>;
-  meta?: unknown;
-  injectStack?: boolean;
-  levelValue?: number;
 }
 
 export interface AyamariErr extends Error {
@@ -236,19 +233,13 @@ export class Ayamari<CustomErrCode> {
 
   // Arrow fields so they stay bound to `this` when destructured
   // (e.g. `const { wrapErr } = new Ayamari()`).
-  #resolveCause(
-    cause: AyamariErr | Error | AnzenResultErr<AyamariErr>,
-  ): AyamariErr | Error {
-    return isAnzenResult(cause) ? cause.unwrapErr() : cause;
-  }
-
   wrapErr = (msg: string, opts: AyamariWrapErrOpts) => {
     // Reuse the cause's code when it is a recognized Ayamari error.
     // A native Error (or an unknown code) has no registered name, so
     // fall back to UnexpectedError instead of crashing.
     const { cause: rawCause, ...restOpts } = opts;
-    const cause = this.#resolveCause(
-      rawCause,
+    const cause = (
+      isAnzenResult(rawCause) ? rawCause.unwrapErr() : rawCause
     ) as AyamariErr;
     const errName =
       this.#errName.get(cause.code) ?? 'UnexpectedError';

--- a/packages/ayamari/src/ayamari.ts
+++ b/packages/ayamari/src/ayamari.ts
@@ -63,7 +63,10 @@ export interface AyamariErrOpts {
   levelValue?: number;
 }
 
-export interface AyamariWrapErrOpts extends Omit<AyamariErrOpts, 'cause'> {
+export interface AyamariWrapErrOpts extends Omit<
+  AyamariErrOpts,
+  'cause'
+> {
   cause: AyamariErr | Error | AnzenResultErr<AyamariErr>;
 }
 
@@ -239,7 +242,9 @@ export class Ayamari<CustomErrCode> {
     // fall back to UnexpectedError instead of crashing.
     const { cause: rawCause, ...restOpts } = opts;
     const cause = (
-      isAnzenResult(rawCause) ? rawCause.unwrapErr() : rawCause
+      isAnzenResult(rawCause)
+        ? rawCause.unwrapErr()
+        : rawCause
     ) as AyamariErr;
     const errName =
       this.#errName.get(cause.code) ?? 'UnexpectedError';


### PR DESCRIPTION
## Summary

- `wrapErr` and `wrapErrResult` now accept `AnzenResultErr<AyamariErr>` as `cause`, in addition to `AyamariErr` and `Error`
- A new `AyamariWrapErrOpts` interface defines the widened opts type
- A private `#resolveCause` helper unwraps the `ResultErr` using `isAnzenResult` before delegating to the existing `errs[errName]` creator
- Callers no longer need to manually call `.unwrapErr()` at every error-wrapping call site

## Test plan

- [ ] `wrapErr` with `AyamariErr` cause — code and cause chain preserved
- [ ] `wrapErr` with `Error` cause — falls back to `UnexpectedError`
- [ ] `wrapErr` with `AnzenResultErr` cause — unwrapped automatically, code and cause preserved
- [ ] `wrapErrResult` with `AnzenResultErr` cause — result is `Err`, inner error correct
- [ ] `levelValue` carried through in all cases